### PR TITLE
fix: import lru_cache for python below 3.9, close #1056

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -3,8 +3,10 @@
 import sys
 from typing import List, Optional
 import warnings
-from functools import cache
-
+if sys.version_info >= (3, 9):
+    from functools import cache
+else:
+    from functools import lru_cache as cache
 import torch
 from transformers import (
     AutoConfig,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

cache is added after python 3.9, so it's required for python<=3.8

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

Closes #1056

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
