### PR TITLE
Ensure the PeftModelAdapter loads the base models convo loader

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -327,7 +327,8 @@ class PeftModelAdapter:
             raise ValueError(
                 f"PeftModelAdapter cannot load a base model with 'peft' in the name: {config.base_model_name_or_path}"
             )
-        return get_conv_template(config.base_model_name_or_path)
+        base_adapter = get_model_adapter(config.base_model_name_or_path)
+        return base_adapter.get_default_conv_template(config.base_model_name_or_path)
 
 
 class VicunaAdapter(BaseModelAdapter):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This fixes yet another small issue in the PeftModelAdapter, it previously wasn't loading the default convo loader correctly.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->
Fixes https://github.com/lm-sys/FastChat/issues/1806

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).

I can confirm I actually ran this locally this time.  Previous PRs ran a fork of this code that I lost when a machine got unexpectedly shut down.