### PR TITLE
Count the tokens/second when using --debug 

### DIFF
--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -5,6 +5,7 @@ import math
 from typing import Iterable, Optional
 import sys
 import warnings
+import time
 
 import psutil
 import torch
@@ -307,8 +308,12 @@ def chat_loop(
 
         chatio.prompt_for_output(conv.roles[1])
         output_stream = generate_stream_func(model, tokenizer, gen_params, device)
+        t = time.time()
         outputs = chatio.stream_output(output_stream)
+        t = time.time() - t
         conv.update_last_message(outputs.strip())
 
         if debug:
             print("\n", {"prompt": prompt, "outputs": outputs}, "\n")
+            num_tokens = len(tokenizer.encode(outputs))
+            print(f"Tokens per second: {num_tokens / t:.2f}\n")

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -4,8 +4,8 @@ import gc
 import math
 from typing import Iterable, Optional
 import sys
-import warnings
 import time
+import warnings
 
 import psutil
 import torch

--- a/fastchat/train/llama_flash_attn_monkey_patch.py
+++ b/fastchat/train/llama_flash_attn_monkey_patch.py
@@ -1,4 +1,5 @@
 from typing import List, Optional, Tuple
+import logging
 
 import torch
 from torch import nn
@@ -108,6 +109,12 @@ def _prepare_decoder_attention_mask(
 
 
 def replace_llama_attn_with_flash_attn():
+    cuda_major, cuda_minor = torch.cuda.get_device_capability()
+    if (cuda_major, cuda_minor) != (8, 0) or  (cuda_major, cuda_minor) != (9, 0):
+        logging.warning(
+            "Flash attention is only supported on A100 or H100 GPU during training due to head dim > 64 backward."
+            "ref: https://github.com/HazyResearch/flash-attention/issues/190#issuecomment-1523359593"
+        )
     transformers.models.llama.modeling_llama.LlamaModel._prepare_decoder_attention_mask = (
         _prepare_decoder_attention_mask
     )

--- a/fastchat/train/llama_flash_attn_monkey_patch.py
+++ b/fastchat/train/llama_flash_attn_monkey_patch.py
@@ -1,5 +1,4 @@
 from typing import List, Optional, Tuple
-import logging
 
 import torch
 from torch import nn
@@ -109,12 +108,6 @@ def _prepare_decoder_attention_mask(
 
 
 def replace_llama_attn_with_flash_attn():
-    cuda_major, cuda_minor = torch.cuda.get_device_capability()
-    if (cuda_major, cuda_minor) != (8, 0) or  (cuda_major, cuda_minor) != (9, 0):
-        logging.warning(
-            "Flash attention is only supported on A100 or H100 GPU during training due to head dim > 64 backward."
-            "ref: https://github.com/HazyResearch/flash-attention/issues/190#issuecomment-1523359593"
-        )
     transformers.models.llama.modeling_llama.LlamaModel._prepare_decoder_attention_mask = (
         _prepare_decoder_attention_mask
     )


### PR DESCRIPTION
## Why are these changes needed?
We would like to count the tokens/second when debugging a served model on the cli.
Result using `llama-7b`:
<img width="1360" alt="image" src="https://github.com/lm-sys/FastChat/assets/49086305/65021ce9-75e7-43f3-b716-1e84ce46c075">


## Related issue number (if applicable)
Closes #1268 

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
