### PR TITLE
Bug fixes - Serve model_worker in resulted in encoding errors in Windows

### DIFF
--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -61,7 +61,7 @@ def build_logger(logger_name, logger_filename):
         os.makedirs(LOGDIR, exist_ok=True)
         filename = os.path.join(LOGDIR, logger_filename)
         handler = logging.handlers.TimedRotatingFileHandler(
-            filename, when="D", utc=True
+            filename, when="D", utc=True, encoding='utf-8'
         )
         handler.setFormatter(formatter)
 


### PR DESCRIPTION
1. Environments:
* Windows 11
* Python 3.10.6
* Pytorch 2.0.0+cu118
* Gradio WebUI

2. Steps to produce:
* `python3 -m fastchat.serve.controller`
* `python3 -m fastchat.serve.model_worker --load-8bit --model-path .\vicuna_13b\`

3. Detailed logs:
```
2023-05-05 21:25:13 | ERROR | stderr | Traceback (most recent call last):
2023-05-05 21:25:13 | ERROR | stderr |   File "D:\Program Files\Python310\lib\logging\__init__.py", line 1103, in emit
2023-05-05 21:25:13 | ERROR | stderr |     stream.write(msg + self.terminator)
2023-05-05 21:25:13 | ERROR | stderr |   File "D:\Program Files\Python310\lib\encodings\cp1252.py", line 19, in encode
2023-05-05 21:25:13 | ERROR | stderr |     return codecs.charmap_encode(input,self.errors,encoding_table)[0]
2023-05-05 21:25:13 | ERROR | stderr | UnicodeEncodeError: 'charmap' codec can't encode characters in position 44-71: character maps to <undefined>
```

4. Proposed fixes:
* Modify function build_logger() to default using 'utf-8' encoder in fastchat/utils.py

5. Testing results:
* Check with casual prompts: OK
* Check with special characters (code) prompts: OK
* Check logs file output with correct encoding & newlines: OK