### PR TITLE
Add fastest gptq 4bit inference support

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ In addition to that, you can add `--cpu-offloading` to commands above to offload
 
 - [MLC LLM](https://mlc.ai/mlc-llm/), backed by [TVM Unity](https://github.com/apache/tvm/tree/unity) compiler, deploys Vicuna natively on phones, consumer-class GPUs and web browsers via Vulkan, Metal, CUDA and WebGPU.
 
+#### GPTQ 4bit Support
+FastChat provides fastest GPTQ 4bit inference with [GPTQ-for-LLaMa](https://github.com/qwopqwop200/GPTQ-for-LLaMa) . See [docs/gptq.md](/docs/gptq.md)
+
 ## Serving with Web GUI
 
 <a href="https://chat.lmsys.org"><img src="assets/screenshot_gui.png" width="70%"></a>

--- a/docs/gptq.md
+++ b/docs/gptq.md
@@ -1,13 +1,11 @@
-# Fastest GPTQ 4bit Support
+# GPTQ 4bit Inference
 
-Support GPTQ 4bit with [GPTQ-for-LLaMa](https://github.com/qwopqwop200/GPTQ-for-LLaMa).
+Support GPTQ 4bit inference with [GPTQ-for-LLaMa](https://github.com/qwopqwop200/GPTQ-for-LLaMa).
 
 1. Window user: use the `old-cuda` branch.
 2. Linux user: recommend the `fastest-inference-4bit` branch.
 
 ## Install
-
-Follow the [GPTQ-for-LLaMa](https://github.com/qwopqwop200/GPTQ-for-LLaMa) doc to build compressed model.
 
 Setup environment:
 ```bash
@@ -16,18 +14,37 @@ git clone https://github.com/qwopqwop200/GPTQ-for-LLaMa.git repositories/GPTQ-fo
 cd repositories/GPTQ-for-LLaMa
 # Window's user should use the `old-cuda` branch
 git switch fastest-inference-4bit
-
-# install `quant-cuda` package in FastChat's virtualenv
-python setup_cuda.py install
+# Install `quant-cuda` package in FastChat's virtualenv
+python3 setup_cuda.py install
 ```
 
 Start model worker:
 ```bash
-python -m fastchat.serve.model_worker \
-    --model-path ${your_model_path} \
-    --load-gptq ${your_gptq_checkpoint} \
-    --wbits 4 \
-    --groupsize 128
+# Download quantized model from huggingface
+# Make sure you have git-lfs installed (https://git-lfs.com)
+git lfs install
+git clone https://huggingface.co/TheBloke/vicuna-7B-1.1-GPTQ-4bit-128g models/vicuna-7B-1.1-GPTQ-4bit-128g
+
+python3 -m fastchat.serve.model_worker \
+    --model-path models/vicuna-7B-1.1-GPTQ-4bit-128g \
+    --gptq-wbits 4 \
+    --gptq-groupsize 128
+
+# You can specify which quantized model to use
+python3 -m fastchat.serve.model_worker \
+    --model-path models/vicuna-7B-1.1-GPTQ-4bit-128g \
+    --gptq-ckpt models/vicuna-7B-1.1-GPTQ-4bit-128g/vicuna-7B-1.1-GPTQ-4bit-128g.safetensors \
+    --gptq-wbits 4 \
+    --gptq-groupsize 128 \
+    --gptq-act-order
+```
+
+Chat with the CLI:
+```bash
+python3 -m fastchat.serve.cli \
+    --model-path models/vicuna-7B-1.1-GPTQ-4bit-128g \
+    --gptq-wbits 4 \
+    --gptq-groupsize 128
 ```
 
 ## Benchmark

--- a/docs/gptq.md
+++ b/docs/gptq.md
@@ -1,0 +1,41 @@
+# Fastest GPTQ 4bit Support
+
+Support GPTQ 4bit with [GPTQ-for-LLaMa](https://github.com/qwopqwop200/GPTQ-for-LLaMa).
+
+1. Window user: use the `old-cuda` branch.
+2. Linux user: recommend the `fastest-inference-4bit` branch.
+
+## Install
+
+Follow the [GPTQ-for-LLaMa](https://github.com/qwopqwop200/GPTQ-for-LLaMa) doc to build compressed model.
+
+Setup environment:
+```bash
+# cd /path/to/FastChat
+git clone https://github.com/qwopqwop200/GPTQ-for-LLaMa.git repositories/GPTQ-for-LLaMa
+cd repositories/GPTQ-for-LLaMa
+# Window's user should use the `old-cuda` branch
+git switch fastest-inference-4bit
+
+# install `quant-cuda` package in FastChat's virtualenv
+python setup_cuda.py install
+```
+
+Start model worker:
+```bash
+python -m fastchat.serve.model_worker \
+    --model-path ${your_model_path} \
+    --load-gptq ${your_gptq_checkpoint} \
+    --wbits 4 \
+    --groupsize 128
+```
+
+## Benchmark
+
+| LLaMA-13B | branch                 | Bits | group-size | memory(MiB) | PPL(c4) | Median(s/token) | act-order | speed up |
+| --------- | ---------------------- | ---- | ---------- | ----------- | ------- | --------------- | --------- | -------- |
+| FP16      | fastest-inference-4bit | 16   | -          | 26634       | 6.96    | 0.0383          | -         | 1x       |
+| GPTQ      | triton                 | 4    | 128        | 8590        | 6.97    | 0.0551          | -         | 0.69x    |
+| GPTQ      | fastest-inference-4bit | 4    | 128        | 8699        | 6.97    | 0.0429          | true      | 0.89x    |
+| GPTQ      | fastest-inference-4bit | 4    | 128        | 8699        | 7.03    | 0.0287          | false     | 1.33x    |
+| GPTQ      | fastest-inference-4bit | 4    | -1         | 8448        | 7.12    | 0.0284          | false     | 1.44x    |

--- a/fastchat/model/compression.py
+++ b/fastchat/model/compression.py
@@ -3,14 +3,14 @@ import gc
 import glob
 import os
 
+import torch
+import torch.nn as nn
 from accelerate import init_empty_weights
 from accelerate.utils import set_module_tensor_to_device
-import torch
 from torch import Tensor
-import torch.nn as nn
 from torch.nn import functional as F
 from tqdm import tqdm
-from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
 
 @dataclasses.dataclass

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -5,6 +5,8 @@ import sys
 from typing import List, Optional
 import warnings
 
+from fastchat.modules.gptq import GptqConfig, load_gptq_quantized
+
 if sys.version_info >= (3, 9):
     from functools import cache
 else:
@@ -99,6 +101,7 @@ def load_model(
     max_gpu_memory: Optional[str] = None,
     load_8bit: bool = False,
     cpu_offloading: bool = False,
+    gptq_config: Optional[GptqConfig] = None,
     debug: bool = False,
 ):
     """Load a model from Hugging Face."""
@@ -152,6 +155,12 @@ def load_model(
             return load_compress_model(
                 model_path=model_path, device=device, torch_dtype=kwargs["torch_dtype"]
             )
+    elif gptq_config and gptq_config.wbits < 16:
+        return load_gptq_quantized(
+            model_path,
+            gptq_config,
+            device=device,
+        )
 
     # Load model
     adapter = get_model_adapter(model_path)
@@ -204,6 +213,30 @@ def add_model_args(parser):
         "--cpu-offloading",
         action="store_true",
         help="Only when using 8-bit quantization: Offload excess weights to the CPU that don't fit on the GPU",
+    )
+    parser.add_argument(
+        "--gptq-ckpt",
+        type=str,
+        default=None,
+        help="Load quantized model. The path to the local GPTQ checkpoint.",
+    )
+    parser.add_argument(
+        "--gptq-wbits",
+        type=int,
+        default=16,
+        choices=[2, 3, 4, 8, 16],
+        help="#bits to use for quantization",
+    )
+    parser.add_argument(
+        "--gptq-groupsize",
+        type=int,
+        default=-1,
+        help="Groupsize to use for quantization; default uses full row.",
+    )
+    parser.add_argument(
+        "--gptq-act-order",
+        action="store_true",
+        help="Whether to apply the activation order GPTQ heuristic",
     )
 
 

--- a/fastchat/modules/gptq.py
+++ b/fastchat/modules/gptq.py
@@ -1,0 +1,65 @@
+import os
+import sys
+from dataclasses import dataclass, field
+from os.path import isdir, isfile
+from pathlib import Path
+
+from transformers import AutoTokenizer
+
+script_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+module_path = os.path.join(script_path, "../repositories/GPTQ-for-LLaMa")
+
+try:
+    sys.path.insert(0, module_path)
+    from llama import load_quant
+except ImportError:
+    print("Error: Failed to load GPTQ-for-LLaMa")
+    print("See https://github.com/lm-sys/FastChat/blob/main/docs/gptq.md")
+    sys.exit(-1)
+
+
+@dataclass
+class GptqConfig:
+    ckpt: str = field(
+        default=None,
+        metadata={
+            "help": "Load quantized model. The path to the local GPTQ checkpoint."
+        },
+    )
+    wbits: int = field(default=16, metadata={"help": "#bits to use for quantization"})
+    groupsize: int = field(
+        default=-1,
+        metadata={"help": "Groupsize to use for quantization; default uses full row."},
+    )
+    act_order: bool = field(
+        default=True,
+        metadata={"help": "Whether to apply the activation order GPTQ heuristic"},
+    )
+
+
+def load_gptq_quantized(model_name, gptq_config: GptqConfig, device):
+    print("Loading GPTQ quantized model...")
+    tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=False)
+    model = load_quant(
+        model_name,
+        find_gptq_ckpt(gptq_config),
+        gptq_config.wbits,
+        gptq_config.groupsize,
+        act_order=gptq_config.act_order,
+    )
+    model.to(device)
+
+    return model, tokenizer
+
+
+def find_gptq_ckpt(gptq_config: GptqConfig):
+    if Path(gptq_config.ckpt).is_file():
+        return gptq_config.ckpt
+
+    for ext in ["*.pt", "*.safetensors"]:
+        matched_result = sorted(Path(gptq_config.ckpt).glob(ext))
+        if len(matched_result) > 0:
+            return str(matched_result[-1])
+
+    print("Error: gptq checkpoint not found")
+    sys.exit(1)

--- a/fastchat/modules/gptq.py
+++ b/fastchat/modules/gptq.py
@@ -40,13 +40,23 @@ class GptqConfig:
 def load_gptq_quantized(model_name, gptq_config: GptqConfig, device):
     print("Loading GPTQ quantized model...")
     tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=False)
-    model = load_quant(
-        model_name,
-        find_gptq_ckpt(gptq_config),
-        gptq_config.wbits,
-        gptq_config.groupsize,
-        act_order=gptq_config.act_order,
-    )
+    # only `fastest-inference-4bit` branch cares about `act_order`
+    if gptq_config.act_order:
+        model = load_quant(
+            model_name,
+            find_gptq_ckpt(gptq_config),
+            gptq_config.wbits,
+            gptq_config.groupsize,
+            act_order=gptq_config.act_order,
+        )
+    else:
+        # other branches
+        model = load_quant(
+            model_name,
+            find_gptq_ckpt(gptq_config),
+            gptq_config.wbits,
+            gptq_config.groupsize,
+        )
     model.to(device)
 
     return model, tokenizer

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -15,11 +15,12 @@ from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.history import InMemoryHistory
 from rich.console import Console
-from rich.markdown import Markdown
 from rich.live import Live
+from rich.markdown import Markdown
 
 from fastchat.model.model_adapter import add_model_args
-from fastchat.serve.inference import chat_loop, ChatIO
+from fastchat.modules.gptq import GptqConfig
+from fastchat.serve.inference import ChatIO, chat_loop
 
 
 class SimpleChatIO(ChatIO):
@@ -169,6 +170,12 @@ def main(args):
             args.repetition_penalty,
             args.max_new_tokens,
             chatio,
+            GptqConfig(
+                ckpt=args.gptq_ckpt or args.model_path,
+                wbits=args.gptq_wbits,
+                groupsize=args.gptq_groupsize,
+                act_order=args.gptq_act_order,
+            ),
             args.debug,
         )
     except KeyboardInterrupt:

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -29,6 +29,7 @@ from transformers.generation.logits_process import (
 from fastchat.conversation import get_conv_template, SeparatorStyle
 from fastchat.model.model_adapter import load_model, get_conversation_template
 from fastchat.model.chatglm_model import chatglm_generate_stream
+from fastchat.modules.gptq import GptqConfig
 
 
 def prepare_logits_processor(
@@ -256,11 +257,19 @@ def chat_loop(
     repetition_penalty: float,
     max_new_tokens: int,
     chatio: ChatIO,
+    gptq_config: GptqConfig,
     debug: bool,
 ):
     # Model
     model, tokenizer = load_model(
-        model_path, device, num_gpus, max_gpu_memory, load_8bit, cpu_offloading, debug
+        model_path,
+        device,
+        num_gpus,
+        max_gpu_memory,
+        load_8bit,
+        cpu_offloading,
+        gptq_config,
+        debug,
     )
     is_chatglm = "chatglm" in str(type(model)).lower()
     is_fastchat_t5 = "t5" in str(type(model)).lower()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add fastest GPTQ 4bit inference support based on [GPTQ-for-LLaMa/tree/fastest-inference-4bit](https://github.com/qwopqwop200/GPTQ-for-LLaMa/tree/fastest-inference-4bit):
1. **1.44x** speedup compared to FP16 version (test on single A100), and detailed benchmarks are provided
1. Added minimal changes to support GPTQ. Tested with `triton` and `fastest-inference-4bit` branch, also should work with `old-cuda` branch (not test)
2. Support modules follow the [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui) style
3. Updated relevant doc

For a benchmark. [see](https://github.com/qwopqwop200/GPTQ-for-LLaMa/issues/227):
| LLaMA-13B | branch                 | Bits | group-size | memory(MiB) | PPL(c4) | Median(s/token) | act-order | speed up |
| --------- | ---------------------- | ---- | ---------- | ----------- | ------- | --------------- | --------- | -------- |
| FP16      | fastest-inference-4bit | 16   | -          | 26634       | 6.96    | 0.0383          | -         | 1x       |
| GPTQ      | triton                 | 4    | 128        | 8590        | 6.97    | 0.0551          | -         | 0.69x    |
| GPTQ      | fastest-inference-4bit | 4    | 128        | 8699        | 6.97    | 0.0429          | true      | 0.89x    |
| GPTQ      | fastest-inference-4bit | 4    | 128        | 8699        | 7.03    | 0.0287          | false     | 1.33x    |
| GPTQ      | fastest-inference-4bit | 4    | -1         | 8448        | 7.12    | 0.0284          | false     | 1.44x    |

## Related issue number (if applicable)

Closes #452, #455, #487

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
