### PR TITLE
Support specifying `revision` in `load_model`

### DIFF
--- a/fastchat/model/compression.py
+++ b/fastchat/model/compression.py
@@ -99,15 +99,22 @@ def apply_compressed_weight(module, compressed_state_dict, target_device, prefix
         )
 
 
-def load_compress_model(model_path, device, torch_dtype, use_fast=False):
+def load_compress_model(
+    model_path, device, torch_dtype, use_fast=False, revision="main"
+):
     # partially load model
-    tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=use_fast)
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_path, use_fast=use_fast, revision=revision
+    )
     base_pattern = os.path.join(model_path, "pytorch_model*.bin")
     files = glob.glob(base_pattern)
 
     with init_empty_weights():
         config = AutoConfig.from_pretrained(
-            model_path, low_cpu_mem_usage=True, torch_dtype=torch_dtype
+            model_path,
+            low_cpu_mem_usage=True,
+            torch_dtype=torch_dtype,
+            revision=revision,
         )
         model = AutoModelForCausalLM.from_config(config)
         linear_weights = get_compressed_list(model)

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -42,17 +42,24 @@ class BaseAdapter:
         return True
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
+        revision = from_pretrained_kwargs.get("revision", "main")
         tokenizer = AutoTokenizer.from_pretrained(
-            model_path, use_fast=self.use_fast_tokenizer
+            model_path,
+            use_fast=self.use_fast_tokenizer,
+            revision=revision,
         )
         model = AutoModelForCausalLM.from_pretrained(
             model_path, low_cpu_mem_usage=True, **from_pretrained_kwargs
         )
         return model, tokenizer
 
-    def load_compress_model(self, model_path, device, torch_dtype):
+    def load_compress_model(self, model_path, device, torch_dtype, revision="main"):
         return load_compress_model(
-            model_path, device, torch_dtype, use_fast=self.use_fast_tokenizer
+            model_path,
+            device,
+            torch_dtype,
+            use_fast=self.use_fast_tokenizer,
+            revision=revision,
         )
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
@@ -112,6 +119,7 @@ def load_model(
     load_8bit: bool = False,
     cpu_offloading: bool = False,
     gptq_config: Optional[GptqConfig] = None,
+    revision: str = "main",
     debug: bool = False,
 ):
     """Load a model from Hugging Face."""
@@ -168,7 +176,10 @@ def load_model(
             )
         else:
             return adapter.load_compress_model(
-                model_path=model_path, device=device, torch_dtype=kwargs["torch_dtype"]
+                model_path=model_path,
+                device=device,
+                torch_dtype=kwargs["torch_dtype"],
+                revision=revision,
             )
     elif gptq_config and gptq_config.wbits < 16:
         return load_gptq_quantized(
@@ -176,6 +187,7 @@ def load_model(
             gptq_config,
             device=device,
         )
+    kwargs["revision"] = revision
 
     # Load model
     adapter = get_model_adapter(model_path)
@@ -212,6 +224,12 @@ def add_model_args(parser):
         type=str,
         default="lmsys/fastchat-t5-3b-v1.0",
         help="The path to the weights. This can be a local folder or a Hugging Face repo ID.",
+    )
+    parser.add_argument(
+        "--revision",
+        type=str,
+        default="main",
+        help="Hugging Face Hub model revision identifier",
     )
     parser.add_argument(
         "--device",
@@ -280,7 +298,10 @@ class VicunaAdapter(BaseAdapter):
         return "vicuna" in model_path
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
-        tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=False)
+        revision = from_pretrained_kwargs.get("revision", "main")
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_path, use_fast=False, revision=revision
+        )
         model = AutoModelForCausalLM.from_pretrained(
             model_path,
             low_cpu_mem_usage=True,
@@ -313,7 +334,10 @@ class T5Adapter(BaseAdapter):
         return "t5" in model_path
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
-        tokenizer = T5Tokenizer.from_pretrained(model_path, use_fast=False)
+        revision = from_pretrained_kwargs.get("revision", "main")
+        tokenizer = T5Tokenizer.from_pretrained(
+            model_path, use_fast=False, revision=revision
+        )
         model = AutoModelForSeq2SeqLM.from_pretrained(
             model_path, low_cpu_mem_usage=True, **from_pretrained_kwargs
         )
@@ -347,7 +371,10 @@ class ChatGLMAdapter(BaseAdapter):
         return "chatglm" in model_path
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
-        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+        revision = from_pretrained_kwargs.get("revision", "main")
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_path, trust_remote_code=True, revision=revision
+        )
         model = AutoModel.from_pretrained(
             model_path, trust_remote_code=True, **from_pretrained_kwargs
         )
