### PR TITLE
Add warning for wrong Vicuna model weight version

### DIFF
--- a/fastchat/eval/get_model_answer.py
+++ b/fastchat/eval/get_model_answer.py
@@ -1,10 +1,11 @@
 import argparse
-from transformers import AutoTokenizer, AutoModelForCausalLM
+from transformers import AutoTokenizer, AutoModelForCausalLM, LlamaForCausalLM
 import torch
 import os
 import json
 from tqdm import tqdm
 import shortuuid
+import warnings
 import ray
 
 from fastchat.conversation import get_default_conv_template
@@ -40,6 +41,12 @@ def get_model_answers(model_path, model_id, question_jsons):
     tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=False)
     model = AutoModelForCausalLM.from_pretrained(model_path,
         torch_dtype=torch.float16).cuda()
+    
+    if isinstance(model, LlamaForCausalLM):
+        if model.model.vocab_size > 32000:
+            warnings.warn('You are probably using the old Vicuna-v0 model, '
+                          'which will generate unexpected results with the '
+                          'current fschat. Please check the new Vicuna-v1.1.')
 
     ans_jsons = []
     for i, line in enumerate(tqdm(question_jsons)):

--- a/fastchat/eval/get_model_answer.py
+++ b/fastchat/eval/get_model_answer.py
@@ -5,7 +5,6 @@ import os
 import json
 from tqdm import tqdm
 import shortuuid
-import warnings
 import ray
 
 from fastchat.conversation import get_default_conv_template
@@ -41,12 +40,6 @@ def get_model_answers(model_path, model_id, question_jsons):
     tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=False)
     model = AutoModelForCausalLM.from_pretrained(model_path,
         torch_dtype=torch.float16).cuda()
-    
-    if isinstance(model, LlamaForCausalLM):
-        if model.model.vocab_size > 32000:
-            warnings.warn('You are probably using the old Vicuna-v0 model, '
-                          'which will generate unexpected results with the '
-                          'current fschat. Please check the new Vicuna-v1.1.')
 
     ans_jsons = []
     for i, line in enumerate(tqdm(question_jsons)):

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -1,12 +1,13 @@
 """Inference for FastChat models."""
 import abc
 from typing import Optional
+import warnings
 
 import torch
 try:
-    from transformers import AutoTokenizer, AutoModelForCausalLM, LlamaTokenizer, AutoModel
+    from transformers import AutoTokenizer, AutoModelForCausalLM, LlamaTokenizer, LlamaForCausalLM, AutoModel, LlamaForCausalLM
 except ImportError:
-    from transformers import AutoTokenizer, AutoModelForCausalLM, LLaMATokenizer, AutoModel
+    from transformers import AutoTokenizer, AutoModelForCausalLM, LLaMATokenizer, LLamaForCausalLM, AutoModel
 
 from fastchat.conversation import conv_templates, get_default_conv_template, SeparatorStyle
 from fastchat.serve.compression import compress_module
@@ -48,6 +49,15 @@ def load_model(model_path, device, num_gpus, load_8bit=False, debug=False):
         tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=False)
         model = AutoModelForCausalLM.from_pretrained(model_path,
             low_cpu_mem_usage=True, **kwargs)
+        if 'vicuna' in model_path:
+            try:
+                is_vicuna = isinstance(model, LlamaForCausalLM)
+            except Exception:
+                is_vicuna = isinstance(model, LLamaForCausalLM)
+            if is_vicuna and model.model.vocab_size > 32000:
+                warnings.warn('You are probably using the old Vicuna-v0 model, '
+                            'which will generate unexpected results with the '
+                            'current fschat. Please check the new Vicuna-v1.1: https://github.com/lm-sys/FastChat#vicuna-weights')
 
     if load_8bit:
         compress_module(model, device)

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -55,9 +55,9 @@ def load_model(model_path, device, num_gpus, load_8bit=False, debug=False):
             except Exception:
                 is_vicuna = isinstance(model, LLamaForCausalLM)
             if is_vicuna and model.model.vocab_size > 32000:
-                warnings.warn('You are probably using the old Vicuna-v0 model, '
+                warnings.warn('\nYou probably use the old Vicuna-v0 model, '
                             'which will generate unexpected results with the '
-                            'current fschat. Please check the new Vicuna-v1.1: https://github.com/lm-sys/FastChat#vicuna-weights')
+                            'current fschat.\nPlease check the new Vicuna-v1.1: https://github.com/lm-sys/FastChat#vicuna-weights')
 
     if load_8bit:
         compress_module(model, device)


### PR DESCRIPTION
It shows something like the following
```
> python3 -m fastchat.serve.cli --model-path ~/vicuna-7b-old/
Loading checkpoint shards: 100%|███████████████████████████████████████████████████████████████| 2/2 [00:04<00:00,  2.29s/it]
/home/gcpuser/FastChat/fastchat/serve/inference.py:58: UserWarning:
You probably use the old Vicuna-v0 model, which will generate unexpected results with the current fschat.
Please check the new Vicuna-v1.1: https://github.com/lm-sys/FastChat#vicuna-weights
  warnings.warn('You are probably using the old Vicuna-v0 model, '
USER: 
```