### PR TITLE
Add support for programmatic usage with standard streams

### DIFF
--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -113,7 +113,7 @@ class ProgrammaticChatIO(ChatIO):
         #  that signals the end of a message. It is unlikely to occur in
         #  message content.
         end_sequence = "9745805894023423"
-        while true:
+        while True:
             if len(contents) >= 16:
                 last_chars = contents[-16:]
                 if last_chars == end_sequence:

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -113,11 +113,10 @@ class ProgrammaticChatIO(ChatIO):
         #  that signals the end of a message. It is unlikely to occur in
         #  message content.
         end_sequence = "9745805894023423"
-        while not prompt_done:
+        while true:
             if len(contents) >= 16:
                 last_chars = contents[-16:]
                 if last_chars == end_sequence:
-                    prompt_done = True
                     break
             try:
                 char = sys.stdin.read(1)
@@ -171,7 +170,6 @@ def main(args):
             args.max_new_tokens,
             chatio,
             args.debug,
-            args.style,
         )
     except KeyboardInterrupt:
         print("exit...")

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -108,7 +108,6 @@ class ProgrammaticChatIO(ChatIO):
     def prompt_for_input(self, role) -> str:
         print(f"[!OP:{role}]: ", end="", flush=True)
         contents = ""
-        prompt_done = False
         # `end_sequence` is a randomly-generated, 16-digit number
         #  that signals the end of a message. It is unlikely to occur in
         #  message content.

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -8,6 +8,7 @@ python3 -m fastchat.serve.cli --model ~/model_weights/vicuna-7b
 import argparse
 import os
 import re
+import sys
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
@@ -103,6 +104,44 @@ class RichChatIO(ChatIO):
         return text
 
 
+class ProgrammaticChatIO(ChatIO):
+    def prompt_for_input(self, role) -> str:
+        print(f"[!OP:{role}]: ", end="", flush=True)
+        contents = ""
+        prompt_done = False
+        # `end_sequence` is a randomly-generated, 16-digit number
+        #  that signals the end of a message. It is unlikely to occur in
+        #  message content.
+        end_sequence = "9745805894023423"
+        while not prompt_done:
+            if len(contents) >= 16:
+                last_chars = contents[-16:]
+                if last_chars == end_sequence:
+                    prompt_done = True
+                    break
+            try:
+                char = sys.stdin.read(1)
+                contents = contents + char
+            except EOFError:
+                continue
+        return contents[:-16]
+
+    def prompt_for_output(self, role: str):
+        print(f"[!OP:{role}]: ", end="", flush=True)
+
+    def stream_output(self, output_stream):
+        pre = 0
+        for outputs in output_stream:
+            output_text = outputs["text"]
+            output_text = output_text.strip().split(" ")
+            now = len(output_text) - 1
+            if now > pre:
+                print(" ".join(output_text[pre:now]), end=" ", flush=True)
+                pre = now
+        print(" ".join(output_text[pre:]), flush=True)
+        return " ".join(output_text)
+
+
 def main(args):
     if args.gpus:
         if len(args.gpus.split(",")) < args.num_gpus:
@@ -115,6 +154,8 @@ def main(args):
         chatio = SimpleChatIO()
     elif args.style == "rich":
         chatio = RichChatIO()
+    elif args.style == "programmatic":
+        chatio = ProgrammaticChatIO()
     else:
         raise ValueError(f"Invalid style for console: {args.style}")
     try:
@@ -130,6 +171,7 @@ def main(args):
             args.max_new_tokens,
             chatio,
             args.debug,
+            args.style,
         )
     except KeyboardInterrupt:
         print("exit...")
@@ -147,7 +189,7 @@ if __name__ == "__main__":
         "--style",
         type=str,
         default="simple",
-        choices=["simple", "rich"],
+        choices=["simple", "rich", "programmatic"],
         help="Display style.",
     )
     parser.add_argument(

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -256,7 +256,6 @@ def chat_loop(
     max_new_tokens: int,
     chatio: ChatIO,
     debug: bool,
-    style: str,
 ):
     # Model
     model, tokenizer = load_model(

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -256,6 +256,7 @@ def chat_loop(
     max_new_tokens: int,
     chatio: ChatIO,
     debug: bool,
+    style: str,
 ):
     # Model
     model, tokenizer = load_model(


### PR DESCRIPTION
## Why are these changes needed?

These changes add support for an additional CLI mode that external programs can use over standard streams (stdin/stdout/stderr). This was motivated by a desire to use it in JavaScript (specifically in Deno), but it can be done from any language capable of communicating with a subprocess. This feature is prevalent across programming languages, so it allows lots of integrations.

## Related issue number

Closes #456 

## Checks

- [X] I've run `format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed.
- [X] I've made sure the relevant tests are passing (if applicable).
