### PR TITLE
Add cmake installation instructions for Apple Silicon users

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,7 @@ cd FastChat
 
 If you are running on Mac:
 ```bash
-brew install rust 
-```
-
-For some Apple Silicon (M1 | M2) users, it may be necessary to install cmake:
-```bash
-brew install cmake
+brew install rust cmake
 ```
 
 2. Install Package

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ cd FastChat
 
 If you are running on Mac:
 ```bash
-brew install rust
+brew install rust 
+```
+
+For some Apple Silicon (M1 | M2) users, it may be necessary to install cmake:
+```bash
+brew install cmake
 ```
 
 2. Install Package


### PR DESCRIPTION
This pull request updates the README.md file to include additional installation instructions for Apple Silicon (M1 and M2) users. The changes made are as follows:

+
+For some Apple Silicon (M1 | M2) users, it may be necessary to install cmake:
+```bash
+brew install cmake
+```

By adding these instructions, we aim to improve the installation experience for Apple Silicon users who may encounter issues during the process (like me). This should help prevent errors related to cmake and ensure a smoother installation.
