### PR TITLE
chore: set pydantic<=2.0 since greater has breaking change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
     "accelerate", "fastapi", "gradio==3.35.2", "httpx", "markdown2[all]", "nh3", "numpy",
-    "peft", "prompt_toolkit>=3.0.0", "pydantic", "requests", "rich>=10.0.0", "sentencepiece",
+    "peft", "prompt_toolkit>=3.0.0", "pydantic<=2.0", "requests", "rich>=10.0.0", "sentencepiece",
     "shortuuid", "shortuuid", "tiktoken", "tokenizers>=0.12.1", "torch",
     "transformers>=4.28.0,<4.29.0", "uvicorn", "wandb",
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Although not listed, pydantic 2.0.2 has breaking change: 
https://docs.pydantic.dev/2.0/migration/#basesettings-has-moved-to-pydantic-settings
https://github.com/pydantic/pydantic/releases

This sets pydantic version to <=2.0 so that it works as before 
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).


## POC
### Before change:
![image](https://github.com/lm-sys/FastChat/assets/459925/f38146e5-8818-4aeb-8de2-8b161f8455bc)

### After change:
![image](https://github.com/lm-sys/FastChat/assets/459925/bbc0ab49-b2a7-4498-a345-9a67aa551fe9)


