### PR TITLE
Remove winrate on the leaderboard

### DIFF
--- a/fastchat/serve/monitor/monitor.py
+++ b/fastchat/serve/monitor/monitor.py
@@ -34,7 +34,7 @@ def make_leaderboard_md(elo_results):
 - [MT-Bench](https://arxiv.org/abs/2306.05685) - a set of challenging multi-turn questions. We use GPT-4 to grade the model responses.
 - [MMLU](https://arxiv.org/abs/2009.03300) (5-shot) - a test to measure a model's multitask accuracy on 57 tasks.
 
-💻 We use [fastchat.llm_judge](https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge) to compute MT-bench scores (single-answer grading on a scale of 10) and win rates (against gpt-3.5). The Arena Elo ratings are computed by this [notebook]({notebook_url}). The MMLU scores are computed by [InstructEval](https://github.com/declare-lab/instruct-eval) and [Chain-of-Thought Hub](https://github.com/FranxYao/chain-of-thought-hub). Higher values are better for all benchmarks. Empty cells mean not available.
+💻 We use [fastchat.llm_judge](https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge) to compute MT-bench scores (single-answer grading on a scale of 10). The Arena Elo ratings are computed by this [notebook]({notebook_url}). The MMLU scores are computed by [InstructEval](https://github.com/declare-lab/instruct-eval) and [Chain-of-Thought Hub](https://github.com/FranxYao/chain-of-thought-hub). Higher values are better for all benchmarks. Empty cells mean not available.
 """
     return leaderboard_md
 
@@ -183,7 +183,6 @@ def build_leaderboard_tab(elo_results_file, leaderboard_table_file):
             "Model",
             "Arena Elo rating",
             "MT-bench (score)",
-            "MT-bench (win rate %)",
             "MMLU",
             "License",
         ]


### PR DESCRIPTION
As now we recommend score-based single-answer grading for MT-bench (https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge#step-2-generate-gpt-4-judgments), we remove the win rate on the leaderboard to avoid confusion.
