### PR TITLE
Fix tokenizer issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip3 install fschat
 
 # Install a specific commit of huggingface/transformers
 # Our released weights do not work with commits after this due to some upstream changes in the tokenizer.
-pip3 install git+https://github.com/huggingface/transformers@c612628045822f909020f7eb6784c79700813eda
+pip3 install git+https://github.com/huggingface/transformers
 ```
 
 ### Method 2: From source
@@ -55,8 +55,7 @@ You can add our delta to the original LLaMA weights to obtain the Vicuna weights
 2. Use the following scripts to get Vicuna weights by applying our delta. It will automatically download delta weights from our Hugging Face account.
 
 **NOTE**:
-Our released weights are only compatible with huggingface/transformers commit: `c612628045822f909020f7eb6784c79700813eda`.
-The weights do not work with commits after this due to some upstream changes in the tokenizer. We install the correct version of
+Our released weights are only compatible with the latest huggingface/transformers. We install the correct version of
 transformers when fastchat is installed.
 
 ### Vicuna-13B

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -6,7 +6,7 @@ import argparse
 import time
 
 import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM
+from transformers import AutoTokenizer, AutoModelForCausalLM, LlamaTokenizer
 
 from fastchat.conversation import conv_templates, SeparatorStyle
 
@@ -94,6 +94,13 @@ def main(args):
         raise ValueError(f"Invalid device: {args.device}")
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if isinstance(tokenizer, LlamaTokenizer):
+        # This is a hack to make the new transformers' tokenizer work with the vicuna model
+        # trained with the transformers before commit: c0f99b4
+        # TODO: remove this when we retrain the vicuna model
+        tokenizer.bos_token_id = tokenizer.sp_model.bos_id()
+        tokenizer.eos_token_id = tokenizer.sp_model.eos_id()
+
     model = AutoModelForCausalLM.from_pretrained(model_name,
         low_cpu_mem_usage=True, **kwargs)
 

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -94,13 +94,6 @@ def main(args):
         raise ValueError(f"Invalid device: {args.device}")
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    if isinstance(tokenizer, LlamaTokenizer):
-        # This is a hack to make the new transformers' tokenizer work with the vicuna model
-        # trained with the transformers before commit: c0f99b4
-        # TODO: remove this when we retrain the vicuna model
-        tokenizer.bos_token_id = tokenizer.sp_model.bos_id()
-        tokenizer.eos_token_id = tokenizer.sp_model.eos_id()
-
     model = AutoModelForCausalLM.from_pretrained(model_name,
         low_cpu_mem_usage=True, **kwargs)
 

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -14,7 +14,7 @@ import uuid
 from fastapi import FastAPI, Request, BackgroundTasks
 from fastapi.responses import StreamingResponse
 import requests
-from transformers import AutoTokenizer, AutoModelForCausalLM
+from transformers import AutoTokenizer, AutoModelForCausalLM, LlamaTokenizer
 import torch
 import uvicorn
 
@@ -48,6 +48,13 @@ def load_model(model_path, num_gpus):
         }
 
     tokenizer = AutoTokenizer.from_pretrained(model_path)
+    if isinstance(tokenizer, LlamaTokenizer):
+        # This is a hack to make the new transformers' tokenizer work with the vicuna model
+        # trained with the transformers before commit: c0f99b4
+        # TODO: remove this when we retrain the vicuna model
+        tokenizer.bos_token_id = tokenizer.sp_model.bos_id()
+        tokenizer.eos_token_id = tokenizer.sp_model.eos_id()
+
     model = AutoModelForCausalLM.from_pretrained(
        model_path, torch_dtype=torch.float16, low_cpu_mem_usage=True, **kwargs)
 

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -48,13 +48,6 @@ def load_model(model_path, num_gpus):
         }
 
     tokenizer = AutoTokenizer.from_pretrained(model_path)
-    if isinstance(tokenizer, LlamaTokenizer):
-        # This is a hack to make the new transformers' tokenizer work with the vicuna model
-        # trained with the transformers before commit: c0f99b4
-        # TODO: remove this when we retrain the vicuna model
-        tokenizer.bos_token_id = tokenizer.sp_model.bos_id()
-        tokenizer.eos_token_id = tokenizer.sp_model.eos_id()
-
     model = AutoModelForCausalLM.from_pretrained(
        model_path, torch_dtype=torch.float16, low_cpu_mem_usage=True, **kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "accelerate", "fastapi", "gradio==3.23", "markdown2[all]", "numpy",
     "requests", "sentencepiece", "tokenizers==0.12.1",
     "torch", "uvicorn", "wandb",
-    "transformers @ git+https://github.com/huggingface/transformers.git@c612628045822f909020f7eb6784c79700813eda"
+    "transformers @ git+https://github.com/huggingface/transformers.git"
 ]
 
 [project.urls]

--- a/scripts/train-alpaca.yaml
+++ b/scripts/train-alpaca.yaml
@@ -29,7 +29,7 @@ setup: |
   cd ~
   git clone https://github.com/huggingface/transformers.git
   cd transformers
-  git checkout c612628045822f909020f7eb6784c79700813eda # pin to latest commit
+  git checkout 41a2f3529c6b56866c317031375ffd3e7b8bea01
   pip install .
   cd ~/sky_workdir
 

--- a/scripts/train-vicuna.yaml
+++ b/scripts/train-vicuna.yaml
@@ -33,7 +33,7 @@ setup: |
   cd ~
   git clone https://github.com/huggingface/transformers.git
   cd transformers
-  git checkout c612628045822f909020f7eb6784c79700813eda # pin to latest commit
+  git checkout 41a2f3529c6b56866c317031375ffd3e7b8bea01
   pip install .
   cd ~/sky_workdir
 


### PR DESCRIPTION
The change of the bos_id and eos_id in the latest tokenizer makes our model fail with the latest hugging face transformers. This PR patches the loaded tokenizer for vicuna to ensure the vicuna model works with the latest huggingface code.

TODO:
- [ ] Update our released model weight delta with the tokenizer config mentioned in https://github.com/lm-sys/FastChat/pull/167#discussion_r1157062502