### PR TITLE
Fix missing controller address in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,6 +35,6 @@ services:
     image: fastchat:latest
     ports:
       - "8000:8000"
-    entrypoint: ["python3", "-m", "fastchat.serve.openai_api_server", "--host", "0.0.0.0", "--port", "8000"]
+    entrypoint: ["python3", "-m", "fastchat.serve.openai_api_server", "--controller-address", "http://fastchat-controller:21001", "--host", "0.0.0.0", "--port", "8000"]
 volumes:
   huggingface:


### PR DESCRIPTION
With this change, `docker-compose up` will correctly reach the controller worker when receiving calls.

## Why are these changes needed?

Without this change, the fastchat-controller is unreachable to the fastchat-api-server, resulting in these errors:
```
fastchat-api-server_1 | INFO: 172.19.0.1:35490 - "POST /v1/completions HTTP/1.1" 500 Internal Server Error
fastchat-api-server_1 | ERROR: Exception in ASGI application
fastchat-api-server_1 | anyio._backends._asyncio.ExceptionGroup: 2 exceptions were raised in the task group:
fastchat-api-server_1 | ----------------------------
fastchat-api-server_1 | Traceback (most recent call last):
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/anyio/_core/_sockets.py", line 167, in try_connect
fastchat-api-server_1 | stream = await asynclib.connect_tcp(remote_host, remote_port, local_address)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/anyio/_backends/_asyncio.py", line 1627, in connect_tcp
fastchat-api-server_1 | await get_running_loop().create_connection(
fastchat-api-server_1 | File "/usr/lib/python3.8/asyncio/base_events.py", line 1025, in create_connection
fastchat-api-server_1 | raise exceptions[0]
fastchat-api-server_1 | File "/usr/lib/python3.8/asyncio/base_events.py", line 1010, in create_connection
fastchat-api-server_1 | sock = await self._connect_sock(
fastchat-api-server_1 | File "/usr/lib/python3.8/asyncio/base_events.py", line 924, in _connect_sock
fastchat-api-server_1 | await self.sock_connect(sock, address)
fastchat-api-server_1 | File "/usr/lib/python3.8/asyncio/selector_events.py", line 496, in sock_connect
fastchat-api-server_1 | return await fut
fastchat-api-server_1 | File "/usr/lib/python3.8/asyncio/selector_events.py", line 501, in _sock_connect
fastchat-api-server_1 | sock.connect(address)
fastchat-api-server_1 | OSError: [Errno 99] Cannot assign requested address
fastchat-api-server_1 | ----------------------------
fastchat-api-server_1 | Traceback (most recent call last):
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/anyio/_core/_sockets.py", line 167, in try_connect
fastchat-api-server_1 | stream = await asynclib.connect_tcp(remote_host, remote_port, local_address)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/anyio/_backends/_asyncio.py", line 1627, in connect_tcp
fastchat-api-server_1 | await get_running_loop().create_connection(
fastchat-api-server_1 | File "/usr/lib/python3.8/asyncio/base_events.py", line 1025, in create_connection
fastchat-api-server_1 | raise exceptions[0]
fastchat-api-server_1 | File "/usr/lib/python3.8/asyncio/base_events.py", line 1010, in create_connection
fastchat-api-server_1 | sock = await self._connect_sock(
fastchat-api-server_1 | File "/usr/lib/python3.8/asyncio/base_events.py", line 924, in _connect_sock
fastchat-api-server_1 | await self.sock_connect(sock, address)
fastchat-api-server_1 | File "/usr/lib/python3.8/asyncio/selector_events.py", line 496, in sock_connect
fastchat-api-server_1 | return await fut
fastchat-api-server_1 | File "/usr/lib/python3.8/asyncio/selector_events.py", line 528, in _sock_connect_cb
fastchat-api-server_1 | raise OSError(err, f'Connect call failed {address}')
fastchat-api-server_1 | ConnectionRefusedError: [Errno 111] Connect call failed ('127.0.0.1', 21001)
fastchat-api-server_1 |
fastchat-api-server_1 |
fastchat-api-server_1 | The above exception was the direct cause of the following exception:
fastchat-api-server_1 |
fastchat-api-server_1 | Traceback (most recent call last):
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpcore/_exceptions.py", line 10, in map_exceptions
fastchat-api-server_1 | yield
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpcore/backends/asyncio.py", line 114, in connect_tcp
fastchat-api-server_1 | stream: anyio.abc.ByteStream = await anyio.connect_tcp(
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/anyio/_core/_sockets.py", line 225, in connect_tcp
fastchat-api-server_1 | raise OSError("All connection attempts failed") from cause
fastchat-api-server_1 | OSError: All connection attempts failed
fastchat-api-server_1 |
fastchat-api-server_1 | The above exception was the direct cause of the following exception:
fastchat-api-server_1 |
fastchat-api-server_1 | Traceback (most recent call last):
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpx/_transports/default.py", line 60, in map_httpcore_exceptions
fastchat-api-server_1 | yield
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpx/_transports/default.py", line 353, in handle_async_request
fastchat-api-server_1 | resp = await self._pool.handle_async_request(req)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpcore/_async/connection_pool.py", line 261, in handle_async_request
fastchat-api-server_1 | raise exc
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpcore/_async/connection_pool.py", line 245, in handle_async_request
fastchat-api-server_1 | response = await connection.handle_async_request(request)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpcore/_async/connection.py", line 92, in handle_async_request
fastchat-api-server_1 | raise exc
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpcore/_async/connection.py", line 69, in handle_async_request
fastchat-api-server_1 | stream = await self._connect(request)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpcore/_async/connection.py", line 117, in _connect
fastchat-api-server_1 | stream = await self._network_backend.connect_tcp(**kwargs)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpcore/backends/auto.py", line 31, in connect_tcp
fastchat-api-server_1 | return await self._backend.connect_tcp(
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpcore/backends/asyncio.py", line 121, in connect_tcp
fastchat-api-server_1 | stream._raw_socket.setsockopt(*option) # type: ignore[attr-defined] # pragma: no cover
fastchat-api-server_1 | File "/usr/lib/python3.8/contextlib.py", line 131, in exit
fastchat-api-server_1 | self.gen.throw(type, value, traceback)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpcore/_exceptions.py", line 14, in map_exceptions
fastchat-api-server_1 | raise to_exc(exc) from exc
fastchat-api-server_1 | httpcore.ConnectError: All connection attempts failed
fastchat-api-server_1 |
fastchat-api-server_1 | The above exception was the direct cause of the following exception:
fastchat-api-server_1 |
fastchat-api-server_1 | Traceback (most recent call last):
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/uvicorn/protocols/http/h11_impl.py", line 428, in run_asgi
fastchat-api-server_1 | result = await app( # type: ignore[func-returns-value]
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/uvicorn/middleware/proxy_headers.py", line 78, in call
fastchat-api-server_1 | return await self.app(scope, receive, send)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/fastapi/applications.py", line 276, in call
fastchat-api-server_1 | await super().call(scope, receive, send)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/starlette/applications.py", line 122, in call
fastchat-api-server_1 | await self.middleware_stack(scope, receive, send)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/starlette/middleware/errors.py", line 184, in call
fastchat-api-server_1 | raise exc
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/starlette/middleware/errors.py", line 162, in call
fastchat-api-server_1 | await self.app(scope, receive, _send)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/starlette/middleware/cors.py", line 83, in call
fastchat-api-server_1 | await self.app(scope, receive, send)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/starlette/middleware/exceptions.py", line 79, in call
fastchat-api-server_1 | raise exc
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/starlette/middleware/exceptions.py", line 68, in call
fastchat-api-server_1 | await self.app(scope, receive, sender)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/fastapi/middleware/asyncexitstack.py", line 21, in call
fastchat-api-server_1 | raise e
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/fastapi/middleware/asyncexitstack.py", line 18, in call
fastchat-api-server_1 | await self.app(scope, receive, send)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/starlette/routing.py", line 718, in call
fastchat-api-server_1 | await route.handle(scope, receive, send)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/starlette/routing.py", line 276, in handle
fastchat-api-server_1 | await self.app(scope, receive, send)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/starlette/routing.py", line 66, in app
fastchat-api-server_1 | response = await func(request)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/fastapi/routing.py", line 237, in app
fastchat-api-server_1 | raw_response = await run_endpoint_function(
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/fastapi/routing.py", line 163, in run_endpoint_function
fastchat-api-server_1 | return await dependant.call(**values)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/fastchat/serve/openai_api_server.py", line 480, in create_completion
fastchat-api-server_1 | error_check_ret = await check_model(request)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/fastchat/serve/openai_api_server.py", line 88, in check_model
fastchat-api-server_1 | models_ret = await client.post(controller_address + "/list_models")
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpx/_client.py", line 1848, in post
fastchat-api-server_1 | return await self.request(
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpx/_client.py", line 1530, in request
fastchat-api-server_1 | return await self.send(request, auth=auth, follow_redirects=follow_redirects)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpx/_client.py", line 1617, in send
fastchat-api-server_1 | response = await self._send_handling_auth(
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpx/_client.py", line 1645, in _send_handling_auth
fastchat-api-server_1 | response = await self._send_handling_redirects(
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpx/_client.py", line 1682, in _send_handling_redirects
fastchat-api-server_1 | response = await self._send_single_request(request)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpx/_client.py", line 1719, in _send_single_request
fastchat-api-server_1 | response = await transport.handle_async_request(request)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpx/_transports/default.py", line 353, in handle_async_request
fastchat-api-server_1 | resp = await self._pool.handle_async_request(req)
fastchat-api-server_1 | File "/usr/lib/python3.8/contextlib.py", line 131, in exit
fastchat-api-server_1 | self.gen.throw(type, value, traceback)
fastchat-api-server_1 | File "/usr/local/lib/python3.8/dist-packages/httpx/_transports/default.py", line 77, in map_httpcore_exceptions
fastchat-api-server_1 | raise mapped_exc(message) from exc
fastchat-api-server_1 | httpx.ConnectError: All connection attempts failed
```

