### PR TITLE
Handle errors in split_files function (delete tmp_path files) 

### DIFF
--- a/fastchat/model/apply_delta.py
+++ b/fastchat/model/apply_delta.py
@@ -37,7 +37,7 @@ def split_files(model_path, tmp_path, split_size):
         new_state_dict = {}
 
         current_size = 0
-
+    try:
         for name, param in state_dict.items():
             param_size = param.numel() * param.element_size()
 
@@ -61,6 +61,10 @@ def split_files(model_path, tmp_path, split_size):
         gc.collect()
         new_state_dict = {}
         part += 1
+    except Exception as e:
+        print(f"An error occurred during split_files: {e}")
+        shutil.rmtree(tmp_path)
+        raise
 
 
 def apply_delta_low_cpu_mem(base_model_path, target_model_path, delta_path):


### PR DESCRIPTION
This pull request improves error handling in the `split_files` function. It ensures that the temporary directory, which may contain large files, is removed when an exception occurs during the file splitting process. This helps prevent unused, large files from consuming disk space when an error is encountered.

Changes include:

- Wrap the file splitting process in a try-except block
- Remove the temporary directory containing large files if an exception is raised
- Print the error message and re-raise the exception for further handling