### PR TITLE
Set an ordering to sequence length to handle order preferences

### DIFF
--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -273,11 +273,13 @@ def is_sentence_complete(output: str):
 
 # Models don't use the same configuration key for determining the maximum
 # sequence length.  Store them here so we can sanely check them.
+# NOTE: The ordering here is important.  Some models have two of these and we
+# have a preference for which value gets used.
 SEQUENCE_LENGTH_KEYS = [
-    "max_position_embeddings",
     "max_sequence_length",
-    "max_seq_len",
     "seq_length",
+    "max_position_embeddings",
+    "max_seq_len",
 ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

LongChat apparently use two values set for context length and there's a precedence ordering to this (as mentioned [here](https://github.com/lm-sys/FastChat/commit/246c616bed970cec327d4fb16983e79906ee486f#commitcomment-121675555).

## Related issue number (if applicable)

Fixes issue mentioned [here](https://github.com/lm-sys/FastChat/commit/246c616bed970cec327d4fb16983e79906ee486f#commitcomment-121675555)

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
