### PR TITLE
[UI] Fix markdown rendering in rich cli format

### DIFF
--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -72,12 +72,13 @@ class RichChatIO(ChatIO):
                     continue
                 # Render the accumulated text as Markdown
                 # NOTE: this is a workaround for the rendering "unstandard markdown"
-                #  in rich. The output of chatbots would treat "\n" as a new line for
-                #  better compatibility with real-world text. However, then rendering
-                #  in markdown this would not work. Standard markdown would treat a single
-                #  "\n" in normal text as a space. Our workaround is adding two spaces at
-                #  the end of each line. This is not a perfect solution, as it would
-                #  introduce trailing spaces in code block, but it works
+                #  in rich. The chatbots output treat "\n" as a new line for
+                #  better compatibility with real-world text. However, rendering
+                #  in markdown would break the format. It is because standard markdown
+                #  treat a single "\n" in normal text as a space.
+                #  Our workaround is adding two spaces at the end of each line.
+                #  This is not a perfect solution, as it would
+                #  introduce trailing spaces (only) in code block, but it works well
                 #  especially for console output, because in general the console does not
                 #  care about trailing spaces.
                 lines = []

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -85,7 +85,7 @@ class RichChatIO(ChatIO):
                 for line in accumulated_text.splitlines():
                     lines.append(line)
                     if line.startswith("```"):
-                        # Code block - do not add trailing spaces, as it would
+                        # Code block marker - do not add trailing spaces, as it would
                         #  break the syntax highlighting
                         lines.append("\n")
                     else:

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -71,7 +71,16 @@ class RichChatIO(ChatIO):
                 if not accumulated_text:
                     continue
                 # Render the accumulated text as Markdown
-                markdown = Markdown(accumulated_text)
+                # NOTE: this is a workaround for the rendering "unstandard markdown"
+                #  in rich. The output of chatbots would treat "\n" as a new line for
+                #  better compatibility with real-world text. However, then rendering
+                #  in markdown this would not work. Standard markdown would treat a single
+                #  "\n" in normal text as a space. Our workaround is adding two spaces at
+                #  the end of each line. This is not a perfect solution, as it would
+                #  introduce trailing spaces in code block, but it works
+                #  especially for console output, because in general the console does not
+                #  care about trailing spaces.
+                markdown = Markdown(accumulated_text.replace("\n", "  \n"))
                 # Update the Live console output
                 live.update(markdown)
         self._console.print()

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -80,7 +80,16 @@ class RichChatIO(ChatIO):
                 #  introduce trailing spaces in code block, but it works
                 #  especially for console output, because in general the console does not
                 #  care about trailing spaces.
-                markdown = Markdown(accumulated_text.replace("\n", "  \n"))
+                lines = []
+                for line in accumulated_text.splitlines():
+                    lines.append(line)
+                    if line.startswith("```"):
+                        # Code block - do not add trailing spaces, as it would
+                        #  break the syntax highlighting
+                        lines.append("\n")
+                    else:
+                        lines.append("  \n")
+                markdown = Markdown("".join(lines))
                 # Update the Live console output
                 live.update(markdown)
         self._console.print()


### PR DESCRIPTION
This is a workaround for the rendering "unstandard markdown" in rich. The output of chatbots would treat "\n" as a new line for better compatibility with real-world text.

However, then rendering in markdown this would not work. Standard markdown would treat a single "\n" in normal text as a space. Our workaround is adding two spaces at the end of each line. This is not a perfect solution, as it would  introduce trailing spaces in code block, but it works especially for console output, because in general the console does not care about trailing spaces.

Before:

<img width="691" alt="image" src="https://user-images.githubusercontent.com/13750372/231614483-5b89aa0d-0cb8-4d40-84c9-cfa3131ee210.png">


After:

<img width="215" alt="image" src="https://user-images.githubusercontent.com/13750372/231614372-4828e209-5658-46f9-b247-b8d1c072d8b4.png">


