### PR TITLE
Configurable worker timeout

### DIFF
--- a/docs/openai_api.md
+++ b/docs/openai_api.md
@@ -102,6 +102,9 @@ curl http://localhost:8000/v1/embeddings \
   }'
 ```
 
+## Tunning
+Runner should answer within 20 seconds. If your model/hardware is slower, you wil get Timeout errors. You can change this timeout through ENV variables : "export WORKER_API_TIMEOUT=<larger timeout in seconds>"
+
 ## Todos
 Some features to be implemented:
 

--- a/fastchat/constants.py
+++ b/fastchat/constants.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-
+import os
 
 # For the gradio web server
 SERVER_ERROR_MSG = (

--- a/fastchat/constants.py
+++ b/fastchat/constants.py
@@ -11,10 +11,10 @@ INPUT_CHAR_LEN_LIMIT = 2560
 CONVERSATION_LEN_LIMIT = 50
 LOGDIR = "."
 
-# For the controller and workers
-CONTROLLER_HEART_BEAT_EXPIRATION = 90
-WORKER_HEART_BEAT_INTERVAL = 30
-WORKER_API_TIMEOUT = 20
+# For the controller and workers(could be overwritten through ENV variables.)
+CONTROLLER_HEART_BEAT_EXPIRATION = int(os.getenv("CONTROLLER_HEART_BEAT_EXPIRATION", 90))
+WORKER_HEART_BEAT_INTERVAL = int(os.getenv("WORKER_HEART_BEAT_INTERVAL", 30))
+WORKER_API_TIMEOUT = int(os.getenv("WORKER_API_TIMEOUT", 20)) 
 
 
 class ErrorCode(IntEnum):


### PR DESCRIPTION
## Why are these changes needed?

My worker are slower than you might have and do not answer within the 20 seconds specified in contstants.py.

The change allows those constants to be configured through environment variables.

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR. -> NO, it make many other unrelated changes
- [ ] I've included any doc changes needed. -> yes
- [ ] I've made sure the relevant tests are passing (if applicable). -> not applicable
