### PR TITLE
Add Baize v2 model registry

### DIFF
--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -136,6 +136,6 @@ register_model_info(
 register_model_info(
     ["baize-v2-7b", "baize-v2-13b"],
     "Baize v2",
-    "https://github.com/project-baize/baize-chatbot",
+    "https://github.com/project-baize/baize-chatbot#v2",
     "A chatbot fine-tuned from LLaMA with ChatGPT self-chat data and Self-Disillation with Feedback (SDF) by UCSD and SYSU.",
 )

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -137,5 +137,5 @@ register_model_info(
     ["baize-v2-7b", "baize-v2-13b"],
     "Baize v2",
     "https://github.com/project-baize/baize-chatbot",
-    "A chatbot fine-tuned from LLaMA with ChatGPT self-data and Self-Disillation with Feedback (SDF) by UCSD and SYSU.",
+    "A chatbot fine-tuned from LLaMA with ChatGPT self-chat data and Self-Disillation with Feedback (SDF) by UCSD and SYSU.",
 )

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -133,3 +133,9 @@ register_model_info(
     "https://huggingface.co/h2oai/h2ogpt-gm-oasst1-en-2048-open-llama-7b-preview-300bt-v2",
     "an instruction-tuned OpenLLaMA with enhanced conversational ability by H2O.ai",
 )
+register_model_info(
+    ["baize-v2-7b", "baize-v2-13b"],
+    "Baize v2",
+    "https://github.com/project-baize/baize-chatbot",
+    "A chatbot fine-tuned from LLaMA with ChatGPT self-data and Self-Disillation with Feedback (SDF) by UCSD and SYSU.",
+)


### PR DESCRIPTION
Hi, as we have released Baize v2, we are adding the two checkpoints into model registry. By the way, given these two models are optimized with a new self-distillation technique and achieve good performance with automatic GPT-4 evaluation, we would like to see how it performs with human evaluation. Could you add them to the arena?