### PR TITLE
Bard support

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -431,6 +431,21 @@ register_conv_template(
     )
 )
 
+# Bard default template
+# Reference: https://github.com/google/generative-ai-python/blob/9c99bcb474a991a97a2e7d62fcdb52db7ce40729/google/generativeai/discuss.py#L150
+#            https://github.com/google/generative-ai-python/blob/9c99bcb474a991a97a2e7d62fcdb52db7ce40729/google/generativeai/discuss.py#L40
+register_conv_template(
+    Conversation(
+        name="bard",
+        system="",
+        roles=("0", "1"),
+        messages=(),
+        offset=0,
+        sep_style=None,
+        sep=None,
+    )
+)
+
 if __name__ == "__main__":
     conv = get_conv_template("vicuna_v1.1")
     conv.append_message(conv.roles[0], "Hello!")

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -453,6 +453,19 @@ class ClaudeAdapter(BaseAdapter):
         return get_conv_template("claude")
 
 
+class BardAdapter(BaseAdapter):
+    """The model adapter for Bard."""
+
+    def match(self, model_path: str):
+        return model_path == "bard"
+
+    def load_model(self, model_path: str, from_pretrained_kwargs: dict):
+        raise NotImplementedError()
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("bard")
+
+
 # Note: the registration order matters.
 # The one registered earlier has a higher matching priority.
 register_model_adapter(VicunaAdapter)
@@ -466,6 +479,7 @@ register_model_adapter(BaizeAdapter)
 register_model_adapter(RwkvAdapter)
 register_model_adapter(OpenBuddyAdapter)
 register_model_adapter(PhoenixAdapter)
