### PR TITLE
Set lora target modules via command line arguments

### DIFF
--- a/fastchat/train/train_lora.py
+++ b/fastchat/train/train_lora.py
@@ -37,7 +37,7 @@ DEFAULT_EOS_TOKEN = "</s>"
 DEFAULT_BOS_TOKEN = "</s>"
 DEFAULT_UNK_TOKEN = "</s>"
 
-# TODO: the lora_target_modules cannot support list
+
 @dataclass
 class LoraArguments:
     lora_r: int = 8,
@@ -59,7 +59,7 @@ def train():
     lora_config = LoraConfig(
         r=lora_args.lora_r,
         lora_alpha=lora_args.lora_alpha,
-        target_modules=["q_proj", "v_proj"],
+        target_modules=lora_args.lora_target_modules,
         lora_dropout=lora_args.lora_dropout,
         bias="none",
         task_type="CAUSAL_LM",


### PR DESCRIPTION
Now it possible to set the modules directly from the command line

for example
`--lora_target_modules "q_proj", "k_proj", "v_proj", "down_proj", "gate_proj", "up_proj"`