### PR TITLE
Add model list reload support to gradio_web_server_multi

### DIFF
--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -56,8 +56,8 @@ def load_demo_side_by_side_named(models, url_params):
         model_right = model_left
 
     selector_updates = (
-        gr.Dropdown.update(model_left, visible=True),
-        gr.Dropdown.update(model_right, visible=True),
+        gr.Dropdown.update(choices=models, value=model_left, visible=True),
+        gr.Dropdown.update(choices=models, value=model_right, visible=True),
     )
 
     return (

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -115,8 +115,7 @@ def get_model_list(controller_url):
     return models
 
 
-def load_demo_refresh_model_list(url_params):
-    models = get_model_list(controller_url)
+def load_demo_single(models, url_params):
     selected_model = models[0] if len(models) > 0 else ""
     if "model" in url_params:
         model = url_params["model"]
@@ -143,26 +142,8 @@ def load_demo_reload_model(url_params, request: gr.Request):
     logger.info(
         f"load_demo_reload_model. ip: {request.client.host}. params: {url_params}"
     )
-    return load_demo_refresh_model_list(url_params)
-
-
-def load_demo_single(models, url_params):
-    dropdown_update = gr.Dropdown.update(visible=True)
-    if "model" in url_params:
-        model = url_params["model"]
-        if model in models:
-            dropdown_update = gr.Dropdown.update(value=model, visible=True)
-
-    state = None
-    return (
-        state,
-        dropdown_update,
-        gr.Chatbot.update(visible=True),
-        gr.Textbox.update(visible=True),
-        gr.Button.update(visible=True),
-        gr.Row.update(visible=True),
-        gr.Accordion.update(visible=True),
-    )
+    models = get_model_list(controller_url)
+    return load_demo_single(models, url_params)
 
 
 def load_demo(url_params, request: gr.Request):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Model list updates are not reflected in gradio_web_server_multi. This change adds support for `--model-list-mode=reload` similar to gradio_web_server.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
