### PR TITLE
Add `token_check` endpoint to OpenAI API server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ output
 # Data
 *.pkl
 *.csv
+
+# Build
+build

--- a/fastchat/protocol/openai_api_protocol.py
+++ b/fastchat/protocol/openai_api_protocol.py
@@ -50,7 +50,7 @@ class UsageInfo(BaseModel):
 
 class ChatCompletionRequest(BaseModel):
     model: str
-    messages: List[Dict[str, str]]
+    messages: Union[str, List[Dict[str, str]]]
     temperature: Optional[float] = 0.7
     top_p: Optional[float] = 1.0
     n: Optional[int] = 1

--- a/fastchat/protocol/openai_api_protocol.py
+++ b/fastchat/protocol/openai_api_protocol.py
@@ -100,6 +100,15 @@ class ChatCompletionStreamResponse(BaseModel):
     model: str
     choices: List[ChatCompletionResponseStreamChoice]
 
+class TokenCheckRequest(BaseModel):
+    model: str
+    prompt: str
+    max_tokens: int
+
+class TokenCheckResponse(BaseModel):
+    fits: bool
+    tokenCount: int
+    contextLength: int
 
 class EmbeddingsRequest(BaseModel):
     model: str

--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -47,6 +47,8 @@ from fastchat.protocol.openai_api_protocol import (
     ModelCard,
     ModelList,
     ModelPermission,
+    TokenCheckRequest,
+    TokenCheckResponse,
     UsageInfo,
 )
 
@@ -66,7 +68,7 @@ headers = {"User-Agent": "FastChat API Server"}
 
 def create_error_response(code: int, message: str) -> JSONResponse:
     return JSONResponse(
-        ErrorResponse(message=message, code=code).dict(), status_code=500
+        ErrorResponse(message=message, code=code).dict(), status_code=400
     )
 
 
@@ -267,6 +269,39 @@ async def show_available_models():
     for m in models:
         model_cards.append(ModelCard(id=m, root=m, permission=[ModelPermission()]))
     return ModelList(data=model_cards)
+
+
+# TODO: Have check_length and count_tokens share code.
+@app.post("/v1/token_check")
+async def count_tokens(request: TokenCheckRequest):
+    """Checks the token count against your message"""
+    async with httpx.AsyncClient() as client:
+        worker_addr = await _get_worker_address(request.model, client)
+
+        response = await client.post(
+            worker_addr + "/model_details",
+            headers=headers,
+            json={},
+            timeout=WORKER_API_TIMEOUT,
+        )
+        context_len = response.json()["context_length"]
+
+        response = await client.post(
+            worker_addr + "/count_token",
+            headers=headers,
+            json={"prompt": request.prompt},
+            timeout=WORKER_API_TIMEOUT,
+        )
+        token_num = response.json()["count"]
+
+    # TODO: Fix this for other models
+    context_len = 2048
+
+    can_fit = True
+    if token_num + request.max_tokens > context_len:
+        can_fit = False
+
+    return TokenCheckResponse(fits=can_fit, contextLength=context_len, tokenCount=token_num)
 
 
 @app.post("/v1/chat/completions")

--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -274,7 +274,10 @@ async def show_available_models():
 # TODO: Have check_length and count_tokens share code.
 @app.post("/v1/token_check")
 async def count_tokens(request: TokenCheckRequest):
-    """Checks the token count against your message"""
+    """
+    Checks the token count against your message
+    This is not part of the OpenAI API spec.
+    """
     async with httpx.AsyncClient() as client:
         worker_addr = await _get_worker_address(request.model, client)
 
@@ -293,9 +296,6 @@ async def count_tokens(request: TokenCheckRequest):
             timeout=WORKER_API_TIMEOUT,
         )
         token_num = response.json()["count"]
-
-    # TODO: Fix this for other models
-    context_len = 2048
 
     can_fit = True
     if token_num + request.max_tokens > context_len:


### PR DESCRIPTION
## Why are these changes needed?

- When running `pip install .` the build files are not .gitignore'd, this fixes that. 
- We also fix errors being thrown from the API from `500` to `400` because the errors are related to the request most often. A better revision later would specify the error code depending on the depending on exactly the kind of error we have. 
- This PR adds a `token_check` API. I know this not strictly part of the OpenAI spec but it is needed, and since the old API was deleted in favor of this one, I figured this is the best place to put it for now.
- Fix a bug in the spec causing it to reject a type of chat completion message that should be supported.

Suggestion for later:
`max_tokens` is not a good variable name at all. It can easily get confused with `context_length` in a production app. Changing it to `max_generation_tokens`, while not ideal, would still at least indicate that it is in fact, for the generated tokens and not defining the total amount of tokens the model can handle at any given time.