### PR TITLE
Add support for RedPajama-INCITE-Chat-7B-v0.1

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -131,7 +131,7 @@ class Conversation:
                 if message:
                     ret += role + ": " + message + self.sep
                 else:
-                    ret += role + ": " # must be end with a space
+                    ret += role + ": "  # must be end with a space
             return ret
         else:
             raise ValueError(f"Invalid style: {self.sep_style}")
@@ -466,6 +466,20 @@ register_conv_template(
         sep_style=SeparatorStyle.BILLA,
         sep="\n",
         stop_str="Human:",
+    )
+)
+
+# RedPajama INCITE default template
+register_conv_template(
+    Conversation(
+        name="redpajama-incite",
+        system="",
+        roles=("<human>", "<bot>"),
+        messages=(),
+        offset=0,
+        sep_style=SeparatorStyle.ADD_COLON_SINGLE,
+        sep="\n",
+        stop_str="<human>:",
     )
 )
 

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -4,6 +4,7 @@ import math
 import sys
 from typing import List, Optional
 import warnings
+
 if sys.version_info >= (3, 9):
     from functools import cache
 else:
@@ -476,6 +477,25 @@ class BiLLaAdapter(BaseAdapter):
         return get_conv_template("billa")
 
 
+class RedPajamaINCITEAdapter(BaseAdapter):
+    """The model adapter for RedPajama INCITE."""
+
+    def match(self, model_path: str):
+        return "redpajama-incite" in model_path.lower()
+
+    def load_model(self, model_path: str, from_pretrained_kwargs: dict):
+        tokenizer = AutoTokenizer.from_pretrained(model_path)  # no use_fast=False
+        model = AutoModelForCausalLM.from_pretrained(
+            model_path,
+            low_cpu_mem_usage=True,
+            **from_pretrained_kwargs,
+        )
+        return model, tokenizer
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("redpajama-incite")
+
+
 # Note: the registration order matters.
 # The one registered earlier has a higher matching priority.
 register_model_adapter(VicunaAdapter)
@@ -494,6 +514,7 @@ register_model_adapter(ChatGPTAdapter)
 register_model_adapter(ClaudeAdapter)
 register_model_adapter(MPTAdapter)
 register_model_adapter(BiLLaAdapter)
+register_model_adapter(RedPajamaINCITEAdapter)
 
 # After all adapters, try the default base adapter.
 register_model_adapter(BaseAdapter)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Model card: https://huggingface.co/togethercomputer/RedPajama-INCITE-Chat-7B-v0.1
See press release: https://www.together.xyz/blog/redpajama-models-v1

This model family is still in preview, but the performance looks really promising. I ran this command and got the following results:

```bash
python3 -m fastchat.serve.cli --model-path togethercomputer/RedPajama-INCITE-Chat-7B-v0.1 --debug
```

<img width="1463" alt="Screenshot with results of a few shots of conversation; see detail below" src="https://github.com/lm-sys/FastChat/assets/790279/252c5e3a-21c6-4f04-a0aa-e5d257b84a27">

<details>
<summary>Screen reader accessible version of the results</summary>

```
<human>: good morning
<bot>: 2023-05-19 02:45:08.122269: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX512F AVX512_VNNI
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2023-05-19 02:45:08.238555: I tensorflow/core/util/port.cc:104] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
--------------------------------------------------------------------------
WARNING: No preset parameters were found for the device that Open MPI
detected:

  Local host:            152-67-248-215
  Device name:           mlx5_0
  Device vendor ID:      0x02c9
  Device vendor part ID: 4126

Default device parameters will be used, which may result in lower
performance.  You can edit any of the files specified by the
btl_openib_device_param_files MCA parameter to set values for your
device.

NOTE: You can turn off this warning by setting the MCA parameter
      btl_openib_warn_no_device_params_found to 0.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
No OpenFabrics connection schemes reported that they were able to be
used on a specific port.  As such, the openib BTL (OpenFabrics
support) will be disabled for this port.

  Local host:           152-67-248-215
  Local device:         mlx5_0
  Local port:           1
  CPCs attempted:       udcm
--------------------------------------------------------------------------
/home/ubuntu/.local/lib/python3.8/site-packages/pandas/core/computation/expressions.py:20: UserWarning: Pandas requires version '2.7.3' or newer of 'numexpr' (version '2.7.1' currently installed).
  from pandas.core.computation.check import NUMEXPR_INSTALLED
It's nice to meet you. How can I help you today?

 {'prompt': '\n<human>: good morning\n<bot>:', 'outputs': "It's nice to meet you. How can I help you today?"} 

<human>: I am throwing a dinner party this Friday. Could you help me write an email for friends?    
<bot>: Sure! Here is a sample email you can use as a starting point:

Good morning,

I hope you are having a great start to your day! I hope that you are able to relax and enjoy your weekend, surrounded by your loved ones.

I wanted to let you know that I am planning on throwing a dinner party this Friday night. I hope that you will be able to come and spend some time with me and the other guests that I have invited.

I am very excited to share this special time with all of you, and I hope that you will be able to make it!

If you have any questions or concerns, please feel free to reach out to me.

Thank you so much for your time and consideration. I look forward to seeing you on Friday!

Best,

[Your name]

 {'prompt': "\n<human>: good morning\n<bot>: It's nice to meet you. How can I help you today?\n<human>: I am throwing a dinner party this Friday. Could you help me write an email for friends?\n<bot>:", 'outputs': 'Sure! Here is a sample email you can use as a starting point:\n\nGood morning,\n\nI hope you are having a great start to your day! I hope that you are able to relax and enjoy your weekend, surrounded by your loved ones.\n\nI wanted to let you know that I am planning on throwing a dinner party this Friday night. I hope that you will be able to come and spend some time with me and the other guests that I have invited.\n\nI am very excited to share this special time with all of you, and I hope that you will be able to make it!\n\nIf you have any questions or concerns, please feel free to reach out to me.\n\nThank you so much for your time and consideration. I look forward to seeing you on Friday!\n\nBest,\n\n[Your name]'} 

<human>:
```

</details>

It seems like the BaseAdapter does not work because `use_fast=False` excludes the default tokenizer, so I simply overwrote that. The conversation template is pretty straightforward and seems to work reliably, but I did not run any automated tests. Could use some help from experts as this is my first contribution. :)

Please let me know if you have any other suggestions to improve the code! Main outstanding issue is there are a bunch of warnings I don't quite understand yet, but they seem to show up even when I run the examples from the model card so I think they might be unrelated.

I ran this on a Lambda Labs GPU cloud instance. Specs:

1x A10 (24 GB PCIe)
30 vCPUs, 200 GiB RAM, 1.4 TiB SSD

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

N/A
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
