### PR TITLE
add api-key support

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -733,7 +733,7 @@ if __name__ == "__main__":
         "--allowed-headers", type=json.loads, default=["*"], help="allowed headers"
     )
     parser.add_argument(
-        "--api-keys", type=lambda s: s.split(','), help="Optional list of comma separated keys"
+        "--api-keys", type=lambda s: s.split(','), help="Optional list of comma separated API keys"
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
The official OpenAI api sends the OPENAI_API_KEY as a bearer header.
This PR will check the same header against an `api-key` set as command line arg.
If no `api-key` is set then all access is allowed, same as current behavior.