### PR TITLE
Fix crash when using cpu offloading flag

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1,5 +1,6 @@
 """Model adapter registration."""
 
+import sys
 from typing import List, Optional
 import warnings
 from functools import cache


### PR DESCRIPTION
This fixes as the title says a crash when using --cpu-offloading.
The error was:  `NameError: name 'sys' is not defined`
