### PR TITLE
add multi-node config

### DIFF
--- a/scripts/train.yaml
+++ b/scripts/train.yaml
@@ -74,6 +74,8 @@ run: |
     --nnodes=$NUM_NODES \
     --nproc_per_node=$SKYPILOT_NUM_GPUS_PER_NODE \
     --master_port=12355 \
+    --master_addr=$HOST_ADDR \
+    --node_rank=${SKYPILOT_NODE_RANK} \
     train.py \
     --model_name_or_path /artifacts/llama-hf/llama-7B \
     --data_path /data/alpaca-data.json \


### PR DESCRIPTION
This is to enable multi-node training. however, I don't find any speedup when scaling from one `A100-80G:4` to two `A100-80G:4`.
Although A100 are all fully utilized according to `nvidia-smi`. 


nccl test output:
```
gcpuser@ray-a100-4-head-82dddc7a-compute:~/sky_workdir/alpa/benchmark/cupy$ python profile_communication.py
2023-03-20 03:56:04,178 INFO worker.py:1337 -- Connecting to existing Ray cluster at address: 10.150.15.215:6380...
2023-03-20 03:56:04,185 INFO worker.py:1519 -- Connected to Ray cluster. View the dashboard at http://127.0.0.1:8265
(GpuHost pid=42671) AllReduce: [[0, 1, 2, 3, 4, 5, 6, 7]]       Bytes: 2.00000 GB       Time: 0.68834 s Bandwidth: 5.08 GB/s
(GpuHost pid=42671) AllReduce: [[0, 1, 2, 3]]   Bytes: 2.00000 GB       Time: 0.01403 s Bandwidth: 213.81 GB/s
(GpuHost pid=42671) SendRecv: [[0, 1]]  Bytes: 2.00000 GB       Time: 0.00814 s Bandwidth: 245.77 GB/s
```

<img width="1085" alt="image (14)" src="https://user-images.githubusercontent.com/1206058/226238189-2eff57b8-472b-491c-8a49-7bea99783787.png">
<img width="1901" alt="image (15)" src="https://user-images.githubusercontent.com/1206058/226238268-7129bf6c-b5e5-430c-b857-e9bf4d965bab.png">
<img width="836" alt="Screen Shot 2023-03-19 at 8 03 02 PM" src="https://user-images.githubusercontent.com/1206058/226238328-c6470225-4e4f-4a61-9d48-d45d6847dbfc.png">
