### PR TITLE
Fix bug of Alpaca Prompt template

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -289,8 +289,9 @@ register_conv_template(
         roles=("### Instruction", "### Response"),
         messages=(),
         offset=0,
-        sep_style=SeparatorStyle.ADD_COLON_SINGLE,
+        sep_style=SeparatorStyle.ADD_COLON_TWO,
         sep="\n\n",
+        sep2="</s>",
     )
 )
 


### PR DESCRIPTION
Fixing error in Alpaca template causing empty sep2.
Calling preprocess during training resulted in exceptions while splitting dialogues.
Even after disabling conversationn splitting, it caused missing </s> compared to Viucna's template, triggering warnings and resulting in data loss.

## Why are these changes needed?

adjust the conversation template of Alpaca

## Related issue number (if applicable)

None

## Checks

- [ x] I've run `format.sh` to lint the changes in this PR.
- [ x] I've included any doc changes needed.
- [ x] I've made sure the relevant tests are passing (if applicable).
