### PR TITLE
fix tokenizer issue

### DIFF
--- a/fastchat/model/apply_delta.py
+++ b/fastchat/model/apply_delta.py
@@ -37,7 +37,7 @@ def apply_delta(base_model_path, target_model_path, delta_path):
 
     print(f"Saving the target model to {target_model_path}")
     base.save_pretrained(target_model_path)
-    delta_tokenizer.save_pretrained(target_model_path)
+    base_tokenizer.save_pretrained(target_model_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
the delta tokenizer does not seem to contain the pad token.

The upstream vicuna weights repo should be updated. Alternately, this solution works too.

Fixes: https://github.com/lm-sys/FastChat/issues/363