### PR TITLE
Mention AMD GPU compatibility in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ See a complete list of supported models and instructions to add a new model [her
 
 #### Single GPU
 The command below requires around 14GB of GPU memory for Vicuna-7B and 28GB of GPU memory for Vicuna-13B.
-See the "No Enough Memory" section below if you do not have enough memory.
+See the ["Not Enough Memory" section](#not-enough-memory) below if you do not have enough memory.
 `--model-path` can be a local folder or a Hugging Face repo name.
 ```
 python3 -m fastchat.serve.cli --model-path lmsys/vicuna-7b-v1.3
@@ -133,7 +133,7 @@ python3 -m fastchat.serve.cli --model-path lmsys/vicuna-7b-v1.3 --device xpu
 ```
 Vicuna-7B can run on an Intel Arc A770 16GB.
 
-#### No Enough Memory
+#### Not Enough Memory
 If you do not have enough memory, you can enable 8-bit compression by adding `--load-8bit` to commands above.
 This can reduce memory usage by around half with slightly degraded model quality.
 It is compatible with the CPU, GPU, and Metal backend.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ FastChat is an open platform for training, serving, and evaluating large languag
 
 ## Install
 
+### Prerequisites
+#### Running models on AMD GPUs
+If you want to run models using an AMD GPU, install ROCm and [the ROCm version of PyTorch](https://pytorch.org/get-started/locally/) before you install FastChat.
+
 ### Method 1: With pip
 
 ```bash
@@ -137,7 +141,8 @@ Vicuna-7B can run on an Intel Arc A770 16GB.
 If you do not have enough memory, you can enable 8-bit compression by adding `--load-8bit` to commands above.
 This can reduce memory usage by around half with slightly degraded model quality.
 It is compatible with the CPU, GPU, and Metal backend.
-Vicuna-13B with 8-bit compression can run on a single NVIDIA 3090/4080/T4/V100(16GB) GPU.
+
+Vicuna-13B with 8-bit compression can run on a single GPU with 16 GB of VRAM, like an Nvidia RTX 3090, RTX 4080, T4, or V100 (16GB), or an AMD RX 6800 XT.
 ```
 python3 -m fastchat.serve.cli --model-path lmsys/vicuna-7b-v1.3 --load-8bit
 ```


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR updates the README with information about running models on AMD GPUs, which was missing before. This includes extra installation notes and a remark that Vicuna-13B with `--load-8bit` works on an RX 6800 XT just like it does with some other graphics cards.

Commit bd476f9e44d20120edf27dd3316204af9631bf7a in this PR also fixes a typo.

## Related issue number (if applicable)
Closes #104 
<!-- For example: "Closes #1234" -->

## Checks

NOTE: this PR only changes the README, so these checks aren't relevant.

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
