### PR TITLE
Add preprocess exception handler for trainer.

### DIFF
--- a/fastchat/train/train.py
+++ b/fastchat/train/train.py
@@ -84,11 +84,17 @@ def preprocess(
     conversations = []
     for i, source in enumerate(sources):
         if len(source) == 0:
-            rank0_print(f"WARNING: size of source is 0.")
+            rank0_print(
+                f"WARNING: size of source is 0."
+                f" (ignored)"
+            )
             conversations.append(conv.get_prompt())
             continue
         if source[0]["from"] not in roles:
-            rank0_print(f"WARNING: `{source[0]['from']} is not in roles.")
+            rank0_print(
+                f"WARNING: `{source[0]['from']} is not in roles."
+                f" (ignored)"
+            )
             conversations.append(conv.get_prompt())
             continue
         if roles[source[0]["from"]] != conv.roles[0]:
@@ -99,7 +105,10 @@ def preprocess(
         for j, sentence in enumerate(source):
             role = roles[sentence["from"]]
             if role != conv.roles[j % 2]:
-                rank0_print(f'WARNING: `{role}` == `{conv.roles[j % 2]}` mismatch.')
+                rank0_print(
+                    f'WARNING: `{role}` == `{conv.roles[j % 2]}` mismatch.'
+                    f' (ignored)'
+                )
                 conv.messages = []
                 break
             conv.append_message(role, sentence["value"])

--- a/fastchat/train/train.py
+++ b/fastchat/train/train.py
@@ -83,6 +83,14 @@ def preprocess(
     # Apply prompt templates
     conversations = []
     for i, source in enumerate(sources):
+        if len(source) == 0:
+            rank0_print(f"WARNING: size of source is 0.")
+            conversations.append(conv.get_prompt())
+            continue
+        if source[0]["from"] not in roles:
+            rank0_print(f"WARNING: `{source[0]['from']} is not in roles.")
+            conversations.append(conv.get_prompt())
+            continue
         if roles[source[0]["from"]] != conv.roles[0]:
             # Skip the first one if it is not from human
             source = source[1:]
@@ -90,7 +98,10 @@ def preprocess(
         conv.messages = []
         for j, sentence in enumerate(source):
             role = roles[sentence["from"]]
-            assert role == conv.roles[j % 2], f"{i}"
+            if role != conv.roles[j % 2]:
+                rank0_print(f'WARNING: `{role}` == `{conv.roles[j % 2]}` mismatch.')
+                conv.messages = []
+                break
             conv.append_message(role, sentence["value"])
         conversations.append(conv.get_prompt())
 


### PR DESCRIPTION
Add preprocess exception handling for 3 type of errors:
- size of source is 0
- `chatgpt` or `bing` is not in roles.
- The order of `human` and `assistant` is incorrect.