### PR TITLE
Remove the uesless _get_html_tags function

### DIFF
--- a/fastchat/data/clean_sharegpt.py
+++ b/fastchat/data/clean_sharegpt.py
@@ -14,11 +14,8 @@ import tqdm
 
 def _get_html_tags(file_path: str):
     # Generate the list of html tags occurred in the file.
-    tags = set()
     with open(file_path, "r") as f:
-        for line in f:
-            for match in re.findall("</[^<>]+>", line):
-                tags.add(match)
+        tags = {match for line in f for match in re.findall("</[^<>]+>", line)}
     return tags
 
 div_pattern = re.compile("<div.*?>")

--- a/fastchat/data/clean_sharegpt.py
+++ b/fastchat/data/clean_sharegpt.py
@@ -61,7 +61,10 @@ def html_to_markdown(val: str) -> str:
 
 def should_skip(val: str) -> bool:
     black_list = ["openai", "chatgpt"]
-    return any(w in val.lower() for w in black_list)
+    for w in black_list:
+        if w in val.lower():
+            return True
+    return False
 
 
 def clean_html_source(content, begin, end, check_tag, check_num):

--- a/fastchat/data/clean_sharegpt.py
+++ b/fastchat/data/clean_sharegpt.py
@@ -13,12 +13,13 @@ import tqdm
 
 
 def _get_html_tags(file_path: str):
-    # Generate the list of html tags occured in the file.
-    s = set()
-    for l in open("file_path", "r"):
-        for m in re.findall("</[^<>]+>", l):
-            s.add(m)
-    return s
+    # Generate the list of html tags occurred in the file.
+    tags = set()
+    with open(file_path, "r") as f:
+        for line in f:
+            for match in re.findall("</[^<>]+>", line):
+                tags.add(match)
+    return tags
 
 div_pattern = re.compile("<div.*?>")
 span_pattern = re.compile("<span.*?>")
@@ -69,10 +70,7 @@ def html_to_markdown(val: str) -> str:
 
 def should_skip(val: str) -> bool:
     black_list = ["openai", "chatgpt"]
-    for w in black_list:
-        if w in val.lower():
-            return True
-    return False
+    return any(w in val.lower() for w in black_list)
 
 
 def clean_html_source(content, begin, end, check_tag, check_num):

--- a/fastchat/data/clean_sharegpt.py
+++ b/fastchat/data/clean_sharegpt.py
@@ -12,12 +12,6 @@ import markdownify  # == 0.11.6
 import tqdm
 
 
-def _get_html_tags(file_path: str):
-    # Generate the list of html tags occurred in the file.
-    with open(file_path, "r") as f:
-        tags = {match for line in f for match in re.findall("</[^<>]+>", line)}
-    return tags
-
 div_pattern = re.compile("<div.*?>")
 span_pattern = re.compile("<span.*?>")
 code_lang_pattern = re.compile("```\s*" + "(.*?)" + "(?:Copy code)+" + "(.+?)" + "\s*?```", re.DOTALL)


### PR DESCRIPTION
Here are little improvements to some code 
- The argument `file_path` in `_get_html_tags` should be passed as a variable, not a string literal.
- The `should_skip` function can be simplified using the any function.