### PR TITLE
Fix-dolly-8-bit

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -35,6 +35,7 @@ from fastchat.utils import get_gpu_memory
 
 class BaseAdapter:
     """The base and the default model adapter."""
+    use_fast_flag = False
 
     def match(self, model_path: str):
         return True
@@ -45,6 +46,9 @@ class BaseAdapter:
             model_path, low_cpu_mem_usage=True, **from_pretrained_kwargs
         )
         return model, tokenizer
+    
+    def load_compress_model(self, model_path, device, torch_dtype):
+        return load_compress_model(model_path, device, torch_dtype, use_fast=self.use_fast_flag)
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("one_shot")
@@ -107,6 +111,9 @@ def load_model(
 ):
     """Load a model from Hugging Face."""
 
+    # get model adapter
+    adapter = get_model_adapter(model_path)
+
     # Handle device mapping
     cpu_offloading = raise_warning_for_incompatible_cpu_offloading_configuration(
         device, load_8bit, cpu_offloading
@@ -153,7 +160,7 @@ def load_model(
                 "8-bit quantization is not supported for multi-gpu inference."
             )
         else:
-            return load_compress_model(
+            return adapter.load_compress_model(
                 model_path=model_path, device=device, torch_dtype=kwargs["torch_dtype"]
             )
     elif gptq_config and gptq_config.wbits < 16:
@@ -250,6 +257,7 @@ def remove_parent_directory_name(model_path):
 
 class VicunaAdapter(BaseAdapter):
     "Model adapater for vicuna-v1.1"
+    use_fast_flag = False
 
     def match(self, model_path: str):
         return "vicuna" in model_path
@@ -283,6 +291,7 @@ class VicunaAdapter(BaseAdapter):
 
 class T5Adapter(BaseAdapter):
     """The model adapter for lmsys/fastchat-t5-3b-v1.0"""
+    use_fast_flag = False
 
     def match(self, model_path: str):
         return "t5" in model_path
@@ -297,6 +306,7 @@ class T5Adapter(BaseAdapter):
 
 class KoalaAdapter(BaseAdapter):
     """The model adapter for koala"""
+    use_fast_flag = False
 
     def match(self, model_path: str):
         return "koala" in model_path
@@ -317,6 +327,7 @@ class AlpacaAdapter(BaseAdapter):
 
 class ChatGLMAdapter(BaseAdapter):
     """The model adapter for THUDM/chatglm-6b"""
+    use_fast_flag = False
 
     def match(self, model_path: str):
         return "chatglm" in model_path
@@ -331,6 +342,7 @@ class ChatGLMAdapter(BaseAdapter):
 
 class DollyV2Adapter(BaseAdapter):
     """The model adapter for databricks/dolly-v2-12b"""
+    use_fast_flag = True
 
     def match(self, model_path: str):
         return "dolly-v2" in model_path
@@ -352,6 +364,7 @@ class DollyV2Adapter(BaseAdapter):
 
 class OasstPythiaAdapter(BaseAdapter):
     """The model adapter for OpenAssistant/oasst-sft-1-pythia-12b"""
+    use_fast_flag = True
 
     def match(self, model_path: str):
         return "oasst" in model_path and "pythia" in model_path
@@ -371,6 +384,7 @@ class OasstPythiaAdapter(BaseAdapter):
 
 class StableLMAdapter(BaseAdapter):
     """The model adapter for StabilityAI/stablelm-tuned-alpha-7b"""
+    use_fast_flag = True
 
     def match(self, model_path: str):
         return "stablelm" in model_path
@@ -390,6 +404,7 @@ class StableLMAdapter(BaseAdapter):
 
 class MPTAdapter(BaseAdapter):
     """The model adapter for mosaicml/mpt-7b-chat"""
+    use_fast_flag = True
 
     def match(self, model_path: str):
         return "mpt" in model_path
@@ -423,6 +438,7 @@ class BaizeAdapter(BaseAdapter):
 
 class RwkvAdapter(BaseAdapter):
     """The model adapter for BlinkDL/RWKV-4-Raven"""
+    use_fast_flag = True
 
     def match(self, model_path: str):
         return "RWKV-4" in model_path
@@ -464,6 +480,7 @@ class OpenBuddyAdapter(BaseAdapter):
 
 class PhoenixAdapter(BaseAdapter):
     """The model adapter for FreedomIntelligence/phoenix-inst-chat-7b"""
+    use_fast_flag = True
 
     def match(self, model_path: str):
         return "phoenix" in model_path
@@ -610,6 +627,7 @@ class ManticoreAdapter(BaseAdapter):
 
 class GuanacoAdapter(BaseAdapter):
     """The model adapter for timdettmers/guanaco-33b-merged"""
+    use_fast_flag = False
 
     def match(self, model_path: str):
         return "guanaco" in model_path


### PR DESCRIPTION
In this pull request, I propose an enhancement to the Dolly model by fixing the load-8bit option.

Try with:
~~~bash
python3 -m fastchat.serve.cli --model path/to/dolly-v2-12b --load-8bit
~~~