### PR TITLE
Update get_gen_params func in openai_api_server to fix stop criteria 

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -243,6 +243,8 @@ async def get_gen_params(
         sep_style=SeparatorStyle(conv["sep_style"]),
         sep=conv["sep"],
         sep2=conv["sep2"],
+        stop_str=conv["stop_str"],
+        stop_token_ids=conv["stop_token_ids"],
     )
 
     if isinstance(messages, str):


### PR DESCRIPTION
the conversation object has a recreation, but missing params of stop_str and stop_token_ids, which will lead to unstoppable issue in serving

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
