### PR TITLE
Change Keybinds for Multi Line Input in CLI

### DIFF
--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -18,6 +18,7 @@ from prompt_toolkit import PromptSession
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.history import InMemoryHistory
+from prompt_toolkit.key_binding import KeyBindings
 from rich.console import Console
 from rich.live import Live
 from rich.markdown import Markdown
@@ -48,6 +49,12 @@ class SimpleChatIO(ChatIO):
 
 
 class RichChatIO(ChatIO):
+    bindings = KeyBindings()
+
+    @bindings.add("escape", "enter")
+    def _(event):
+        event.app.current_buffer.newline()
+
     def __init__(self, multiline: bool = False):
         self._prompt_session = PromptSession(history=InMemoryHistory())
         self._completer = WordCompleter(
@@ -61,10 +68,10 @@ class RichChatIO(ChatIO):
         # TODO(suquark): multiline input has some issues. fix it later.
         prompt_input = self._prompt_session.prompt(
             completer=self._completer,
-            multiline=self._multiline,
+            multiline=False,
             mouse_support=self._multiline,  # Enable mouse support when using multiline
             auto_suggest=AutoSuggestFromHistory(),
-            key_bindings=None,
+            key_bindings=self.bindings if self._multiline else None,
         )
         self._console.print()
         return prompt_input
@@ -208,7 +215,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--multiline",
         action="store_true",
-        help="Enable multiline input. Only works for rich style. Use ESC+Enter to submit.",
+        help="Enable multiline input. Only works for rich style. Use ESC+Enter for newline.",
     )
     parser.add_argument(
         "--debug",

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -55,13 +55,14 @@ class RichChatIO(ChatIO):
     def _(event):
         event.app.current_buffer.newline()
 
-    def __init__(self, multiline: bool = False):
+    def __init__(self, multiline: bool = False, mouse: bool = False):
         self._prompt_session = PromptSession(history=InMemoryHistory())
         self._completer = WordCompleter(
             words=["!!exit", "!!reset"], pattern=re.compile("$")
         )
         self._console = Console()
         self._multiline = multiline
+        self._mouse = mouse
 
     def prompt_for_input(self, role) -> str:
         self._console.print(f"[bold]{role}:")
@@ -69,7 +70,7 @@ class RichChatIO(ChatIO):
         prompt_input = self._prompt_session.prompt(
             completer=self._completer,
             multiline=False,
-            mouse_support=self._multiline,  # Enable mouse support when using multiline
+            mouse_support=self._mouse,
             auto_suggest=AutoSuggestFromHistory(),
             key_bindings=self.bindings if self._multiline else None,
         )
@@ -165,7 +166,7 @@ def main(args):
     if args.style == "simple":
         chatio = SimpleChatIO()
     elif args.style == "rich":
-        chatio = RichChatIO(args.multiline)
+        chatio = RichChatIO(args.multiline, args.mouse)
     elif args.style == "programmatic":
         chatio = ProgrammaticChatIO()
     else:
@@ -215,7 +216,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--multiline",
         action="store_true",
-        help="Enable multiline input. Only works for rich style. Use ESC+Enter for newline.",
+        help="[Rich Style]: Enable multiline input. Use ESC+Enter for newline.",
+    )
+    parser.add_argument(
+        "--mouse",
+        action="store_true",
+        help="[Rich Style]: Enable mouse support for cursor positioning.",
     )
     parser.add_argument(
         "--debug",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Swap ESC + Enter to be new line instead of submit for UX reasons.

Also make `--mouse` an option since enabling mouse support disables the right click context menu in some terminal emulators.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)
N/A
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
