### PR TITLE
remove attention mask in inference.py to fit different models

### DIFF
--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -74,11 +74,8 @@ def generate_stream(model, tokenizer, params, device,
             logits = out.logits
             past_key_values = out.past_key_values
         else:
-            attention_mask = torch.ones(
-                1, past_key_values[0][0].shape[-2] + 1, device=device)
             out = model(input_ids=torch.as_tensor([[token]], device=device),
                         use_cache=True,
-                        attention_mask=attention_mask,
                         past_key_values=past_key_values)
             logits = out.logits
             past_key_values = out.past_key_values


### PR DESCRIPTION
Fix #357 

Remove the manual attention mask setting in the inference process according to the shape of past_key_value, since different models have different past_key_values. 
Hence the attention mask could be one-initialized in the model forward function.