+register_model_adapter(BardAdapter)
 register_model_adapter(ChatGPTAdapter)
 register_model_adapter(ClaudeAdapter)
 register_model_adapter(MPTAdapter)

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -37,6 +37,12 @@ register_model_info(
     "Claude by Anthropic",
 )
 register_model_info(
+    ["bard"],
+    "Bard",
+    "https://bard.google.com/",
+    "Bard by Google",
+)
+register_model_info(
     ["vicuna-13b"],
     "Vicuna",
     "https://lmsys.org/blog/2023-03-30-vicuna/",

--- a/fastchat/serve/bard_worker.py
+++ b/fastchat/serve/bard_worker.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 import httpx
 from pydantic import BaseModel, Field
 from typing import List, Optional, Union
+import uvicorn
 
 
 class ConversationState(BaseModel):
@@ -135,7 +136,8 @@ chatbot = None
 @app.on_event("startup")
 async def startup_event():
     global chatbot
-    chatbot = Chatbot("<__Secure-1PSID cookie of bard.google.com>")
+    cookie = json.load(open("bard_cookie.json"))
+    chatbot = Chatbot(cookie["__Secure-1PSID"])
     chatbot.SNlM0e = await chatbot._get_snlm0e()
 
 
@@ -146,12 +148,12 @@ async def chat(message: Message):
 
 
 if __name__ == "__main__":
-    import uvicorn
-
     parser = argparse.ArgumentParser("Google Bard worker")
     parser.add_argument("--host", type=str, default="localhost")
     parser.add_argument("--port", type=int, default=18900)
+    parser.add_argument("--reload", action="store_true")
     args = parser.parse_args()
     uvicorn.run(
-        "bard_worker:app", host=args.host, port=args.port, log_level="info", reload=True
+        "bard_worker:app", host=args.host, port=args.port, log_level="info",
+        reload=args.reload
     )

--- a/fastchat/serve/bard_worker.py
+++ b/fastchat/serve/bard_worker.py
@@ -1,0 +1,163 @@
+"""
+Adapted from https://github.com/acheong08/Bard.
+"""
+import argparse
+import json
+import random
+import re
+import string
+
+import requests
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+
+class ConversationState(BaseModel):
+    conversation_id: str = ""
+    response_id: str = ""
+    choice_id: str = ""
+    req_id: int = Field(default_factory=lambda: int("".join(random.choices(string.digits, k=4))))
+
+
+class Message(BaseModel):
+    content: str
+    state: ConversationState
+
+
+class Response(BaseModel):
+    content: str
+    factualityQueries: Optional[List[dict]]
+    textQuery: Optional[str]
+    choices: List[dict]
+    state: ConversationState
+
+
+class Chatbot:
+    """
+    A class to interact with Google Bard.
+    Parameters
+        session_id: str
+            The __Secure-1PSID cookie.
+    """
+
+    __slots__ = [
+        "headers",
+        "_reqid",
+        "SNlM0e",
+        "conversation_id",
+        "response_id",
+        "choice_id",
+        "session",
+    ]
+
+    def __init__(self, session_id):
+        headers = {
+            "Host": "bard.google.com",
+            "X-Same-Domain": "1",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36",
+            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            "Origin": "https://bard.google.com",
+            "Referer": "https://bard.google.com/",
+        }
+        self.session = requests.Session()
+        self.session.headers = headers
+        self.session.cookies.set("__Secure-1PSID", session_id)
+        self.SNlM0e = self.__get_snlm0e()
+
+    def __get_snlm0e(self):
+        resp = self.session.get(url="https://bard.google.com/", timeout=10)
+        # Find "SNlM0e":"<ID>"
+        if resp.status_code != 200:
+            raise Exception("Could not get Google Bard")
+        SNlM0e = re.search(r"SNlM0e\":\"(.*?)\"", resp.text).group(1)
+        return SNlM0e
+
+    def ask(self, message: Message) -> Response:
+        """
+        Send a message to Google Bard and return the response.
+        :param message: The message to send to Google Bard.
+        :return: A dict containing the response from Google Bard.
+        """
+        # url params
+        params = {
+            #"bl": "boq_assistant-bard-web-server_20230315.04_p2",
+            # This is a newer API version
+            "bl": "boq_assistant-bard-web-server_20230507.20_p2",
+            "_reqid": str(message.state.req_id),
+            "rt": "c",
+        }
+
+        # message arr -> data["f.req"]. Message is double json stringified
+        message_struct = [
+            [message.content],
+            None,
+            [
+                message.state.conversation_id,
+                message.state.response_id,
+                message.state.choice_id
+            ],
+        ]
+        data = {
+            "f.req": json.dumps([None, json.dumps(message_struct)]),
+            "at": self.SNlM0e,
+        }
+
+        # do the request!
+        resp = self.session.post(
+            "https://bard.google.com/_/BardChatUi/data/assistant.lamda.BardFrontendService/StreamGenerate",
+            params=params,
+            data=data,
+            timeout=120,
+        )
+
+        chat_data = json.loads(resp.content.splitlines()[3])[0][2]
+        if not chat_data:
+            return Response(
+                content=f"Google Bard encountered an error: {resp.content}.",
+                factualityQueries=[],
+                textQuery="",
+                choices=[],
+                state=message.state,
+            )
+        json_chat_data = json.loads(chat_data)
+        conversation = ConversationState(
+            conversation_id=json_chat_data[1][0],
+            response_id=json_chat_data[1][1],
+            choice_id=json_chat_data[4][0][0],
+            req_id=message.state.req_id + 100000,
+        )
+        return Response(
+            content=json_chat_data[0][0],
+            factualityQueries=json_chat_data[3],
+            textQuery=json_chat_data[2][0] if json_chat_data[2] is not None else "",
+            choices=[{"id": i[0], "content": i[1]} for i in json_chat_data[4]],
+            state=conversation,
+        )
+
+
+app = FastAPI()
+chatbot = None
+
+
+@app.on_event("startup")
+async def startup_event():
+    global chatbot
+    chatbot = Chatbot("<__Secure-1PSID cookie of bard.google.com>")
+
+
+@app.post("/chat", response_model=Response)
+async def chat(message: Message):
+    response = chatbot.ask(message)
+    return response
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    parser = argparse.ArgumentParser("Google Bard worker")
+    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=18900)
+    args = parser.parse_args()
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info", reload=True)

--- a/fastchat/serve/bard_worker.py
+++ b/fastchat/serve/bard_worker.py
@@ -109,7 +109,7 @@ class Chatbot:
             "https://bard.google.com/_/BardChatUi/data/assistant.lamda.BardFrontendService/StreamGenerate",
             params=params,
             data=data,
