### PR TITLE
Support model list reload feature

### DIFF
--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -50,8 +50,8 @@ def load_demo_side_by_side_named(models, url_params):
         model_right = model_left
 
     selector_updates = (
-        gr.Dropdown.update(model_left, visible=True),
-        gr.Dropdown.update(model_right, visible=True),
+        gr.Dropdown.update(choices=models, value=model_left, visible=True),
+        gr.Dropdown.update(choices=models, value=model_right, visible=True),
     )
 
     return (

--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -50,8 +50,8 @@ def load_demo_side_by_side_named(models, url_params):
         model_right = model_left
 
     selector_updates = (
-        gr.Dropdown.update(choices=models, value=model_left, visible=True),
-        gr.Dropdown.update(choices=models, value=model_right, visible=True),
+        gr.Dropdown.update(model_left, visible=True),
+        gr.Dropdown.update(model_right, visible=True),
     )
 
     return (

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -67,6 +67,30 @@ def get_model_list(controller_url):
     logger.info(f"Models: {models}")
     return models
 
+def load_demo_refresh_model_list(url_params):
+    models = get_model_list(controller_url)
+    selected_model = models[0] if len(models) > 0 else ""
+    if "model" in url_params:
+        model = url_params["model"]
+        if model in models:
+            selected_model = model
+
+    dropdown_update = gr.Dropdown.update(choices=models, value=selected_model, visible=True)
+
+    state = None
+    return (
+        state,
+        dropdown_update,
+        gr.Chatbot.update(visible=True),
+        gr.Textbox.update(visible=True),
+        gr.Button.update(visible=True),
+        gr.Row.update(visible=True),
+        gr.Accordion.update(visible=True),
+    )
+
+def load_demo_reload_model(url_params, request: gr.Request):
+    logger.info(f"load_demo_reload_model. ip: {request.client.host}. params: {url_params}")
+    return load_demo_refresh_model_list(url_params)
 
 def load_demo_single(models, url_params):
     dropdown_update = gr.Dropdown.update(visible=True)
@@ -573,6 +597,21 @@ def build_demo(models):
                 ],
                 _js=get_window_url_params_js,
             )
+        elif args.model_list_mode == "reload":
+            demo.load(
+                load_demo_reload_model,
+                [url_params],
+                [
+                    state,
+                    model_selector,
+                    chatbot,
+                    textbox,
+                    send_btn,
+                    button_row,
+                    parameter_row,
+                ],
+                _js=get_window_url_params_js,
+            )
         else:
             raise ValueError(f"Unknown model list mode: {args.model_list_mode}")
 
@@ -586,7 +625,7 @@ if __name__ == "__main__":
     parser.add_argument("--controller-url", type=str, default="http://localhost:21001")
     parser.add_argument("--concurrency-count", type=int, default=10)
     parser.add_argument(
-        "--model-list-mode", type=str, default="once", choices=["once", "reload"]
+        "--model-list-mode", type=str, default="reload", choices=["once", "reload"]
     )
     parser.add_argument("--share", action="store_true")
     parser.add_argument(

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -67,6 +67,7 @@ def get_model_list(controller_url):
     logger.info(f"Models: {models}")
     return models
 
+
 def load_demo_refresh_model_list(url_params):
     models = get_model_list(controller_url)
     selected_model = models[0] if len(models) > 0 else ""
@@ -88,9 +89,11 @@ def load_demo_refresh_model_list(url_params):
         gr.Accordion.update(visible=True),
     )
 
+
 def load_demo_reload_model(url_params, request: gr.Request):
     logger.info(f"load_demo_reload_model. ip: {request.client.host}. params: {url_params}")
     return load_demo_refresh_model_list(url_params)
+
 
 def load_demo_single(models, url_params):
     dropdown_update = gr.Dropdown.update(visible=True)
@@ -625,7 +628,8 @@ if __name__ == "__main__":
     parser.add_argument("--controller-url", type=str, default="http://localhost:21001")
     parser.add_argument("--concurrency-count", type=int, default=10)
     parser.add_argument(
-        "--model-list-mode", type=str, default="reload", choices=["once", "reload"]
+        "--model-list-mode", type=str, default="once", choices=["once", "reload"],
+        help="Whether to load the model list once or reload the model list every time."
     )
     parser.add_argument("--share", action="store_true")
     parser.add_argument(

--- a/fastchat/serve/gradio_web_server_multi.py
+++ b/fastchat/serve/gradio_web_server_multi.py
@@ -25,28 +25,12 @@ from fastchat.serve.gradio_web_server import (
     build_single_model_ui,
     get_model_list,
     load_demo_single,
-    load_demo_refresh_model_list,
 )
 from fastchat.serve.monitor.monitor import build_leaderboard_tab
 from fastchat.utils import build_logger, get_window_url_params_js
 
 
 logger = build_logger("gradio_web_server_multi", "gradio_web_server_multi.log")
-
-def load_demo_reload_mode(url_params, request: gr.Request):
-    logger.info(f"load_demo_reload_mode. ip: {request.client.host}. params: {url_params}")
-    selected = 0
-    if "arena" in url_params:
-        selected = 1
-    elif "compare" in url_params:
-        selected = 2
-
-    models = get_model_list(args.controller_url)
-    single_updates = load_demo_refresh_model_list(url_params)
-    side_by_side_anony_updates = load_demo_side_by_side_anony(models, url_params)
-    side_by_side_named_updates = load_demo_side_by_side_named(models, url_params)
-    return ((gr.Tabs.update(selected=selected),) + single_updates +
-            side_by_side_anony_updates + side_by_side_named_updates)
 
 
 def load_demo(url_params, request: gr.Request):
@@ -164,13 +148,6 @@ def build_demo(models, elo_results_file):
                 [tabs] + a_list + b_list + c_list,
                 _js=get_window_url_params_js,
             )
-        elif args.model_list_mode == "reload":
-            demo.load(
-                load_demo_reload_mode,
-                [url_params],
-                [tabs] + a_list + b_list + c_list,
-                _js=get_window_url_params_js,
-            )
         else:
             raise ValueError(f"Unknown model list mode: {args.model_list_mode}")
 
@@ -184,7 +161,7 @@ if __name__ == "__main__":
     parser.add_argument("--controller-url", type=str, default="http://localhost:21001")
     parser.add_argument("--concurrency-count", type=int, default=10)
     parser.add_argument(
-        "--model-list-mode", type=str, default="reload", choices=["once", "reload"]
+        "--model-list-mode", type=str, default="once", choices=["once"],
     )
     parser.add_argument("--share", action="store_true")
     parser.add_argument(


### PR DESCRIPTION
Address https://github.com/lm-sys/FastChat/issues/847

Test procedure:

1. Start controller, model worker1, model worker2 and web,  model list does show 2 models
2. Kill model worker2 and check dropdown list again and we will notice there's only 1 now.