### PR TITLE
Check for the sequence length configuration key MPT uses

### DIFF
--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -271,13 +271,19 @@ def is_sentence_complete(output: str):
     return output.endswith(end_symbols)
 
 
+# Models don't use the same configuration key for determining the maximum
+# sequence length.  Store them here so we can sanely check them.
+SEQUENCE_LENGTH_KEYS = [
+    "max_position_embeddings",
+    "max_sequence_length",
+    "max_seq_len",
+    "seq_length",
+]
+
+
 def get_context_length(config):
     """Get the context length of a model from a huggingface model config."""
-    if hasattr(config, "max_sequence_length"):
-        return config.max_sequence_length
-    elif hasattr(config, "seq_length"):
-        return config.seq_length
-    elif hasattr(config, "max_position_embeddings"):
-        return config.max_position_embeddings
-    else:
-        return 2048
+    for key in SEQUENCE_LENGTH_KEYS:
+        if hasattr(config, key):
+            return getattr(config, key)
+    return 2048


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

MPT models use `max_seq_len` for configuring the context length.  This change ensures that the model worker reports the correct context length for MPT models by also checking for this configuration key.

## Related issue number (if applicable)

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