-            timeout=120,
+            timeout=60,
         )
 
         chat_data = json.loads(resp.content.splitlines()[3])[0][2]

--- a/fastchat/serve/gradio_block_arena_anony.py
+++ b/fastchat/serve/gradio_block_arena_anony.py
@@ -161,6 +161,7 @@ DEFAULT_WEIGHTS = {
     "gpt-4": 1.5,
     "gpt-3.5-turbo": 1.5,
     "claude-v1": 1.5,
+    "bard": 1.5,
     "vicuna-13b": 1.5,
     "koala-13b": 1.5,
     "RWKV-4-Raven-14B": 1.2,

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -277,10 +277,14 @@ def bard_api_stream_iter(state):
     content = resp_json["content"]
     # The Bard Web API does not support streaming yet. Here we have to simulate
     # the streaming behavior by adding some time.sleep().
-    for char in content:
-        time.sleep(max(random.gauss(0.05, 0.01), 0))
+    pos = 1
+    while pos < len(content):
+        # This is a fancy way to simulate token generation latency combined
+        # with a Poisson process.
+        pos += random.randint(1, 5)
+        time.sleep(random.expovariate(20))
         data = {
-            "text": char,
+            "text": content[:pos],
             "error_code": 0,
         }
         yield data

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -704,7 +704,6 @@ if __name__ == "__main__":
         action="store_true",
         help="Add Google's Bard model",
     )
-
     args = parser.parse_args()
     logger.info(f"args: {args}")
 

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -277,7 +277,7 @@ def bard_api_stream_iter(state):
     content = resp_json["content"]
     # The Bard Web API does not support streaming yet. Here we have to simulate
     # the streaming behavior by adding some time.sleep().
-    pos = 1
+    pos = 0
     while pos < len(content):
         # This is a fancy way to simulate token generation latency combined
         # with a Poisson process.

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -263,6 +263,14 @@ def bard_api_stream_iter(state):
     # TODO: we will use the official PaLM 2 API sooner or later,
     # and we will update this function accordingly. So here we just hard code the
     # Bard worker address. It is going to be deprecated anyway.
+
+    # Make requests
+    gen_params = {
+        "model": "bard",
+        "prompt": state.messages,
+    }
+    logger.info(f"==== request ====\n{gen_params}")
+
     response = requests.post(
         "http://localhost:18900/chat",
         json={

--- a/fastchat/serve/gradio_web_server_multi.py
+++ b/fastchat/serve/gradio_web_server_multi.py
@@ -45,10 +45,13 @@ def load_demo(url_params, request: gr.Request):
     single_updates = load_demo_single(models, url_params)
 
     models_anony = models
+    # Only enable these models in anony battles.
     if args.add_chatgpt:
         models_anony = ["gpt-4", "gpt-3.5-turbo"] + models_anony
     if args.add_claude:
         models_anony = ["claude-v1"] + models_anony
+    if args.add_bard:
+        models_anony = ["bard"] + models_anony
 
     side_by_side_anony_updates = load_demo_side_by_side_anony(models_anony, url_params)
     side_by_side_named_updates = load_demo_side_by_side_named(models, url_params)
@@ -176,6 +179,11 @@ if __name__ == "__main__":
         "--add-claude",
         action="store_true",
         help="Add Anthropic's Claude models (claude-v1)",
+    )
+    parser.add_argument(
+        "--add-bard",
+        action="store_true",
+        help="Add Google's Bard model",
     )
     parser.add_argument("--elo-results-file", type=str)
     args = parser.parse_args()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Include Google Bard in the single Chatbot demo (later in the Arena).

Bard (web version) does not support streaming, but I use `time.sleep`+ proper distributions to make it really feels like streaming.

Also I figured out how to serve multiple conversations concurrently in this PR. So this PR is ready to use.

To use Bard

1. Replace `<__Secure-1PSID cookie of bard.google.com>` in `bard_worker.py` with your cookies of `bard.google.com`
2. python `bard_worker.py`
3. start the controller (gradio_web_server need it)
4. python3 -m fastchat.serve.gradio_web_server --add-bard

NOTE: we use a separated worker to make sure it is easy to update the cookies once expired.

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
