### PR TITLE
Fix Chinese garbled code problem by filtering special characters \ufffd.

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -205,7 +205,7 @@ async def chat_completion_stream(model_name: str, gen_params: Dict[str, Any], n:
                 # TODO: begins with a single delta containing the role and a null finish reason
                 async for raw_chunk in post_response.aiter_raw():
                     for chunk in raw_chunk.split(delimiter):
-                        if not chunk:
+                        if not chunk or chunk.find(b'\ufffd')>0:
                             continue
                         data = json.loads(chunk.decode())
                         if data["error_code"] == 0:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When chatting in Chinese, the content returned by Vicuna has transitional special characters, causing the displayed content to be garbled. Add the filter special character \ufffd to fix the garbled situation in Chinese chat.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [✅ ] I've run `format.sh` to lint the changes in this PR.
- [✅ ] I've included any doc changes needed.
- [✅ ] I've made sure the relevant tests are passing (if applicable).
