### PR TITLE
a fix to chatglm model, relate issue: #1385 

### DIFF
--- a/fastchat/model/chatglm_model.py
+++ b/fastchat/model/chatglm_model.py
@@ -21,7 +21,7 @@ def chatglm_generate_stream(
     model, tokenizer, params, device, context_len=2048, stream_interval=2
 ):
     """Generate text using model's chat api"""
-    messages = params["prompt"]
+    query = params["prompt"]
     max_new_tokens = int(params.get("max_new_tokens", 256))
     temperature = float(params.get("temperature", 1.0))
     top_p = float(params.get("top_p", 1.0))
@@ -39,10 +39,6 @@ def chatglm_generate_stream(
         gen_kwargs["temperature"] = temperature
 
     hist = []
-    for i in range(0, len(messages) - 2, 2):
-        hist.append((messages[i][1], messages[i + 1][1]))
-    query = messages[-2][1]
-
     input_echo_len = stream_chat_token_num(tokenizer, query, hist)
 
     output = ""


### PR DESCRIPTION
a fix to chatglm model, relate issue: #1385 

removed hist in the chatglm_generate_stream, it's not nessesary, and i don't the purpose of this code:
```python
    for i in range(0, len(messages) - 2, 2):
        hist.append((messages[i][1], messages[i + 1][1]))
    query = messages[-2][1]
```

The `messages` passed in is a string with all conversation history, not a `List[Tuple[str, str]]`, it should be passed to `model.stream_chat` directly.


```python
    @torch.no_grad()
    def stream_chat(self, tokenizer, query: str, history: List[Tuple[str, str]] = None, max_length: int = 2048,
                    do_sample=True, top_p=0.7, temperature=0.95, logits_processor=None, **kwargs):
        if history is None:
            history = []
        if logits_processor is None:
            logits_processor = LogitsProcessorList()
        logits_processor.append(InvalidScoreLogitsProcessor())
        gen_kwargs = {"max_length": max_length, "do_sample": do_sample, "top_p": top_p,
                      "temperature": temperature, "logits_processor": logits_processor, **kwargs}
        if not history:
            prompt = query
        else:
            prompt = ""
            for i, (old_query, response) in enumerate(history):
                prompt += "[Round {}]\n问：{}\n答：{}\n".format(i, old_query, response)
            prompt += "[Round {}]\n问：{}\n答：".format(len(history), query)
        inputs = tokenizer([prompt], return_tensors="pt")
        inputs = inputs.to(self.device)
        for outputs in self.stream_generate(**inputs, **gen_kwargs):
            outputs = outputs.tolist()[0][len(inputs["input_ids"][0]):]
            response = tokenizer.decode(outputs)
            response = self.process_response(response)
            new_history = history + [(query, response)]
            yield response, new_history
```