### PR TITLE
Fix `--load-8bit` for Intel ARC GPUs

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -146,6 +146,13 @@ def load_model(
         replace_llama_attn_with_non_inplace_operations()
     elif device == "xpu":
         kwargs = {"torch_dtype": torch.bfloat16}
+        # Try to load ipex, while it looks unused, it links into torch for xpu support
+        try:
+            import intel_extension_for_pytorch as ipex
+        except ImportError:
+            warnings.warn(
+                "Intel Extension for PyTorch is not installed, but is required for xpu inference."
+            )
     else:
         raise ValueError(f"Invalid device: {device}")
 
@@ -185,12 +192,6 @@ def load_model(
         model.to(device)
 
     elif device == "xpu":
-        try:
-            import intel_extension_for_pytorch as ipex
-        except ImportError:
-            warnings.warn(
-                "Intel Extension for PyTorch is not installed, but is required for xpu inference."
-            )
         model.eval()
         model = model.to("xpu")
         model = torch.xpu.optimize(model, dtype=torch.bfloat16, inplace=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
I accidentally broke `--load-8bit` for Intel XPUs when making changes in #1677, 8bit loading makes it possible to load LLaMA 13B and probably other 13B models on 16GB Intel ARC GPUs.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)
N/A
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
