### PR TITLE
Add warning when training with flash attention

### DIFF
--- a/fastchat/train/llama_flash_attn_monkey_patch.py
+++ b/fastchat/train/llama_flash_attn_monkey_patch.py
@@ -1,4 +1,5 @@
 from typing import List, Optional, Tuple
+import logging
 
 import torch
 from torch import nn
@@ -108,6 +109,12 @@ def _prepare_decoder_attention_mask(
 
 
 def replace_llama_attn_with_flash_attn():
+    cuda_major, cuda_minor = torch.cuda.get_device_capability()
+    if (cuda_major, cuda_minor) != (8, 0) or  (cuda_major, cuda_minor) != (9, 0):
+        logging.warning(
+            "Flash attention is only supported on A100 or H100 GPU during training due to head dim > 64 backward."
+            "ref: https://github.com/HazyResearch/flash-attention/issues/190#issuecomment-1523359593"
+        )
     transformers.models.llama.modeling_llama.LlamaModel._prepare_decoder_attention_mask = (
         _prepare_decoder_attention_mask
     )

--- a/fastchat/train/llama_flash_attn_monkey_patch.py
+++ b/fastchat/train/llama_flash_attn_monkey_patch.py
@@ -110,7 +110,7 @@ def _prepare_decoder_attention_mask(
 
 def replace_llama_attn_with_flash_attn():
     cuda_major, cuda_minor = torch.cuda.get_device_capability()
-    if (cuda_major, cuda_minor) != (8, 0) or  (cuda_major, cuda_minor) != (9, 0):
+    if (cuda_major, cuda_minor) != (8, 0) or (cuda_major, cuda_minor) != (9, 0):
         logging.warning(
             "Flash attention is only supported on A100 or H100 GPU during training due to head dim > 64 backward."
             "ref: https://github.com/HazyResearch/flash-attention/issues/190#issuecomment-1523359593"

--- a/fastchat/train/llama_flash_attn_monkey_patch.py
+++ b/fastchat/train/llama_flash_attn_monkey_patch.py
@@ -1,5 +1,4 @@
 from typing import List, Optional, Tuple
-import logging
 
 import torch
 from torch import nn
@@ -109,12 +108,6 @@ def _prepare_decoder_attention_mask(
 
 
 def replace_llama_attn_with_flash_attn():
-    cuda_major, cuda_minor = torch.cuda.get_device_capability()
-    if (cuda_major, cuda_minor) != (8, 0) or  (cuda_major, cuda_minor) != (9, 0):
-        logging.warning(
-            "Flash attention is only supported on A100 or H100 GPU during training due to head dim > 64 backward."
-            "ref: https://github.com/HazyResearch/flash-attention/issues/190#issuecomment-1523359593"
-        )
     transformers.models.llama.modeling_llama.LlamaModel._prepare_decoder_attention_mask = (
         _prepare_decoder_attention_mask
     )


### PR DESCRIPTION
## Why are these changes needed?
Add a warning before replacing llama with flash attention since older GPUs may not have the capability to use it. These limitations are listed [here](https://github.com/HazyResearch/flash-attention#:~:text=Head%20dimensions%20that%20are%20multiples%20of%208%2C%20up%20to%20128%20(e.g.%2C%208%2C%2016%2C%2024%2C%20...%2C%20128).%20Head%20dim%20%3E%2064%20backward%20requires%20A100%20or%20H100.)

## Related issue number (if applicable)
N/A

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
