### PR TITLE
Add support for Baize and LoRA models

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -23,6 +23,7 @@ class SeparatorStyle(Enum):
     TWO = auto()
     DOLLY = auto()
     OASST_PYTHIA = auto()
+    BAIZE = auto()
 
 
 @dataclasses.dataclass
@@ -77,6 +78,14 @@ class Conversation:
                     ret += role + message + self.sep
                 else:
                     ret += role
+            return ret
+        elif self.sep_style == SeparatorStyle.BAIZE:
+            ret = self.system
+            for role, message in self.messages:
+                if message:
+                    ret += "\n" + role + message
+                else:
+                    ret += "\n" + role
             return ret
         else:
             raise ValueError(f"Invalid style: {self.sep_style}")
@@ -209,12 +218,26 @@ conv_stablelm = Conversation(
     sep="",
 )
 
+conv_baize = Conversation(
+    system="The following is a conversation between a human and an AI assistant named Baize (named after a mythical creature in Chinese folklore). Baize is an open-source AI assistant developed by UCSD and Sun Yat-Sen University. The human and the AI assistant take turns chatting. Human statements start with [|Human|] and AI assistant statements start with [|AI|]. The AI assistant always provides responses in as much detail as possible, and in Markdown format. The AI assistant always declines to engage with topics, questions and instructions related to unethical, controversial, or sensitive issues. Complete the transcript in exactly that format.",
+    roles=("[|Human|]", "[|AI|]"),
+    messages=(
+        ("[|Human|]", "Hello!"),
+        ("[|AI|]", "Hi!"),
+    ),
+    offset=0,
+    sep_style=SeparatorStyle.BAIZE,
+    sep="[|Human|]",
+)
+
+
 conv_templates = {
     "conv_one_shot": conv_one_shot,
     "vicuna_v1.1": conv_vicuna_v1_1,
     "koala_v1": conv_koala_v1,
     "dolly": conv_dolly,
     "oasst": conv_oasst,
+    "baize": conv_baize,
 }
 
 
@@ -228,6 +251,8 @@ def get_default_conv_template(model_name):
         return conv_dolly
     elif "oasst" in model_name and "pythia" in model_name:
         return conv_oasst
+    elif "baize" in model_name:
+        return conv_baize
     elif "stablelm" in model_name:
         return conv_stablelm
     return conv_one_shot
@@ -252,6 +277,8 @@ def compute_skip_echo_len(model_name, conv, prompt):
         skip_echo_len = len(prompt)
         for tok in special_toks:
             skip_echo_len -= prompt.count(tok) * len(tok)
+    elif "baize" in model_name:
+        skip_echo_len = len(prompt)
     else:
         skip_echo_len = len(prompt) + 1 - prompt.count("</s>") * 3
     return skip_echo_len

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -226,7 +226,7 @@ conv_baize = Conversation(
         ("[|Human|]", "Hello!"),
         ("[|AI|]", "Hi!"),
     ),
-    offset=0,
+    offset=2,
     sep_style=SeparatorStyle.BAIZE,
     sep="[|Human|]",
 )

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -8,6 +8,7 @@ Now we support
 - StabilityAI/stablelm-tuned-alpha-7b
 - databricks/dolly-v2-12b
 - THUDM/chatglm-6b
+- project-baize/baize-lora-7B
 - Alpaca/LLaMa
 """
 

--- a/fastchat/model/apply_lora.py
+++ b/fastchat/model/apply_lora.py
@@ -1,0 +1,48 @@
+"""
+Apply the LoRA weights on top of a base model.
+
+Usage:
+python3 -m fastchat.model.apply_lora --base ~/model_weights/llama-7b --target ~/model_weights/baize-7b --lora project-baize/baize-lora-7B
+"""
+import argparse
+
+from huggingface_hub import snapshot_download
+import torch
+from torch import nn
+from tqdm import tqdm
+from peft import PeftModel
+from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
+
+
+def apply_lora(base_model_path, target_model_path, lora_path):
+    print(f"Loading the base model from {base_model_path}")
+    base = AutoModelForCausalLM.from_pretrained(
+        base_model_path, torch_dtype=torch.float16, low_cpu_mem_usage=True
+    )
+    base_tokenizer = AutoTokenizer.from_pretrained(base_model_path, use_fast=False)
+
+    print(f"Loading the LoRA adapter from {lora_path}")
+
+    lora_model = PeftModel.from_pretrained(
+        base,
+        lora_path,
+        torch_dtype=torch.float16,
+    )
+
+    print("Applying the LoRA")
+    model = lora_model.merge_and_unload()
+
+    print(f"Saving the target model to {target_model_path}")
+    model.save_pretrained(target_model_path)
+    base_tokenizer.save_pretrained(target_model_path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-model-path", type=str, required=True)
+    parser.add_argument("--target-model-path", type=str, required=True)
+    parser.add_argument("--lora-path", type=str, required=True)
+
+    args = parser.parse_args()
+
+    apply_lora(args.base_model_path, args.target_model_path, args.lora_path)

--- a/fastchat/model/apply_lora.py
+++ b/fastchat/model/apply_lora.py
@@ -3,6 +3,9 @@ Apply the LoRA weights on top of a base model.
 
 Usage:
 python3 -m fastchat.model.apply_lora --base ~/model_weights/llama-7b --target ~/model_weights/baize-7b --lora project-baize/baize-lora-7B
+
+Dependency:
+pip3 install git+https://github.com/huggingface/peft.git@2822398fbe896f25d4dac5e468624dc5fd65a51b
 """
 import argparse
 

