### PR TITLE
Model adapter matching improve by prioritizing last folder of model path

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -99,7 +99,7 @@ def get_model_adapter(model_path: str) -> BaseModelAdapter:
     """Get a model adapter for a model_path."""
     model_path_basename = os.path.basename(os.path.normpath(model_path))
 
-    #Try the basename of model_path at first
+    # Try the basename of model_path at first
     for adapter in model_adapters:
         if adapter.match(model_path_basename) and type(adapter) != BaseModelAdapter:
             return adapter

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -97,25 +97,18 @@ def register_model_adapter(cls):
 @cache
 def get_model_adapter(model_path: str) -> BaseModelAdapter:
     """Get a model adapter for a model_path."""
-    model_last_folder_path = os.path.basename(os.path.normpath(model_path))
+    model_path_basename = os.path.basename(os.path.normpath(model_path))
 
-    adapter_matched_full_path = None
-    adapter_matched_last_path = None
-
+    #Try the basename of model_path at first
     for adapter in model_adapters:
-        if adapter.match(model_last_folder_path) and type(adapter) != BaseModelAdapter:
-            adapter_matched_last_path = adapter
-        elif adapter.match(model_path) and not adapter_matched_full_path:
-            adapter_matched_full_path = adapter
-        if adapter_matched_last_path and adapter_matched_full_path:
-            break
+        if adapter.match(model_path_basename) and type(adapter) != BaseModelAdapter:
+            return adapter
 
-    if adapter_matched_full_path or adapter_matched_last_path:
-        return (
-            adapter_matched_last_path
-            if adapter_matched_last_path
-            else adapter_matched_full_path
-        )
+    # Then try the full path
+    for adapter in model_adapters:
+        if adapter.match(model_path):
+            return adapter
+
     raise ValueError(f"No valid model adapter for {model_path}")
 
 

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -97,9 +97,21 @@ def register_model_adapter(cls):
 @cache
 def get_model_adapter(model_path: str) -> BaseModelAdapter:
     """Get a model adapter for a model_path."""
+    model_last_folder_path = os.path.basename(os.path.normpath(model_path))
+
+    adapter_matched_full_path = None
+    adapter_matched_last_path = None
+
     for adapter in model_adapters:
-        if adapter.match(model_path):
-            return adapter
+        if adapter.match(model_last_folder_path) and type(adapter) != BaseModelAdapter :
+            adapter_matched_last_path = adapter
+        elif adapter.match(model_path) and not adapter_matched_full_path:
+            adapter_matched_full_path = adapter
+        if adapter_matched_last_path and adapter_matched_full_path:
+            break
+ 
+    if adapter_matched_full_path or adapter_matched_last_path:
+        return adapter_matched_last_path if adapter_matched_last_path else adapter_matched_full_path
     raise ValueError(f"No valid model adapter for {model_path}")
 
 

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -103,15 +103,19 @@ def get_model_adapter(model_path: str) -> BaseModelAdapter:
     adapter_matched_last_path = None
 
     for adapter in model_adapters:
-        if adapter.match(model_last_folder_path) and type(adapter) != BaseModelAdapter :
+        if adapter.match(model_last_folder_path) and type(adapter) != BaseModelAdapter:
             adapter_matched_last_path = adapter
         elif adapter.match(model_path) and not adapter_matched_full_path:
             adapter_matched_full_path = adapter
         if adapter_matched_last_path and adapter_matched_full_path:
             break
- 
+
     if adapter_matched_full_path or adapter_matched_last_path:
-        return adapter_matched_last_path if adapter_matched_last_path else adapter_matched_full_path
+        return (
+            adapter_matched_last_path
+            if adapter_matched_last_path
+            else adapter_matched_full_path
+        )
     raise ValueError(f"No valid model adapter for {model_path}")
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Original method matches model name with full model path and return immediately after matched.

The problem happens when my Longchat model located at `/home/vicuna/models/lmsys_longchat-13b-16k`, the first adapter it matches and returns is **VicunaAdapter**, however **LongChatAdapter** should be the correct one. This leads to missing on monkey patches for Longchat model and repeating token generation.

So I slightly change method to match adapter by priortizing last folder name, which usually be the exact model name, in model path. 

Then current adapter matching priority shall be:
- Adapter matched last folder path (but not BaseAdapter)
- Adapter matched full model path
- BaseAdapter
- ValueError (No way happens since BaseAdapter returns True for any path? )

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
