### PR TITLE
fix wrong conversation template for peft models

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -323,11 +323,14 @@ class PeftModelAdapter:
         from peft import PeftConfig, PeftModel
 
         config = PeftConfig.from_pretrained(model_path)
+        base_model_path = config.base_model_name_or_path
         if "peft" in config.base_model_name_or_path:
             raise ValueError(
                 f"PeftModelAdapter cannot load a base model with 'peft' in the name: {config.base_model_name_or_path}"
             )
-        return get_conv_template(config.base_model_name_or_path)
+        base_model_path = config.base_model_name_or_path
+        base_adapter = get_model_adapter(base_model_path)
+        return base_adapter.get_default_conv_template(config.base_model_name_or_path)
 
 
 class VicunaAdapter(BaseModelAdapter):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When using the peft model adapter, we cannot get the conversation template.
<!-- Please give a short summary of the change and the problem this solves. -->
In the change, I first get the base model adapter and use its method for getting the default conversation template to get the correct template.
## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [yes ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
