### PR TITLE
test transformers==4.30 with long-llama model

### DIFF
--- a/fastchat/train/train.py
+++ b/fastchat/train/train.py
@@ -245,6 +245,8 @@ def train():
     model = transformers.AutoModelForCausalLM.from_pretrained(
         model_args.model_name_or_path,
         cache_dir=training_args.cache_dir,
+        torch_dtype=torch.float32,
+        trust_remote_code=True
     )
     model.config.use_cache = False
     tokenizer = transformers.AutoTokenizer.from_pretrained(

--- a/train.sh
+++ b/train.sh
@@ -1,0 +1,24 @@
+OMP_NUM_THREADS=20 CUDA_VISIBLE_DEVICES=4,5 torchrun --nproc_per_node=2 --master_port=20000 fastchat/train/train_mem.py \
+    --model_name_or_path /media/public/models/huggingface/long_llama_3b  \
+    --data_path ../FastChat/data/data.json \
+    --bf16 True \
+    --output_dir /output \
+    --num_train_epochs 3 \
+    --per_device_train_batch_size 32 \
+    --per_device_eval_batch_size 2 \
+    --gradient_accumulation_steps 1 \
+    --evaluation_strategy "no" \
+    --save_strategy "steps" \
+    --save_steps 300 \
+    --save_total_limit 10 \
+    --learning_rate 2e-5 \
+    --weight_decay 0. \
+    --warmup_ratio 0.03 \
+    --lr_scheduler_type "cosine" \
+    --logging_steps 1 \
+    --fsdp "full_shard auto_wrap" \
+    --fsdp_transformer_layer_cls_to_wrap 'LlamaDecoderLayer' \
+    --tf32 True \
+    --model_max_length 256000 \
+    --gradient_checkpointing True \
+    --lazy_preprocess True


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Long-llama support long context but requires transformers==4.30, however, fastchat requires transformers<4.29.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)
Open #1234
<!-- For example: "Closes #1234" -->

## Test result:
It raises the following error:

![image](https://github.com/lm-sys/FastChat/assets/55051961/d4928dfa-1b5d-4368-a879-fc3aa9e54725)

