### PR TITLE
Fix train_lora configuration dataclass

### DIFF
--- a/fastchat/train/train_lora.py
+++ b/fastchat/train/train_lora.py
@@ -15,7 +15,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import pathlib
 import typing
 
@@ -40,10 +40,10 @@ DEFAULT_UNK_TOKEN = "</s>"
 
 @dataclass
 class LoraArguments:
-    lora_r: int = 8,
-    lora_alpha: int = 16,
-    lora_dropout: float = 0.05,
-    lora_target_modules: typing.List[str] = ["q_proj", "v_proj"],
+    lora_r: int = 8
+    lora_alpha: int = 16
+    lora_dropout: float = 0.05
+    lora_target_modules: typing.List[str] = field(default_factory=lambda: ["q_proj", "v_proj"])
     lora_weight_path: str = ""
 
 def train():


### PR DESCRIPTION
The previous dataclass code do not store float values but 1-uplet and therefore can't be passed to PEFT.

See the following debug output from the previous code:
```
LoraConfig(peft_type=<PeftType.LORA: 'LORA'>, base_model_name_or_path=None, task_type='CAUSAL_LM', inference_mode=False, r=(8,), target_modules=None, lora_alpha=(16,), lora_dropout=(0.05,), fan_in_fan_out=False, bias='none', modules_to_save=None, init_lora_weights=True) (0.05,)
```

Werease lora_alpha should be `16` instead of `(16,)`.