### PR TITLE
try to fix bug #1306

### DIFF
--- a/fastchat/protocol/openai_api_protocol.py
+++ b/fastchat/protocol/openai_api_protocol.py
@@ -116,7 +116,7 @@ class EmbeddingsResponse(BaseModel):
 
 class CompletionRequest(BaseModel):
     model: str
-    prompt: str
+    prompt: Union[str, list[str]]
     suffix: Optional[str] = None
     temperature: Optional[float] = 0.7
     n: Optional[int] = 1


### PR DESCRIPTION
## Why are these changes needed?

Hi, as stated in https://github.com/lm-sys/FastChat/issues/1306 I have a compatibility issue since OpenAI stated in its specification that prompt may be a string or an array. (https://platform.openai.com/docs/api-reference/completions).

I found out where it trigger the issue in fast chat : first in validation (fastapi) and then in request handling (get_gen_param).

Since get_gen_param is used in completions and in chat/completions, both may be impacted by my changes. I tried to keep it as safe as possible but I do not have many test cases by myself.

I hope this contribution will help.

## Related issue number (if applicable)

Closes #1306 

## Checks

- I did not run format.sh since it made a lot of other changes
- I ran both curl and python tests in `tests` directory
