### PR TITLE
Add LoraAdapter to model_adapter.py

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -23,7 +23,6 @@ from transformers import (
     T5Tokenizer,
 )
 
-from peft import PeftModel
 import os
 import json
 
@@ -518,6 +517,7 @@ class LoraAdapter(BaseAdapter):
         return res
 
     def load_model(self, lora_path: str, from_pretrained_kwargs: dict):
+        from peft import PeftModel
         lora_conf = json.load(open(os.path.join(lora_path, "adapter_config.json")))
 
         base_model_path = lora_conf['base_model_name_or_path']


### PR DESCRIPTION
Add LoRA adapter, so that a finetuned adapter doesn't need to be merged to model every time, but instead be loaded directly.

## Why are these changes needed?

Loading Adapters directly allows for many different finetuned versions with little storage space requirements and easier infrastructure management.

## Checks

- I tested it with Vicuna7B-v1.1 and an adapter finetuned using alpaca-lora
