### PR TITLE
provide default conversation template variable for user to check

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -290,4 +290,5 @@ def compute_skip_echo_len(model_name, conv, prompt):
 
 
 if __name__ == "__main__":
+    default_conversation = conv_templates["vicuna_v1.1"]
     print(default_conversation.get_prompt())


### PR DESCRIPTION
Hi, just realised that the new version update of vicuna 2.x took away the default_conversation variable. Technically, the conversation.py cannot be run as a main now. I guess it will be still potentially useful for user to run the script to check out different base prompt to get a quick idea of what prompt is being appended, let's add it back?