### PR TITLE
Add Multi Line Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ python3 -m fastchat.serve.cli --model-path lmsys/fastchat-t5-3b-v1.0
 
 <a href="https://chat.lmsys.org"><img src="assets/screenshot_cli.png" width="70%"></a>
 
-(Experimental Feature: You can specify `--style rich` to enable rich text output and better text streaming quality for some non-ASCII content. This may not work properly on certain terminals. Adding `--multiline` in rich text mode will also enable multiline input, use `ESC+Enter` to submit.)
+(Experimental Feature: You can specify `--style rich` to enable rich text output and better text streaming quality for some non-ASCII content. This may not work properly on certain terminals. Adding `--multiline` in rich text mode will also enable multiline input and mouse support, use `ESC+Enter` to submit.)
 
 #### Supported Models
 FastChat supports a wide range of models, including

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ python3 -m fastchat.serve.cli --model-path lmsys/fastchat-t5-3b-v1.0
 
 <a href="https://chat.lmsys.org"><img src="assets/screenshot_cli.png" width="70%"></a>
 
-(Experimental Feature: You can specify `--style rich` to enable rich text output and better text streaming quality for some non-ASCII content. This may not work properly on certain terminals.)```
+(Experimental Feature: You can specify `--style rich` to enable rich text output and better text streaming quality for some non-ASCII content. This may not work properly on certain terminals.)
 
 #### Supported Models
 FastChat supports a wide range of models, including

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ python3 -m fastchat.serve.cli --model-path lmsys/fastchat-t5-3b-v1.0
 
 <a href="https://chat.lmsys.org"><img src="assets/screenshot_cli.png" width="70%"></a>
 
-(Experimental Feature: You can specify `--style rich` to enable rich text output and better text streaming quality for some non-ASCII content. This may not work properly on certain terminals. Adding `--multiline` in rich text mode will also enable multiline input and mouse support, use `ESC+Enter` to submit.)
+(Experimental Feature: You can specify `--style rich` to enable rich text output and better text streaming quality for some non-ASCII content. This may not work properly on certain terminals.)```
 
 #### Supported Models
 FastChat supports a wide range of models, including

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ python3 -m fastchat.serve.cli --model-path lmsys/fastchat-t5-3b-v1.0
 
 <a href="https://chat.lmsys.org"><img src="assets/screenshot_cli.png" width="70%"></a>
 
-(Experimental Feature: You can specify `--style rich` to enable rich text output and better text streaming quality for some non-ASCII content. This may not work properly on certain terminals.)
+(Experimental Feature: You can specify `--style rich` to enable rich text output and better text streaming quality for some non-ASCII content. This may not work properly on certain terminals. Adding `--multiline` in rich text mode will also enable multiline input, use `ESC+Enter` to submit.)
 
 #### Supported Models
 FastChat supports a wide range of models, including

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -48,19 +48,20 @@ class SimpleChatIO(ChatIO):
 
 
 class RichChatIO(ChatIO):
-    def __init__(self):
+    def __init__(self, multiline: bool = False):
         self._prompt_session = PromptSession(history=InMemoryHistory())
         self._completer = WordCompleter(
             words=["!!exit", "!!reset"], pattern=re.compile("$")
         )
         self._console = Console()
+        self._multiline = multiline
 
     def prompt_for_input(self, role) -> str:
         self._console.print(f"[bold]{role}:")
         # TODO(suquark): multiline input has some issues. fix it later.
         prompt_input = self._prompt_session.prompt(
             completer=self._completer,
-            multiline=False,
+            multiline=self._multiline,
             auto_suggest=AutoSuggestFromHistory(),
             key_bindings=None,
         )
@@ -156,7 +157,7 @@ def main(args):
     if args.style == "simple":
         chatio = SimpleChatIO()
     elif args.style == "rich":
-        chatio = RichChatIO()
+        chatio = RichChatIO(args.multiline)
     elif args.style == "programmatic":
         chatio = ProgrammaticChatIO()
     else:
@@ -202,6 +203,11 @@ if __name__ == "__main__":
         default="simple",
         choices=["simple", "rich", "programmatic"],
         help="Display style.",
+    )
+    parser.add_argument(
+        "--multiline",
+        action="store_true",
+        help="Enable multiline input. Only works for rich style. Use ESC+Enter to submit.",
     )
     parser.add_argument(
         "--debug",

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -62,6 +62,7 @@ class RichChatIO(ChatIO):
         prompt_input = self._prompt_session.prompt(
             completer=self._completer,
             multiline=self._multiline,
+            mouse_support=self._multiline,  # Enable mouse support when using multiline
             auto_suggest=AutoSuggestFromHistory(),
             key_bindings=None,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There's currently no way to enter a new line from the CLI without pasting in a newline, while I would like to use shift enter in the future (like the web ui), prompt_toolkit's multi line will do for now.

prompt_toolkit uses `Enter` for a new line, and `ESC+Enter` to submit (or apparently `Meta+Enter` but that doesn't work for me).

Multi line can be enabled using the `--multiline` option.

I don't know what issues @suquark was facing, but if there are any issues, multi line isn't enabled by default.
https://github.com/lm-sys/FastChat/blob/edef7de820dc4eccf0237b4c1ca7f22bcce7d223/fastchat/serve/cli.py#L60

Also I've enabled mouse support when multi line is enabled, to make is easier to jump between multiple lines, but the cursor keys still work too.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)
Closes #526
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
