### PR TITLE
Add support of Phoenix, a multilingual instruction-following language model.

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -342,6 +342,7 @@ Assistant: Hi, I'm Buddy, your AI assistant. How can I help you today?""",
 
 # Phoenix default template
 register_conv_template(Conversation(
+    name="phoenix",
     system="A chat between a curious human and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the human's questions.\n\n",
     roles=("Human", "Assistant"),
     messages=(),

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -16,6 +16,7 @@ class SeparatorStyle(Enum):
     BAIZE = auto()
     DOLLY = auto()
     RWKV = auto()
+    PHOENIX = auto()
 
 
 @dataclasses.dataclass
@@ -105,6 +106,14 @@ class Conversation:
                     ret += "\n\n"
                 else:
                     ret += role + ":"
+            return ret
+        elif self.sep_style == SeparatorStyle.PHOENIX:
+            ret = self.system
+            for role, message in self.messages:
+                if message:
+                    ret += role + ": " + "<s>" + message + "</s>"
+                else:
+                    ret += role + ": " + "<s>"
             return ret
         else:
             raise ValueError(f"Invalid style: {self.sep_style}")
@@ -329,6 +338,16 @@ Assistant: Hi, I'm Buddy, your AI assistant. How can I help you today?""",
     offset=0,
     sep_style=SeparatorStyle.ADD_COLON_SINGLE,
     sep="\n",
+))
+
+# Phoenix default template
+register_conv_template(Conversation(
+    system="A chat between a curious human and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the human's questions.\n\n",
+    roles=("Human", "Assistant"),
+    messages=(),
+    offset=0,
+    sep_style=SeparatorStyle.PHOENIX,
+    sep="</s>",
 ))
 
 # ChatGPT default template

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -340,6 +340,23 @@ class OpenBuddyAdapter(BaseAdapter):
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("openbuddy")
+    
+    
+ class PhoenixAdapter(BaseAdapter):
+    """The model adapter for FreedomIntelligence/phoenix-inst-chat-7b"""
+
+    def match(self, model_path: str):
+        return "phoenix" in model_path
+
+    def load_model(self, model_path: str, from_pretrained_kwargs: dict):
+        tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=True)
+        model = AutoModelForCausalLM.from_pretrained(
+            model_path, low_cpu_mem_usage=True, **from_pretrained_kwargs,
+        )
+        return model, tokenizer
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("phoenix")
 
 
 class ChatGPTAdapter(BaseAdapter):
@@ -381,6 +398,7 @@ register_model_adapter(StableLMAdapter)
 register_model_adapter(BaizeAdapter)
 register_model_adapter(RwkvAdapter)
 register_model_adapter(OpenBuddyAdapter)
+register_model_adapter(PhoenixAdapter)
 register_model_adapter(ChatGPTAdapter)
 register_model_adapter(ClaudeAdapter)
 

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -342,7 +342,7 @@ class OpenBuddyAdapter(BaseAdapter):
         return get_conv_template("openbuddy")
     
     
- class PhoenixAdapter(BaseAdapter):
+class PhoenixAdapter(BaseAdapter):
     """The model adapter for FreedomIntelligence/phoenix-inst-chat-7b"""
 
     def match(self, model_path: str):

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -33,3 +33,4 @@ register_model_info(["llama-13b"], "LLaMA", "https://arxiv.org/abs/2302.13971", 
 register_model_info(["dolly-v2-12b"], "Dolly", "https://www.databricks.com/blog/2023/04/12/dolly-first-open-commercially-viable-instruction-tuned-llm", "an instruction-tuned open large language model by Databricks")
 register_model_info(["stablelm-tuned-alpha-7b"], "StableLM", "https://github.com/stability-AI/stableLM", "Stability AI language models")
 register_model_info(["fastchat-t5-3b"], "FastChat-T5", "https://huggingface.co/lmsys/fastchat-t5-3b-v1.0", "a chat assistant fine-tuned from FLAN-T5 by LMSYS")
+register_model_info(["phoenix-inst-chat-7b"], "Phoenix-7b", "https://huggingface.co/FreedomIntelligence/phoenix-inst-chat-7b", "a multilingual chat assistant fine-tuned from Bloomz to democratize ChatGPT across languages by CUHK(SZ)")


### PR DESCRIPTION
[Phoenix](https://github.com/FreedomIntelligence/LLMZoo/tree/main) is a multilingual instruction-following language model which aims to democratize ChatGPT across languages.

It has achieved competitive performance with ChatGLM and Wenxin on Chinese following the evaluation protocol of Vicuna.

We here add support of Phoenix for the cli inference and potentially for the arena. Since Phoenix is tuned from Bloom, we believe the integration is rather straightforward.

You guys could try it via:

```bash
python3 -m fastchat.serve.cli --model-path FreedomIntelligence/phoenix-inst-chat-7b
```

We have verified the integration on an Nvidia A100-40G.