### PR TITLE
Fix typos in evaluation scripts

### DIFF
--- a/fastchat/eval/README.md
+++ b/fastchat/eval/README.md
@@ -20,7 +20,7 @@ Unfortunately, Bard has not release its public APIs till now. You may have to en
 
 To generate answers with Vicuna or other models, specify path to the model checkpoint. Then run:
 ```bash
-python model_qa.py --model-name /model/path --question-file tables/question.jsonl --answer-file table/answer/answer.jsonl
+python model_qa.py --model-name /model/path --question-file table/question.jsonl --answer-file table/answer/answer.jsonl
 ```
 
 ## Evaluate Answers Automatically

--- a/fastchat/eval/model_qa.py
+++ b/fastchat/eval/model_qa.py
@@ -58,4 +58,4 @@ if __name__ == "__main__":
     parser.add_argument("--answer-file", type=str, default="answer.jsonl")
     args = parser.parse_args()
 
-    eval_model(args.model_name, args.question_file, args.answers_file)
+    eval_model(args.model_name, args.question_file, args.answer_file)


### PR DESCRIPTION
Address issue https://github.com/lm-sys/FastChat/issues/157

Fix following issues
```
ubuntu@152-70-114-166:~/FastChat/fastchat/eval$ python model_qa.py --model-name $HOME/llama-13b-hf/ --question-file tables/question.jsonl --answer-file table/answer/answer.jsonl
Traceback (most recent call last):
  File "model_qa.py", line 61, in <module>
    eval_model(args.model_name, args.question_file, args.answers_file)
AttributeError: 'Namespace' object has no attribute 'answers_file'
```

```
ubuntu@152-70-114-166:~/FastChat/fastchat/eval$ python model_qa.py --model-name $HOME/llama-7b-hf/ --question-file tables/question.jsonl --answer-file table/answer/answer_llama-7b.jsonl
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.16s/it]
Traceback (most recent call last):
  File "model_qa.py", line 61, in <module>
    eval_model(args.model_name, args.question_file, args.answer_file)
  File "/usr/lib/python3/dist-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "model_qa.py", line 22, in eval_model
    ques_file = open(os.path.expanduser(questions_file), "r")
FileNotFoundError: [Errno 2] No such file or directory: 'tables/question.jsonl'
```