### PR TITLE
Allow Peft models to share their base model

### DIFF
--- a/docs/model_support.md
+++ b/docs/model_support.md
@@ -30,7 +30,11 @@
 - [baichuan-inc/baichuan-7B](https://huggingface.co/baichuan-inc/baichuan-7B)
 - [internlm/internlm-chat-7b](https://huggingface.co/internlm/internlm-chat-7b)
 - Any [EleutherAI](https://huggingface.co/EleutherAI) pythia model such as [pythia-6.9b](https://huggingface.co/EleutherAI/pythia-6.9b)
-- Any [Peft](https://github.com/huggingface/peft) adapter trained ontop of a model above.  To activate, must have `peft` in the model path.
+- Any [Peft](https://github.com/huggingface/peft) adapter trained ontop of a
+  model above.  To activate, must have `peft` in the model path.  Note: If
+  loading multiple peft models, you can have them share the base model weights by
+  setting the environment variable `PEFT_SHARE_BASE_WEIGHTS=true` in any model
+  worker.
 
 ## How to support a new model
 

--- a/docs/model_support.md
+++ b/docs/model_support.md
@@ -30,7 +30,7 @@
 - [baichuan-inc/baichuan-7B](https://huggingface.co/baichuan-inc/baichuan-7B)
 - [internlm/internlm-chat-7b](https://huggingface.co/internlm/internlm-chat-7b)
 - Any [EleutherAI](https://huggingface.co/EleutherAI) pythia model such as [pythia-6.9b](https://huggingface.co/EleutherAI/pythia-6.9b)
-- Any [Peft](https://github.com/huggingface/peft) adapter trained ontop of a
+- Any [Peft](https://github.com/huggingface/peft) adapter trained on top of a
   model above.  To activate, must have `peft` in the model path.  Note: If
   loading multiple peft models, you can have them share the base model weights by
   setting the environment variable `PEFT_SHARE_BASE_WEIGHTS=true` in any model


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This adds a special environment variable that activates shared Peft model base weights.  Currently when loading two Peft models that have the same base model, those model weights are loaded once.  With this flag activated, all Peft models will share the same base model.

To make this work it requires a few work around due to how Huggingface's Peft model has implemented LoRA adapters, the most popular variant.  These modify the base model's pytorch modules directly and thus adapters sharing the same base model must live within the same model object and a `set_adapter` method must be called to switch between them.  

## Related issue number (if applicable)

Expands #1805

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
