### PR TITLE
Adding a PeftModelAdapter for loading any peft trained weights

### DIFF
--- a/docs/model_support.md
+++ b/docs/model_support.md
@@ -25,6 +25,7 @@
 - [togethercomputer/RedPajama-INCITE-7B-Chat](https://huggingface.co/togethercomputer/RedPajama-INCITE-7B-Chat)
 - [WizardLM/WizardLM-13B-V1.0](https://huggingface.co/WizardLM/WizardLM-13B-V1.0)
 - [baichuan-inc/baichuan-7B](https://huggingface.co/baichuan-inc/baichuan-7B)
+- Any [Peft](https://github.com/huggingface/peft) adapter trained ontop of a model above.  To activate, must have `peft` in the model path.
 
 ## How to support a new model
 

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -13,6 +13,7 @@ else:
 import psutil
 import torch
 
+from peft import PeftConfig, PeftModel
 from transformers import (
     AutoConfig,
     AutoModel,
@@ -290,6 +291,40 @@ def remove_parent_directory_name(model_path):
     if model_path[-1] == "/":
         model_path = model_path[:-1]
     return model_path.split("/")[-1]
+
+
+class PeftModelAdapter:
+    """Loads any "peft" model and it's base model."""
+
+    def match(self, model_path: str):
+        """Accepts any model path with "peft" in the name"""
+        return "peft" in model_path
+
+    def load_model(self, model_path: str, from_pretrained_kwargs: dict):
+        """Loads the base model then the (peft) adapter weights"""
+        config = PeftConfig.from_pretrained(model_path)
+        base_model_path = config.base_model_name_or_path
+        if "peft" in base_model_path:
+            raise ValueError(
+                f"PeftModelAdapter cannot load a base model with 'peft' in the name: {config.base_model_name_or_path}"
+            )
+
+        base_adapter = get_model_adapter(base_model_path)
+        base_model, tokenizer = base_adapter.load_momdel(
+            base_model_path, from_pretrained_kwargs
+        )
+        model = PeftModel.from_pretrained(model, model_path)
+
+        return model, tokenizer
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        """Uses the conv template of the base model"""
+        config = PeftConfig.from_pretrained(model_path)
+        if "peft" in config.base_model_name_or_path:
+            raise ValueError(
+                f"PeftModelAdapter cannot load a base model with 'peft' in the name: {config.base_model_name_or_path}"
+            )
+        return get_conv_template(config.base_model_name_or_path)
 
 
 class VicunaAdapter(BaseModelAdapter):
@@ -834,6 +869,7 @@ class BaichuanAdapter(BaseModelAdapter):
 
 # Note: the registration order matters.
 # The one registered earlier has a higher matching priority.
+register_model_adapter(PeftModelAdapter)
 register_model_adapter(VicunaAdapter)
 register_model_adapter(T5Adapter)
 register_model_adapter(KoalaAdapter)

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -310,7 +310,7 @@ class PeftModelAdapter:
             )
 
         base_adapter = get_model_adapter(base_model_path)
-        base_model, tokenizer = base_adapter.load_momdel(
+        base_model, tokenizer = base_adapter.load_model(
             base_model_path, from_pretrained_kwargs
         )
         model = PeftModel.from_pretrained(model, model_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
     "accelerate", "fastapi", "gradio==3.35.2", "httpx", "markdown2[all]", "nh3", "numpy",
-    "prompt_toolkit>=3.0.0", "pydantic", "requests", "rich>=10.0.0", "sentencepiece",
+    "peft", "prompt_toolkit>=3.0.0", "pydantic", "requests", "rich>=10.0.0", "sentencepiece",
     "shortuuid", "shortuuid", "tiktoken", "tokenizers>=0.12.1", "torch",
     "transformers>=4.28.0,<4.29.0", "uvicorn", "wandb",
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In some scenarios it's desirable to load the Peft adapter weights and base model weights separately (without merging them).  This enables that for properly named models.

<!-- Please give a short summary of the change and the problem this solves. -->
Adds a new high level ModelAdapter that loads a base model weights and then any Peft adapter weights.

## Related issue number (if applicable)
Fixes #1806 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).

I've also tested this manually in a docker instance with a Peft model i've fined tuned.  Everything worked smoothly.
