### PR TITLE
Add the offload_folder parameter when loading the model.

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -225,6 +225,7 @@ class VicunaAdapter(BaseAdapter):
         model = AutoModelForCausalLM.from_pretrained(
             model_path,
             low_cpu_mem_usage=True,
+            offload_folder="offload",
             **from_pretrained_kwargs,
         )
         self.raise_warning_for_old_weights(model)


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When loading a model in Transformer, setting low_cpu_mem_usage=True can lead to significant memory consumption, especially when using larger models or longer input sequences. The offload_folder parameter is used to specify a folder path where a portion of the model can be stored to reduce memory consumption.

## Related issue number (if applicable)

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
