### PR TITLE
Update python requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "fschat"
 version = "0.2.2"
 description = "An open platform for training, serving, and evaluating large language model based chatbots."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
`encoding` argument in [this line](https://github.com/lm-sys/FastChat/blob/main/fastchat/utils.py#L29) is added in 3.9. Current requirements will cause `python3 -m fastchat.serve.controller` to fail. 