### PR TITLE
Update RedPajama 7B Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The following models are tested:
 - [StabilityAI/stablelm-tuned-alpha-7b](https://huggingface.co/stabilityai/stablelm-tuned-alpha-7b)
 - [THUDM/chatglm-6b](https://huggingface.co/THUDM/chatglm-6b)
 - [WizardLM/WizardLM-13B-V1.0](https://huggingface.co/WizardLM/WizardLM-13B-V1.0)
+- [togethercomputer/RedPajama-INCITE-7B-Chat](https://huggingface.co/togethercomputer/RedPajama-INCITE-7B-Chat)
 
 Help us [add more](https://github.com/lm-sys/FastChat/blob/main/docs/arena.md#how-to-add-a-new-model).
 

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -163,3 +163,9 @@ register_model_info(
     "https://huggingface.co/openaccess-ai-collective/manticore-13b-chat-pyg",
     "A chatbot fine-tuned from LlaMa across several CoT and chat datasets.",
 )
+register_model_info(
+    ["redpajama-incite-7b-chat"],
+    "RedPajama-INCITE-7B-Chat",
+    "https://huggingface.co/togethercomputer/RedPajama-INCITE-7B-Chat",
+    "A chatbot fine-tuned from RedPajama-INCITE-7B-Base by Together",
+)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why are these changes needed?

Together has recently released the v1 model, and we might want to update the model information accordingly. 
Model card: https://huggingface.co/togethercomputer/RedPajama-INCITE-7B-Chat
Release blog: https://www.together.xyz/blog/redpajama-7b

The redpajama adapter has already been added through #1319. Therefore, the only updates required would be to the model link and register.

I run this cmd and it works out-of-the-box.
```bash
python3 -m fastchat.serve.cli --model-path togethercomputer/RedPajama-INCITE-7B-Chat --debug
```

Please let me know if there are any other actions that need to be taken.

## Related issue number (if applicable)

NA

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
