### PR TITLE
fix chatglm-6b:when use /v1/completions ,IndexError: string index out of range

### DIFF
--- a/fastchat/model/chatglm_model.py
+++ b/fastchat/model/chatglm_model.py
@@ -39,9 +39,13 @@ def chatglm_generate_stream(
         gen_kwargs["temperature"] = temperature
 
     hist = []
-    for i in range(0, len(messages) - 2, 2):
-        hist.append((messages[i][1], messages[i + 1][1]))
-    query = messages[-2][1]
+    query = ""
+    if type(messages) == list:
+        for i in range(0, len(messages) - 2, 2):
+            hist.append((messages[i][1], messages[i + 1][1]))
+            query = messages[-2][1]
+    elif type(messages) == str:
+        query = messages
 
     input_echo_len = stream_chat_token_num(tokenizer, query, hist)
 


### PR DESCRIPTION
fix chatglm-6b:when use /v1/completions ,IndexError: string index out of range

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are theWse changes needed?
When use  /v1/completions , Server ERROR：IndexError: string index out of range （in File "/fastchat/model/chatglm_model.py", line 43, in chatglm_generate_stream）
`messages` = "Once upon a time" ， type is str not list.

So, we added a type judgment

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

Closes #1385
<!-- For example: "Closes #1234" -->

## Checks



- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
