### PR TITLE
Revert "Improve SSE User Experience"

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -22,7 +22,6 @@ from fastapi.responses import StreamingResponse, JSONResponse
 from fastapi.security.http import HTTPAuthorizationCredentials, HTTPBearer
 import httpx
 from pydantic import BaseSettings
-from sse_starlette.sse import EventSourceResponse
 import shortuuid
 import tiktoken
 import uvicorn
@@ -470,7 +469,7 @@ async def create_completion(request: CompletionRequest):
 
     if request.stream:
         generator = generate_completion_stream_generator(request, request.n)
-        return EventSourceResponse(response_stream, ping=600)
+        return StreamingResponse(generator, media_type="text/event-stream")
     else:
         text_completions = []
         for text in request.prompt:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "accelerate", "fastapi", "gradio==3.35.2", "httpx", "markdown2[all]", "nh3", "numpy",
     "peft", "prompt_toolkit>=3.0.0", "pydantic", "requests", "rich>=10.0.0", "sentencepiece",
     "shortuuid", "shortuuid", "tiktoken", "tokenizers>=0.12.1", "torch",
-    "transformers>=4.28.0,<4.29.0", "uvicorn", "wandb", "sse-starlette",
+    "transformers>=4.28.0,<4.29.0", "uvicorn", "wandb",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Reverts lm-sys/FastChat#1223.

I tested it with https://github.com/lm-sys/FastChat/blob/fcf88ff0259a2a735a52fef091090204b302895a/tests/test_openai_api.py#L1-L3 but meet the following errors
```
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/envs/fastchat/lib/python3.9/site-packages/openai/api_requestor.py", line 335, in handle_error_response
    error_data = resp["error"]
TypeError: string indices must be integers

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/FastChat/tests/test_openai_api.py", line 107, in <module>
    test_completion_stream(model)
  File "/home/ubuntu/FastChat/tests/test_openai_api.py", line 30, in test_completion_stream
    res = openai.Completion.create(
  File "/home/ubuntu/anaconda3/envs/fastchat/lib/python3.9/site-packages/openai/api_resources/completion.py", line 25, in create
    return super().create(*args, **kwargs)
  File "/home/ubuntu/anaconda3/envs/fastchat/lib/python3.9/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 153, in create
    response, _, api_key = requestor.request(
  File "/home/ubuntu/anaconda3/envs/fastchat/lib/python3.9/site-packages/openai/api_requestor.py", line 230, in request
    resp, got_stream = self._interpret_response(result, stream)
  File "/home/ubuntu/anaconda3/envs/fastchat/lib/python3.9/site-packages/openai/api_requestor.py", line 624, in _interpret_response
    self._interpret_response_line(
  File "/home/ubuntu/anaconda3/envs/fastchat/lib/python3.9/site-packages/openai/api_requestor.py", line 687, in _interpret_response_line
    raise self.handle_error_response(
  File "/home/ubuntu/anaconda3/envs/fastchat/lib/python3.9/site-packages/openai/api_requestor.py", line 337, in handle_error_response
    raise error.APIError(
openai.error.APIError: Invalid response object from API: 'Internal Server Error' (HTTP response code was 500)
```