--- a/fastchat/model/apply_lora.py
+++ b/fastchat/model/apply_lora.py
@@ -6,12 +6,9 @@ python3 -m fastchat.model.apply_lora --base ~/model_weights/llama-7b --target ~/
 """
 import argparse
 
-from huggingface_hub import snapshot_download
 import torch
-from torch import nn
-from tqdm import tqdm
 from peft import PeftModel
-from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
+from transformers import AutoTokenizer, AutoModelForCausalLM
 
 
 def apply_lora(base_model_path, target_model_path, lora_path):

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -122,7 +122,7 @@ def load_model(
         )
         # 50277 means "### End"
         tokenizer.eos_token_id = 50277
-    elif "pythia" in model_path or "stablelm" in model_path:
+    elif "pythia" in model_path or "stablelm" in model_path or "":
         tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=True)
         model = AutoModelForCausalLM.from_pretrained(
             model_path, low_cpu_mem_usage=True, **kwargs
@@ -296,13 +296,18 @@ def chat_loop(
             prompt = conv.get_prompt()
 
         skip_echo_len = compute_skip_echo_len(model_path, conv, prompt)
+        stop_str = (
+            conv.sep
+            if conv.sep_style in [SeparatorStyle.SINGLE, SeparatorStyle.BAIZE]
+            else None
+        )
 
         params = {
             "model": model_path,
             "prompt": prompt,
             "temperature": temperature,
             "max_new_tokens": max_new_tokens,
-            "stop": conv.sep if conv.sep_style == SeparatorStyle.SINGLE else None,
+            "stop": stop_str,
         }
 
         chatio.prompt_for_output(conv.roles[1])

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -122,7 +122,7 @@ def load_model(
         )
         # 50277 means "### End"
         tokenizer.eos_token_id = 50277
-    elif "pythia" in model_path or "stablelm" in model_path or "":
+    elif "pythia" in model_path or "stablelm" in model_path:
         tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=True)
         model = AutoModelForCausalLM.from_pretrained(
             model_path, low_cpu_mem_usage=True, **kwargs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ dependencies = [
     "uvicorn", "wandb", "httpx", "shortuuid", "pydantic",
 ]
 
+dependency_links=[
+    "git+https://github.com/huggingface/peft.git@2822398fbe896f25d4dac5e468624dc5fd65a51b#egg=peft"
+]
+
 [project.optional-dependencies]
 dev = ["black==23.3.0", "pylint==2.8.2"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,6 @@ dependencies = [
     "uvicorn", "wandb", "httpx", "shortuuid", "pydantic",
 ]
 
-dependency_links=[
-    "git+https://github.com/huggingface/peft.git@2822398fbe896f25d4dac5e468624dc5fd65a51b#egg=peft"
-]
-
 [project.optional-dependencies]
 dev = ["black==23.3.0", "pylint==2.8.2"]
 


### PR DESCRIPTION
This PR adds support for LoRA weights and support for Baize's chat format.

Test with the following scripts:
```bash
python3 -m fastchat.model.apply_lora --base zpn/llama-7b --target ./model_weights/baize-7b --lora project-baize/baize-lora-7B
python3 -m fastchat.serve.cli --model-path ./model_weights/baize-7b
```

By the way, it would be great if you can host Baize's 7B or 13B on your web demo (especially 13B, as HF's GPU is not good enough for this)
