### PR TITLE
Add support for h2oGPT-gm-7B

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The following models are tested:
 - [StabilityAI/stablelm-tuned-alpha-7b](https://huggingface.co/stabilityai/stablelm-tuned-alpha-7b)
 - [THUDM/chatglm-6b](https://huggingface.co/THUDM/chatglm-6b)
 - [Neutralzz/BiLLa-7B-SFT](https://huggingface.co/Neutralzz/BiLLa-7B-SFT)
+- [h2ogpt-gm-oasst1-en-2048-open-llama-7b-preview-300bt-v2](https://huggingface.co/h2oai/h2ogpt-gm-oasst1-en-2048-open-llama-7b-preview-300bt-v2)
 
 Help us [add more](https://github.com/lm-sys/FastChat/blob/main/docs/arena.md#how-to-add-a-new-model).
 

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -4,7 +4,7 @@ Conversation prompt templates.
 
 import dataclasses
 from enum import auto, Enum
-from typing import List, Tuple, Any, Dict
+from typing import List, Any, Dict
 
 
 class SeparatorStyle(Enum):

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -19,7 +19,6 @@ class SeparatorStyle(Enum):
     PHOENIX = auto()
     NEW_LINE = auto()
     BILLA = auto()
-    H2OGPT = auto()
 
 
 @dataclasses.dataclass

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -19,6 +19,7 @@ class SeparatorStyle(Enum):
     PHOENIX = auto()
     NEW_LINE = auto()
     BILLA = auto()
+    H2OGPT = auto()
 
 
 @dataclasses.dataclass
@@ -131,7 +132,15 @@ class Conversation:
                 if message:
                     ret += role + ": " + message + self.sep
                 else:
-                    ret += role + ": " # must be end with a space
+                    ret += role + ": "  # must be end with a space
+            return ret
+        elif self.sep_style == SeparatorStyle.H2OGPT:
+            ret = self.system + self.sep
+            for role, message in self.messages:
+                if message:
+                    ret += role + message + self.sep
+                else:
+                    ret += role
             return ret
         else:
             raise ValueError(f"Invalid style: {self.sep_style}")
@@ -466,6 +475,20 @@ register_conv_template(
         sep_style=SeparatorStyle.BILLA,
         sep="\n",
         stop_str="Human:",
+    )
+)
+
+# BiLLa default template
+register_conv_template(
+    Conversation(
+        name="h2ogpt",
+        system="",
+        roles=("<|prompt|>", "<|answer|>"),
+        messages=(),
+        offset=0,
+        sep_style=SeparatorStyle.BILLA,
+        sep="</s>",
+        stop_str="</s>",
     )
 )
 

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -469,7 +469,7 @@ register_conv_template(
     )
 )
 
-# BiLLa default template
+# h2oGPT default template
 register_conv_template(
     Conversation(
         name="h2ogpt",

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -134,14 +134,6 @@ class Conversation:
                 else:
                     ret += role + ": "  # must be end with a space
             return ret
-        elif self.sep_style == SeparatorStyle.H2OGPT:
-            ret = self.system + self.sep
-            for role, message in self.messages:
-                if message:
-                    ret += role + message + self.sep
-                else:
-                    ret += role
-            return ret
         else:
             raise ValueError(f"Invalid style: {self.sep_style}")
 
@@ -486,7 +478,7 @@ register_conv_template(
         roles=("<|prompt|>", "<|answer|>"),
         messages=(),
         offset=0,
-        sep_style=SeparatorStyle.BILLA,
+        sep_style=SeparatorStyle.NO_COLON_SINGLE,
         sep="</s>",
         stop_str="</s>",
     )

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -476,6 +476,16 @@ class BiLLaAdapter(BaseAdapter):
         return get_conv_template("billa")
 
 
+class H2OGPTAdapter(BaseAdapter):
+    """The model adapter for BiLLa."""
+
+    def match(self, model_path: str):
+        return "h2ogpt" in model_path.lower()
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("h2ogpt")
+
+
 # Note: the registration order matters.
 # The one registered earlier has a higher matching priority.
 register_model_adapter(VicunaAdapter)
@@ -494,6 +504,7 @@ register_model_adapter(ChatGPTAdapter)
 register_model_adapter(ClaudeAdapter)
 register_model_adapter(MPTAdapter)
 register_model_adapter(BiLLaAdapter)
+register_model_adapter(H2OGPTAdapter)
 
 # After all adapters, try the default base adapter.
 register_model_adapter(BaseAdapter)

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -4,6 +4,7 @@ import math
 import sys
 from typing import List, Optional
 import warnings
+
 if sys.version_info >= (3, 9):
     from functools import cache
 else:

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -478,7 +478,7 @@ class BiLLaAdapter(BaseAdapter):
 
 
 class H2OGPTAdapter(BaseAdapter):
-    """The model adapter for BiLLa."""
+    """The model adapter for h2oGPT."""
 
     def match(self, model_path: str):
         return "h2ogpt" in model_path.lower()

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -126,3 +126,9 @@ register_model_info(
     "https://huggingface.co/Neutralzz/BiLLa-7B-SFT",
     "an instruction-tuned bilingual llama with enhanced reasoning ability by an independent researcher",
 )
+register_model_info(
+    ["h2ogpt-gm-oasst1-en-2048-open-llama-7b-preview-300bt-v2"],
+    "h2oGPT-GM-7b",
+    "https://huggingface.co/h2oai/h2ogpt-gm-oasst1-en-2048-open-llama-7b-preview-300bt-v2",
+    "an instruction-tuned Apache 2.0 licensed llama with enhanced conversational ability by H2O.ai",
+)


### PR DESCRIPTION
## Why are these changes needed?

This PR adds support for an instruction-tuned Apache 2.0 licensed llama with enhanced conversational ability by H2O.ai.
Model card: https://huggingface.co/h2oai/h2ogpt-gm-oasst1-en-2048-open-llama-7b-preview-300bt-v2

## Related issue number (if applicable)

None

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
