### PR TITLE
Add a cli chatbot that uses our default prompt template 

### DIFF
--- a/chatserver/serve/cli.py
+++ b/chatserver/serve/cli.py
@@ -3,12 +3,15 @@ from transformers import AutoTokenizer, AutoModelForCausalLM
 import torch
 
 from chatserver.conversation import default_conversation
+from chatserver.utils import disable_torch_init
 
 
+@torch.inference_mode()
 def main(args):
     model_name = args.model_name
 
     # Model
+    disable_torch_init()
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     model = AutoModelForCausalLM.from_pretrained(model_name,
         torch_dtype=torch.float16).cuda()
@@ -33,7 +36,7 @@ def main(args):
         try:
             index = outputs.index(conv.sep, len(prompt))
         except ValueError:
-            outputs += conv.seq
+            outputs += conv.sep
             index = outputs.index(conv.sep, len(prompt))
         
         outputs = outputs[len(prompt) + len(conv.roles[1]) + 2:index].strip()

--- a/chatserver/serve/model_worker.py
+++ b/chatserver/serve/model_worker.py
@@ -18,20 +18,12 @@ import torch
 import uvicorn
 
 from chatserver.constants import WORKER_HEART_BEAT_INTERVAL
-from chatserver.utils import build_logger
+from chatserver.utils import build_logger, disable_torch_init
 
 GB = 1 << 30
 
 worker_id = str(uuid.uuid4())[:6]
 logger = build_logger("model_worker", f"model_worker_{worker_id}.log")
-
-
-def disable_torch_init():
-    """
-    Disable the redundant torch default initialization to accelerate model creation.
-    """
-    setattr(torch.nn.Linear, "reset_parameters", lambda self: None)
-    setattr(torch.nn.LayerNorm, "reset_parameters", lambda self: None)
 
 
 def heart_beat_worker(controller):

--- a/chatserver/utils.py
+++ b/chatserver/utils.py
@@ -6,6 +6,8 @@ import sys
 
 from chatserver.constants import LOGDIR
 
+import torch
+
 
 handler = None
 
@@ -84,3 +86,11 @@ class StreamToLogger(object):
         if self.linebuf != '':
             self.logger.log(self.log_level, self.linebuf.rstrip())
         self.linebuf = ''
+
+
+def disable_torch_init():
+    """
+    Disable the redundant torch default initialization to accelerate model creation.
+    """
+    setattr(torch.nn.Linear, "reset_parameters", lambda self: None)
+    setattr(torch.nn.LayerNorm, "reset_parameters", lambda self: None)


### PR DESCRIPTION
This can be used to check the model weights without web UI.

```python3 -m chatserver.serve.cli --model-name /home/ubuntu/model_weights/alpaca-7b/```