### PR TITLE
fix: no test_openai_sdk, change to test_openai_api

### DIFF
--- a/docs/openai_api.md
+++ b/docs/openai_api.md
@@ -60,7 +60,7 @@ completion = openai.ChatCompletion.create(
 print(completion.choices[0].message.content)
 ```
 
-Streaming is also supported. See [test_openai_sdk.py](../tests/test_openai_sdk.py).
+Streaming is also supported. See [test_openai_api.py](../tests/test_openai_api.py).
 
 ### cURL
 cURL is another good tool for observing the output of the api.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
![image](https://github.com/lm-sys/FastChat/assets/6478745/bbc384dd-04aa-450b-bc14-cfd6cfeb6abd)
no test_openai_sdk.py files in tests dir, most matched file is test_openai_api.py, and i found openai stream examples in this file.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
