### PR TITLE
Ensure the peft model adapter returns the right conversation template for chatting

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -323,11 +323,14 @@ class PeftModelAdapter:
         from peft import PeftConfig, PeftModel
 
         config = PeftConfig.from_pretrained(model_path)
+        base_model_path = config.base_model_name_or_path
         if "peft" in config.base_model_name_or_path:
             raise ValueError(
                 f"PeftModelAdapter cannot load a base model with 'peft' in the name: {config.base_model_name_or_path}"
             )
-        return get_conv_template(config.base_model_name_or_path)
+        base_model_path = config.base_model_name_or_path
+        base_adapter = get_model_adapter(base_model_path)
+        return base_adapter.get_default_conv_template(config.base_model_name_or_path)
 
 
 class VicunaAdapter(BaseModelAdapter):

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -323,7 +323,6 @@ class PeftModelAdapter:
         from peft import PeftConfig, PeftModel
 
         config = PeftConfig.from_pretrained(model_path)
-        base_model_path = config.base_model_name_or_path
         if "peft" in config.base_model_name_or_path:
             raise ValueError(
                 f"PeftModelAdapter cannot load a base model with 'peft' in the name: {config.base_model_name_or_path}"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Current version gives invalid key for "get_conv_template", modified versions can give the valid conversation template.
<!-- Please give a short summary of the change and the problem this solves. -->
I changed the method to return the base adapter's default conversation template so that the peft model can be used normally.
## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ yes] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ yes] I've made sure the relevant tests are passing (if applicable).
