### PR TITLE
properly handling stop value when it can be a list or a str

### DIFF
--- a/fastchat/serve/vllm_worker.py
+++ b/fastchat/serve/vllm_worker.py
@@ -73,10 +73,13 @@ class VLLMWorker(BaseModelWorker):
         echo = params.get("echo", True)
 
         # Handle stop_str
-        if stop_str is None:
-            stop = []
-        else:
+        if isinstance(stop_str, str) and stop_str != "":
             stop = [stop_str]
+        elif isinstance(stop_str, list) and stop_str != []:
+            stop = stop_str
+        else:
+            stop = []
+
         for tid in stop_token_ids:
             stop.append(self.tokenizer.decode(tid))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The OpenAI `stop` parameter can be either a string or a list of strings.  Right now the vllm worker assumes its always a string and causes some fatal error deep in the vllm engine when a list is passed.  This properly handles both str and list cases.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).

Manually testing this and comparing against vllm's openai api server.  With this fix I now see comparable speeds.