### PR TITLE
added argument to pass the number of cpu threads torch can use

### DIFF
--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -105,7 +105,7 @@ def main(args):
     else:
         raise ValueError(f"Invalid style for console: {args.style}")
     try:
-        chat_loop(args.model_path, args.device, args.num_gpus, args.max_gpu_memory,
+        chat_loop(args.model_path, args.device, args.num_gpus, args.num_threads, args.max_gpu_memory,
             args.load_8bit, args.conv_template, args.temperature, args.max_new_tokens,
             chatio, args.debug)
     except KeyboardInterrupt:
@@ -118,6 +118,7 @@ if __name__ == "__main__":
         help="The path to the weights")
     parser.add_argument("--device", type=str, choices=["cpu", "cuda", "mps"], default="cuda")
     parser.add_argument("--num-gpus", type=str, default="1")
+    parser.add_argument("--num-threads", type=int, default=None)
     parser.add_argument("--max-gpu-memory", type=str, default="13GiB")
     parser.add_argument("--load-8bit", action="store_true",
         help="Use 8-bit quantization.")

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -173,11 +173,15 @@ class ChatIO(abc.ABC):
         """Stream output."""
 
 
-def chat_loop(model_path: str, device: str, num_gpus: str,
+def chat_loop(model_path: str, device: str, num_gpus: str, num_threads: int,
               max_gpu_memory: str, load_8bit: bool,
               conv_template: Optional[str], temperature: float,
               max_new_tokens: int, chatio: ChatIO,
               debug: bool):
+    
+    if num_threads != None:
+        torch.set_num_threads(num_threads)
+    
     # Model
     model, tokenizer = load_model(model_path, device,
         num_gpus, max_gpu_memory, load_8bit, debug)


### PR DESCRIPTION
Thanks for this awesome project!

### Problem: 
It is not possible to tweak the amount of threads being used (default only using 4 on my machine, but i have 8)

### Solution:
I added `--num-threads` to "**cli.py**", when provided it will tell torch inside "**inference.py**" how many threads to use.

Kind Regards

Alex