### PR TITLE
Update model worker and openapi server

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -590,6 +590,7 @@ async def create_embeddings(request: EmbeddingsRequest):
 async def get_embedding(payload: Dict[str, Any]):
     controller_address = app_settings.controller_address
     model_name = payload["model"]
+    timeout = httpx.Timeout(WORKER_API_TIMEOUT, read=None)
     async with httpx.AsyncClient() as client:
         worker_addr = await _get_worker_address(model_name, client)
 
@@ -597,7 +598,7 @@ async def get_embedding(payload: Dict[str, Any]):
             worker_addr + "/worker_get_embeddings",
             headers=headers,
             json=payload,
-            timeout=WORKER_API_TIMEOUT,
+            timeout=timeout,
         )
         embedding = response.json()
         return embedding


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I tried running the `fastchat-t5-3b-v1.0` model via FastChat's openai implementation but was getting the below error when trying to hit the `/embeddings` route:

```console
ValueError: You have to specify either (input_ids and decoder_input_ids) or inputs_embeds
```
The changes in this pr update the model to include input_ids and decoder_input_ids.

## Related issue number (if applicable)

This seems to be an issue within the model for `fastchat-t5-3b-v1.0` and transformers. Here are some related issues, https://github.com/huggingface/transformers/issues/16234 and https://github.com/huggingface/transformers/issues/3626 .

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
