### PR TITLE
Maintain compatibilty with older transformers versions.

### DIFF
--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -1,8 +1,10 @@
 """Inference for FastChat models."""
 import abc
 import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM, LlamaTokenizer, AutoModel
-
+try:
+    from transformers import AutoTokenizer, AutoModelForCausalLM, LlamaTokenizer, AutoModel
+except ImportError:
+    from transformers import AutoTokenizer, AutoModelForCausalLM, LLaMATokenizer, AutoModel
 from fastchat.conversation import conv_templates, SeparatorStyle
 from fastchat.serve.compression import compress_module
 from fastchat.serve.monkey_patch_non_inplace import replace_llama_attn_with_non_inplace_operations

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -14,7 +14,10 @@ import uuid
 from fastapi import FastAPI, Request, BackgroundTasks
 from fastapi.responses import StreamingResponse
 import requests
-from transformers import AutoTokenizer, AutoModelForCausalLM, LlamaTokenizer
+try:
+    from transformers import AutoTokenizer, AutoModelForCausalLM, LlamaTokenizer, AutoModel
+except ImportError:
+    from transformers import AutoTokenizer, AutoModelForCausalLM, LLaMATokenizer, AutoModel
 import torch
 import uvicorn
 


### PR DESCRIPTION
There's an issue with the config file in some weights, I would like to be able to pull the lastest upstream code but these imports make it hard to do.

This PR allows me and others to use versions of the transformers library with the old naming convention.

See: https://github.com/huggingface/transformers/issues/22222
