### PR TITLE
Fix backward compatibility issue for Python 3.8

### DIFF
--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -26,7 +26,7 @@ def build_logger(logger_name, logger_filename):
 
     # Set the format of root handlers
     if not logging.getLogger().handlers:
-        logging.basicConfig(level=logging.INFO, encoding='utf-8')
+        logging.basicConfig(level=logging.INFO)
     logging.getLogger().handlers[0].setFormatter(formatter)
 
     # Redirect stdout and stderr to loggers


### PR DESCRIPTION
```
  File "/XXXX/FastChat/fastchat/serve/model_worker.py", line 33, in <module>
    logger = build_logger("model_worker", f"model_worker_{worker_id}.log")
  File "/XXXX/FastChat/fastchat/utils.py", line 29, in build_logger
    logging.basicConfig(level=logging.INFO, encoding='utf-8')
  File "/usr/lib/python3.8/logging/__init__.py", line 2009, in basicConfig
    raise ValueError('Unrecognised argument(s): %s' % keys)
ValueError: Unrecognised argument(s): encoding
```

`encoding` option is NOT support in Python 3.8 and earlier.