### PR TITLE
fix stop detections

### DIFF
--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -47,6 +47,13 @@ def prepare_logits_processor(
     return processor_list
 
 
+def partial_stop(output, stop_str):
+    for i in range(0, min(len(output), len(stop_str))):
+        if stop_str.startswith(output[-i:]):
+            return True
+    return False
+
+
 @torch.inference_mode()
 def generate_stream(
     model, tokenizer, params, device, context_len=2048, stream_interval=2
@@ -160,12 +167,6 @@ def generate_stream(
                 skip_special_tokens=True,
                 spaces_between_special_tokens=False,
             )
-
-            def partial_stop(output, stop_str):
-                for i in range(0, min(len(output), len(stop_str))):
-                    if stop_str.startswith(output[-i:]):
-                        return True
-                return False
 
             if stop_str:
                 if isinstance(stop_str, str):

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -161,7 +161,7 @@ def generate_stream(
                 spaces_between_special_tokens=False,
             )
 
-            def maybeStop(output, stop_str):
+            def partial_stop(output, stop_str):
                 for i in range(0, len(output)):
                     if i > len(stop_str):
                         return False
@@ -176,7 +176,7 @@ def generate_stream(
                         output = output[:pos]
                         stopped = True
                     else:
-                        maybeStop = maybeStop(output, stop_str)
+                        partial_stop = partial_stop(output, stop_str)
                 elif isinstance(stop_str, Iterable):
                     for each_stop in stop_str:
                         pos = output.rfind(each_stop, rfind_start)
@@ -185,13 +185,14 @@ def generate_stream(
                             stopped = True
                             break
                         else:
-                            maybeStop = maybeStop(output, each_stop)
-                            if maybeStop:
+                            partial_stop = partial_stop(output, each_stop)
+                            if partial_stop:
                                 break
                 else:
                     raise ValueError("Invalid stop field type.")
-
-            if not maybeStop:
+            
+            # prevent yielding partial stop sequence
+            if not partial_stop:
                 yield {
                     "text": output,
                     "usage": {

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -162,9 +162,7 @@ def generate_stream(
             )
 
             def partial_stop(output, stop_str):
-                for i in range(0, len(output)):
-                    if i > len(stop_str):
-                        return False
+                for i in range(0, min(len(output), len(stop_str))):
                     if stop_str.startswith(output[-i:]):
                         return True
                 return False

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -174,7 +174,7 @@ def generate_stream(
                         output = output[:pos]
                         stopped = True
                     else:
-                        partial_stop = partial_stop(output, stop_str)
+                        partially_stopped = partial_stop(output, stop_str)
                 elif isinstance(stop_str, Iterable):
                     for each_stop in stop_str:
                         pos = output.rfind(each_stop, rfind_start)
@@ -183,14 +183,14 @@ def generate_stream(
                             stopped = True
                             break
                         else:
-                            partial_stop = partial_stop(output, each_stop)
-                            if partial_stop:
+                            partially_stopped = partial_stop(output, each_stop)
+                            if partially_stopped:
                                 break
                 else:
                     raise ValueError("Invalid stop field type.")
             
             # prevent yielding partial stop sequence
-            if not partial_stop:
+            if not partially_stopped:
                 yield {
                     "text": output,
                     "usage": {

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -168,6 +168,7 @@ def generate_stream(
                 spaces_between_special_tokens=False,
             )
 
+            partially_stopped = False
             if stop_str:
                 if isinstance(stop_str, str):
                     pos = output.rfind(stop_str, rfind_start)
@@ -189,8 +190,6 @@ def generate_stream(
                                 break
                 else:
                     raise ValueError("Invalid stop field type.")
-            else:
-                partially_stopped = False
             
             # prevent yielding partial stop sequence
             if not partially_stopped:

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -189,6 +189,8 @@ def generate_stream(
                                 break
                 else:
                     raise ValueError("Invalid stop field type.")
+            else:
+                partially_stopped = False
             
             # prevent yielding partial stop sequence
             if not partially_stopped:


### PR DESCRIPTION
The current stop detection works but only after the partial stop sequence was already streamed.
This causes ReAct to break.

This change adds partial stop detection and avoids streaming it.