@@ -363,7 +390,10 @@ class DollyV2Adapter(BaseAdapter):
         return "dolly-v2" in model_path
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
-        tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=True)
+        revision = from_pretrained_kwargs.get("revision", "main")
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_path, use_fast=True, revision=revision
+        )
         model = AutoModelForCausalLM.from_pretrained(
             model_path,
             low_cpu_mem_usage=True,
@@ -410,6 +440,7 @@ class MPTAdapter(BaseAdapter):
         return "mpt" in model_path
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
+        revision = from_pretrained_kwargs.get("revision", "main")
         model = AutoModelForCausalLM.from_pretrained(
             model_path,
             low_cpu_mem_usage=True,
@@ -418,7 +449,7 @@ class MPTAdapter(BaseAdapter):
             **from_pretrained_kwargs,
         )
         tokenizer = AutoTokenizer.from_pretrained(
-            model_path, trust_remote_code=True, use_fast=True
+            model_path, trust_remote_code=True, use_fast=True, revision=revision
         )
         return model, tokenizer
 
@@ -448,8 +479,9 @@ class RwkvAdapter(BaseAdapter):
         from fastchat.model.rwkv_model import RwkvModel
 
         model = RwkvModel(model_path)
+        revision = from_pretrained_kwargs.get("revision", "main")
         tokenizer = AutoTokenizer.from_pretrained(
-            "EleutherAI/pythia-160m", use_fast=True
+            "EleutherAI/pythia-160m", use_fast=True, revision=revision
         )
         return model, tokenizer
 
@@ -472,7 +504,8 @@ class OpenBuddyAdapter(BaseAdapter):
         model = LlamaForCausalLM.from_pretrained(
             model_path, low_cpu_mem_usage=True, **from_pretrained_kwargs
         )
-        tokenizer = LlamaTokenizer.from_pretrained(model_path)
+        revision = from_pretrained_kwargs.get("revision", "main")
+        tokenizer = LlamaTokenizer.from_pretrained(model_path, revision=revision)
         return model, tokenizer
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
@@ -560,7 +593,10 @@ class RedPajamaINCITEAdapter(BaseAdapter):
         return "redpajama-incite" in model_path.lower()
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
-        tokenizer = AutoTokenizer.from_pretrained(model_path)  # no use_fast=False
+        revision = from_pretrained_kwargs.get("revision", "main")
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_path, revision=revision
+        )  # no use_fast=False
         model = AutoModelForCausalLM.from_pretrained(
             model_path,
             low_cpu_mem_usage=True,
@@ -625,7 +661,10 @@ class GuanacoAdapter(BaseAdapter):
         return "guanaco" in model_path
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
-        tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=False)
+        revision = from_pretrained_kwargs.get("revision", "main")
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_path, use_fast=False, revision=revision
+        )
         model = AutoModelForCausalLM.from_pretrained(
             model_path, low_cpu_mem_usage=True, **from_pretrained_kwargs
         )

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -180,6 +180,7 @@ def main(args):
                 groupsize=args.gptq_groupsize,
                 act_order=args.gptq_act_order,
             ),
+            args.revision,
             args.debug,
         )
     except KeyboardInterrupt:

--- a/fastchat/serve/huggingface_api.py
+++ b/fastchat/serve/huggingface_api.py
@@ -23,6 +23,7 @@ def main(args):
         args.max_gpu_memory,
         args.load_8bit,
         args.cpu_offloading,
+        revision=args.revision,
         debug=args.debug,
     )
 

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -259,6 +259,7 @@ def chat_loop(
     max_new_tokens: int,
     chatio: ChatIO,
     gptq_config: GptqConfig,
+    revision: str,
     debug: bool,
 ):
     # Model
@@ -270,6 +271,7 @@ def chat_loop(
         load_8bit,
         cpu_offloading,
         gptq_config,
+        revision,
         debug,
     )
     is_chatglm = "chatglm" in str(type(model)).lower()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

I've added support for the `revision` parameter in `load_model` and `load_compress_model`. It explicitly defaults to `"main"`, which is also the default in Huggingface `from_pretrained` methods. I believe all of the changes are backwards compatible.

I didn't touch the model loading part in `ModelWorker` because the distinction of `model_path` and `model_names` was unclear to me. Please advise.

## Why are these changes needed?

A couple hours ago `mosaicml/mpt-7b-chat` introduced a commit (f9cc150) in its `main` branch that broke inference. (Raises `RuntimeError: expected scalar type Half but found Float` on my A40 GPU machine.) Reverting back to the previous commit (revision) solves the issue for now.
Even without this incident, I do believe that there is sufficient reason to allow users to fix the `revision` of their Hugging Face pretrained models.
I think it'll also make sense for the Vicuna Leaderboard, since you don't want model weights to silently update. It might be better if you post the revision IDs alongside model names so that leaderboard results are clearer and more reproducible.

## Checks

- [x] I've run `format.sh` to lint the changes in this PR. ==> `pylint` screams horribly and I think CI is just running `black`. So I also just ran `black`.
- [x] I've included any doc changes needed. ==> I don't think any was needed, but please correct me if I was wrong.
- [x] I've made sure the relevant tests are passing (if applicable). ==> I don't think there are relevant tests, but I tried the following commands manually and they worked as expected.
  - `python -m fastchat.serve.cli --model-path mosaicml/mpt-7b-chat` (Dies with dtype error)
  - `python -m fastchat.serve.cli --model-path mosaicml/mpt-7b-chat --revision main` (Dies with dtype error)
  - `python -m fastchat.serve.cli --model-path mosaicml/mpt-7b-chat --revision bb4873bde98b60ef1c40d4c6c9729fe95de7dcbf`
  - `python -m fastchat.serve.cli --model-path mosaicml/mpt-7b-chat --revision bb4873bde98b60e`
  - `python -m fastchat.serve.cli --model-path databricks/dolly-v2-12b`
  - `python -m fastchat.serve.cli --model-path lmsys/fastchat-t5-3b-v1.0`
  - `python -m fastchat.serve.cli --model-path weights/llama/7B`
  - `python -m fastchat.serve.cli --model-path weights/vicuna/13B`
  - `python -m fastchat.serve.cli --model-path weights/vicuna/13B  --load-8bit`