### PR TITLE
Added load_in_8bit support for cli and web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ The command below requires around 28GB of GPU memory for Vicuna-13B.
 ```
 python3 -m fastchat.serve.cli --model-name /path/to/vicuna/weights
 ```
+Or you can load in 8-bit mode to reduce GPU memory usage. It is tested on a single 4090 and requires around 18GB of GPU memory. Note that this mode only works on single GPU. You are also required to install [bitsandbytes](https://github.com/TimDettmers/bitsandbytes).
+```
+python3 -m fastchat.serve.cli --model-name /path/to/vicuna/weights --load_8bit
+```
+
 
 #### Multi GPU
 If you do not have enough GPU memory, you can use model parallelism to aggregate memory from multiple GPUs on the same machine.
@@ -108,6 +113,11 @@ python3 -m fastchat.serve.controller
 python3 -m fastchat.serve.model_worker --model-path /path/to/vicuna/weights
 ```
 Wait until the process finishes loading the model and you see "Uvicorn running on ...".
+
+For single GPU, you can also load in 8 bit. You are also required to install [bitsandbytes](https://github.com/TimDettmers/bitsandbytes). 
+```
+python3 -m fastchat.serve.model_worker --model-path /path/to/vicuna/weights --load_8bit
+```
 
 #### Send a test message
 ```bash

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ python3 -m fastchat.serve.cli --model-name /path/to/vicuna/weights --device cpu
 
 ### Others (Quantization, More Platforms)
 
-You can load in 8-bit mode to reduce GPU memory usage. It is tested on a single 4090 and requires around 18GB of GPU memory for Vicuna-13B.
+You can load in 8-bit mode to reduce GPU memory usage with slightly degraded model quality.
+It is tested on a single 4090 and requires around 18GB of GPU memory for Vicuna-13B.
 Note that this mode only works on a single GPU.
 You are also required to install `bitsandbytes` according to the printed messages.
 
@@ -115,11 +116,6 @@ python3 -m fastchat.serve.controller
 python3 -m fastchat.serve.model_worker --model-path /path/to/vicuna/weights
 ```
 Wait until the process finishes loading the model and you see "Uvicorn running on ...".
-
-For single GPU, you can also load in 8 bit. You are also required to install [bitsandbytes](https://github.com/TimDettmers/bitsandbytes). 
-```
-python3 -m fastchat.serve.model_worker --model-path /path/to/vicuna/weights --load_8bit
-```
 
 ### Send a test message
 ```bash

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Join our [Discord](https://discord.gg/h6kCZb72G7) server and follow our [Twitter
 ## Contents
 - [Install](#install)
 - [Vicuna Weights](#vicuna-weights)
-- [Serving](#serving)
+- [Inference with Command Line Interface](#inference-with-command-line-interface)
+- [Serving with Web GUI](#serving-with-web-gui)
 - [Evaluation](#evaluation)
 - [Fine-tuning](#fine-tuning)
 
@@ -69,46 +70,47 @@ python3 -m fastchat.model.apply_delta \
 ### Vicuna-7B
 Coming soon.
 
-## Serving
+## Inference with Command Line Interface
 
-### Command Line Interface
-
-#### Single GPU
+### Single GPU
 The command below requires around 28GB of GPU memory for Vicuna-13B.
 ```
 python3 -m fastchat.serve.cli --model-name /path/to/vicuna/weights
 ```
-Or you can load in 8-bit mode to reduce GPU memory usage. It is tested on a single 4090 and requires around 18GB of GPU memory. Note that this mode only works on single GPU. You are also required to install [bitsandbytes](https://github.com/TimDettmers/bitsandbytes).
-```
-python3 -m fastchat.serve.cli --model-name /path/to/vicuna/weights --load_8bit
-```
 
-
-#### Multi GPU
+### Multiple GPUs
 If you do not have enough GPU memory, you can use model parallelism to aggregate memory from multiple GPUs on the same machine.
 ```
 python3 -m fastchat.serve.cli --model-name /path/to/vicuna/weights --num-gpus 2
 ```
 
-#### CPU Only
+### CPU Only
 This runs on the CPU only and does not require GPU. It requires around 60GB of CPU memory for Vicuna-13B.
 ```
 python3 -m fastchat.serve.cli --model-name /path/to/vicuna/weights --device cpu
 ```
 
-#### Others (Quantization, More Platforms)
-Currently, we only provide some basic commands for running the model.
-We are actively exploring methods to make the model easier to run on more platforms.
+### Others (Quantization, More Platforms)
+
+You can load in 8-bit mode to reduce GPU memory usage. It is tested on a single 4090 and requires around 18GB of GPU memory for Vicuna-13B.
+Note that this mode only works on a single GPU.
+You are also required to install `bitsandbytes` according to the printed messages.
+
+```
+python3 -m fastchat.serve.cli --model-name /path/to/vicuna/weights --load-8bit
+```
+
+Besides, we are actively exploring more methods to make the model easier to run on more platforms.
 Contributions and pull requests are welcome.
 
-### Web UI
+## Serving with Web GUI
 
-#### Launch a controller
+### Launch a controller
 ```bash
 python3 -m fastchat.serve.controller
 ```
 
-#### Launch a model worker
+### Launch a model worker
 ```bash
 python3 -m fastchat.serve.model_worker --model-path /path/to/vicuna/weights
 ```
@@ -119,16 +121,17 @@ For single GPU, you can also load in 8 bit. You are also required to install [bi
 python3 -m fastchat.serve.model_worker --model-path /path/to/vicuna/weights --load_8bit
 ```
 
-#### Send a test message
+### Send a test message
 ```bash
 python3 -m fastchat.serve.test_message --model-name vicuna-13b
 ```
 
-#### Launch a gradio web server.
+### Launch a gradio web server.
 ```bash
 python3 -m fastchat.serve.gradio_web_server
 ```
-#### You can open your browser and chat with a model now.
+
+### You can open your browser and chat with a model now.
 
 ## Evaluation
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This runs on the CPU only and does not require GPU. It requires around 60GB of C
 python3 -m fastchat.serve.cli --model-name /path/to/vicuna/weights --device cpu
 ```
 
-### Others (Quantization, More Platforms)
+### Others (Quantization, Low-end Devices, and More Platforms)
 
 You can load in 8-bit mode to reduce GPU memory usage with slightly degraded model quality.
 It is tested on a single 4090 and requires around 18GB of GPU memory for Vicuna-13B.

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -11,7 +11,7 @@ from transformers import AutoTokenizer, AutoModelForCausalLM, LlamaTokenizer
 from fastchat.conversation import conv_templates, SeparatorStyle
 
 
-def load_model(model_name, num_gpus, device, load_8bit=False):
+def load_model(model_name, device, num_gpus, load_8bit=False):
     if device == "cuda":
         kwargs = {"torch_dtype": torch.float16}
         if load_8bit:
@@ -109,8 +109,8 @@ def main(args):
     model_name = args.model_name
 
     # Model
-    model, tokenizer = load_model(args.model_name, args.num_gpus,
-        args.device, args.load_8bit)
+    model, tokenizer = load_model(args.model_name, args.device,
+        args.num_gpus, args.load_8bit)
 
     # Chat
     conv = conv_templates[args.conv_template].copy()

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -235,7 +235,7 @@ def http_bot(state, model_selector, temperature, max_new_tokens, request: gr.Req
                     return
                 time.sleep(0.02)
     except requests.exceptions.RequestException as e:
-        state.messages[-1][-1] = server_error_msg
+        state.messages[-1][-1] = server_error_msg + f" (error_code: 4)"
         yield (state, state.to_gradio_chatbot()) + (disable_btn, disable_btn, disable_btn, enable_btn, enable_btn)
         return
 

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -49,6 +49,7 @@ class ModelWorker:
         if model_path.endswith("/"):
             model_path = model_path[:-1]
         self.model_name = model_name or model_path.split("/")[-1]
+        self.device = device
 
         logger.info(f"Loading the model {self.model_name} on worker {worker_id} ...")
         self.model, self.tokenizer = load_model(
@@ -137,13 +138,13 @@ class ModelWorker:
         for i in range(max_new_tokens):
             if i == 0:
                 out = model(
-                    torch.as_tensor([input_ids]).cuda(), use_cache=True)
+                    torch.as_tensor([input_ids], device=self.device), use_cache=True)
                 logits = out.logits
                 past_key_values = out.past_key_values
             else:
                 attention_mask = torch.ones(
-                    1, past_key_values[0][0].shape[-2] + 1, device="cuda")
-                out = model(input_ids=torch.as_tensor([[token]], device="cuda"),
+                    1, past_key_values[0][0].shape[-2] + 1, device=self.device)
+                out = model(input_ids=torch.as_tensor([[token]], device=self.device),
                             use_cache=True,
                             attention_mask=attention_mask,
                             past_key_values=past_key_values)

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -19,6 +19,7 @@ import torch
 import uvicorn
 
 from fastchat.constants import WORKER_HEART_BEAT_INTERVAL
+from fastchat.serve.cli import load_model
 from fastchat.utils import (build_logger, server_error_msg,
     pretty_print_semaphore)
 
@@ -36,39 +37,6 @@ def heart_beat_worker(controller):
     while True:
         time.sleep(WORKER_HEART_BEAT_INTERVAL)
         controller.send_heart_beat()
-
-
-def load_model(model_name, num_gpus, device, load_8bit=False):
-    if device == "cuda":
-        kwargs = {"torch_dtype": torch.float16}
-        if load_8bit:
-            if num_gpus != "auto" and int(num_gpus) != 1:
-                print("8-bit weights are not supported on multiple GPUs. Revert to use one GPU.")
-            kwargs.update({"load_in_8bit": True, "device_map": "auto"})
-        else:
-            if num_gpus == "auto":
-                kwargs["device_map"] = "auto"
-            else:
-                num_gpus = int(num_gpus)
-                if num_gpus != 1:
-                    kwargs.update({
-                        "device_map": "auto",
-                        "max_memory": {i: "13GiB" for i in range(num_gpus)},
-                    })
-    elif device == "cpu":
-        kwargs = {}
-    else:
-        raise ValueError(f"Invalid device: {device}")
-
-    tokenizer = AutoTokenizer.from_pretrained(model_name)
-    model = AutoModelForCausalLM.from_pretrained(model_name,
-        low_cpu_mem_usage=True, **kwargs)
-
-    # calling model.cuda() mess up weights if loading 8-bit weights
-    if device == "cuda" and num_gpus == 1 and not load_8bit:
-        model.cuda()
-
-    return model, tokenizer
 
 
 class ModelWorker:

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -54,10 +54,10 @@ class ModelWorker:
         self.model, self.tokenizer = load_model(
             model_path, device, num_gpus, load_8bit)
 
-        if hasattr(model.config, "max_sequence_length"):
-            self.context_len = model.config.max_sequence_length
-        elif hasattr(model.config, "max_position_embeddings"):
-            self.context_len = model.config.max_position_embeddings
+        if hasattr(self.model.config, "max_sequence_length"):
+            self.context_len = self.model.config.max_sequence_length
+        elif hasattr(self.model.config, "max_position_embeddings"):
+            self.context_len = self.model.config.max_position_embeddings
         else:
             self.context_len = 2048
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fschat"
-version = "0.1.3"
+version = "0.1.4"
 description = "An open platform for training, serving, and evaluating large language model based chatbots."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
This PR leveraged the bitsandbytes integration in the transformers package (see https://github.com/TimDettmers/bitsandbytes). Now users can load the original Vicuna weights in 8bit mode, which significantly lowered GPU memory requirements. Loading the model in this mode can reduce GPU memory usage to around 16GB (Generating will require more memory though). It is tested on a single 4090 GPU without any issue. 

Note that this mode only supports running on a single GPU.

README is also updated.