### PR TITLE
Switch MPT model to load zero shot in default scenario

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -621,7 +621,11 @@ class MPTAdapter(BaseModelAdapter):
         elif "mpt-30b-instruct" in model_path:
             return get_conv_template("mpt-30b-instruct")
         else:
-            raise ValueError(f"Unknown MPT model: {model_path}")
+            print(
+                "Warning: Loading base MPT model with `zero_shot` conversation configuration.  "
+                "If this is not desired, inspect model configurations and names."
+            )
+            return get_conv_template("zero_shot")
 
 
 class BaizeAdapter(BaseModelAdapter):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
With Peft models added, its likely others (namely myself) will be training adapters on base models.  In order to load the base model, it should load some reasonable conversation template.  This ensures any MPT Peft model loads the `zero_shot` conversation template rather than crashing.

## Related issue number (if applicable)

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
