### PR TITLE
Rename inspect.py to inspect_data.py

### DIFF
--- a/fastchat/data/inspect_data.py
+++ b/fastchat/data/inspect_data.py
@@ -1,6 +1,6 @@
 """
 Usage:
-python3 -m fastchat.data.inspect --in sharegpt_20230322_clean_lang_split.json
+python3 -m fastchat.data.inspect_data --in sharegpt_20230322_clean_lang_split.json
 """
 import argparse
 import json


### PR DESCRIPTION
The presence of inspect.py seems to be causing an issue with numpy, where it conflicts with the Python library `inspect`. The problem's gone after renaming.

```
❯ python3 split_long_conversation.py --in sharegpt_clean_en.json --out sharegpt_split_en.json --model-name-or-path oobabooga/llama-tokenizer
Traceback (most recent call last):
  File "/home/remote/FastChat/fastchat/data/split_long_conversation.py", line 14, in <module>
    import transformers
  File "/home/remote/.asdf/installs/python/3.11.0/lib/python3.11/site-packages/transformers/__init__.py", line 26, in <module>
    from . import dependency_versions_check
  File "/home/remote/.asdf/installs/python/3.11.0/lib/python3.11/site-packages/transformers/dependency_versions_check.py", line 17, in <module>
    from .utils.versions import require_version, require_version_core
  File "/home/remote/.asdf/installs/python/3.11.0/lib/python3.11/site-packages/transformers/utils/__init__.py", line 30, in <module>
    from .generic import (
  File "/home/remote/.asdf/installs/python/3.11.0/lib/python3.11/site-packages/transformers/utils/generic.py", line 27, in <module>
    import numpy as np
  File "/home/remote/.asdf/installs/python/3.11.0/lib/python3.11/site-packages/numpy/__init__.py", line 153, in <module>
    from . import ma
  File "/home/remote/.asdf/installs/python/3.11.0/lib/python3.11/site-packages/numpy/ma/__init__.py", line 42, in <module>
    from . import core
  File "/home/remote/.asdf/installs/python/3.11.0/lib/python3.11/site-packages/numpy/ma/core.py", line 7694, in <module>
    inner.__doc__ = doc_note(np.inner.__doc__,
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/remote/.asdf/installs/python/3.11.0/lib/python3.11/site-packages/numpy/ma/core.py", line 124, in doc_note
    notesplit = re.split(r'\n\s*?Notes\n\s*?-----', inspect.cleandoc(initialdoc))
                                                    ^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'cleandoc'
```

(Same results when calling with `python3 -m fastchat.data.split_long_conversation`)