### PR TITLE
Update model_adapter.py add config to tokenizer loading

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -147,7 +147,8 @@ def load_model(
                     for i in range(num_gpus)
                 }
             else:
-                kwargs["max_memory"] = {i: max_gpu_memory for i in range(num_gpus)}
+                kwargs["max_memory"] = {
+                    i: max_gpu_memory for i in range(num_gpus)}
     elif device == "mps":
         kwargs = {"torch_dtype": torch.float16}
         # Avoid bugs in mps backend by not using in-place operations.
@@ -506,7 +507,8 @@ class OpenBuddyAdapter(BaseModelAdapter):
             model_path, low_cpu_mem_usage=True, **from_pretrained_kwargs
         )
         revision = from_pretrained_kwargs.get("revision", "main")
-        tokenizer = LlamaTokenizer.from_pretrained(model_path, revision=revision)
+        tokenizer = LlamaTokenizer.from_pretrained(
+            model_path, revision=revision)
         return model, tokenizer
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
@@ -529,7 +531,7 @@ class ChatGPTAdapter(BaseModelAdapter):
     """The model adapter for ChatGPT"""
 
     def match(self, model_path: str):
-        return model_path == "gpt-3.5-turbo" or model_path == "gpt-4"
+        return model_path in ("gpt-3.5-turbo", "gpt-4")
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
         raise NotImplementedError()
@@ -748,7 +750,10 @@ class TigerBotAdapter(BaseModelAdapter):
         revision = from_pretrained_kwargs.get("revision", "main")
         config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
         tokenizer = AutoTokenizer.from_pretrained(
-            model_path, config=config, trust_remote_code=True, revision=revision
+            model_path,
+            config=config,
+            trust_remote_code=True,
+            revision=revision,
         )
         model = AutoModelForCausalLM.from_pretrained(
             model_path,
@@ -771,14 +776,17 @@ class BaichuanAdapter(BaseModelAdapter):
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
         config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
-        tokenizer = AutoTokenizer.from_pretrained(model_path, config=config, trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_path,
+            config=config,
+            trust_remote_code=True
+        )
         model = AutoModelForCausalLM.from_pretrained(
             model_path,
             config=config,
-            torch_dtype=torch.float16,
             trust_remote_code=True,
-            device_map="auto",
             low_cpu_mem_usage=True,
+            **from_pretrained_kwargs,
         )
         return model, tokenizer
 

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -728,7 +728,7 @@ class FalconAdapter(BaseModelAdapter):
             trust_remote_code=True,
             **from_pretrained_kwargs,
         )
-        tokenizer = AutoTokenizer.from_pretrained(model_path)
+        tokenizer = AutoTokenizer.from_pretrained(model_path, config=config)
         # In Falcon tokenizer config and special config there is not any pad token
         # Setting `pad_token_id` to 9, which corresponds to special token '>>SUFFIX<<'
         tokenizer.pad_token_id = 9
@@ -746,10 +746,10 @@ class TigerBotAdapter(BaseModelAdapter):
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
         revision = from_pretrained_kwargs.get("revision", "main")
-        tokenizer = AutoTokenizer.from_pretrained(
-            model_path, trust_remote_code=True, revision=revision
-        )
         config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_path, config=config, trust_remote_code=True, revision=revision
+        )
         model = AutoModelForCausalLM.from_pretrained(
             model_path,
             config=config,
@@ -770,8 +770,8 @@ class BaichuanAdapter(BaseModelAdapter):
         return "baichuan" in model_path
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
-        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
         config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(model_path, config=config, trust_remote_code=True)
         model = AutoModelForCausalLM.from_pretrained(
             model_path,
             config=config,


### PR DESCRIPTION
If the loading of the model and tokenizer requires the use of remote code and configuration files in the path, both model loading and tokenizer loading are required to pass in the config to avoid word crossing

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
