### PR TITLE
Fix Peft Adapter Matching 

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -375,14 +375,15 @@ class PeftModelAdapter:
         """Accepts any model path with "peft" in the name"""
         if os.path.exists(os.path.join(model_path, "adapter_config.json")):
             return True
+        elif os.path.exists(os.path.join(model_path, "config.json")):
+            return False
         else:
-            from huggingface_hub import HfApi
+            from huggingface_hub import list_repo_files
 
-            api = HfApi()
-            model_info = api.model_info(model_path)
-            repo_files = [file.rfilename for file in model_info.siblings]
-            if "adapter_config.json" in repo_files:
+            list_remote_files = list_repo_files(model_path)
+            if "adapter_config.json" in list_remote_files:
                 return True
+        return False
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
         """Loads the base model then the (peft) adapter weights"""


### PR DESCRIPTION
## Why are these changes needed?
As [previously stated](https://github.com/lm-sys/FastChat/pull/1922), there are some issues with PEFT matching. Namely, when we try to load using a local model, it runs into an error where we're trying to search through huggingface hub for a local repo.

We propose a fix by first checking if the local model has a `config.json` and if so, then we return `False` since it is a base model and not an adapter. We test this logic across four possible configurations:
| | **Local Model**  | **Remote Model** |
| ----------- | ------------- | ------------- |
| Base Model Path | models/fastchat-t5-3b | [lmsys/vicuna-7b-v1.3](https://huggingface.co/lmsys/vicuna-7b-v1.3)  |
| Adapter Model Path | models/peft-llama-dummy  | [yahma/alpaca-7b-lora](https://huggingface.co/yahma/alpaca-7b-lora) |


## Related issue number (if applicable)
#1928 

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
