### PR TITLE
[FIX]Typo:finish_tstamp was miswritten as start_tstamp

### DIFF
--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -404,7 +404,7 @@ def http_bot(
                 "max_new_tokens": max_new_tokens,
             },
             "start": round(start_tstamp, 4),
-            "finish": round(start_tstamp, 4),
+            "finish": round(finish_tstamp, 4),
             "state": state.dict(),
             "ip": request.client.host,
         }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In gradio_web_server.py, finish_tstamp was miswritten as start_tstamp, so that running time can be calculated wrongly according the conv_log.


## Checks

- [ y] I've run `format.sh` to lint the changes in this PR.
- [ y] I've included any doc changes needed.
- [ y] I've made sure the relevant tests are passing (if applicable).
