### PR TITLE
fix template get error

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -306,10 +306,10 @@ register_conv_template(
     )
 )
 
-# Vicuna v1.1 template
+# Vicuna v1.3 template
 register_conv_template(
     Conversation(
-        name="vicuna_v1.1",
+        name="vicuna_v1.3",
         system="A chat between a curious user and an artificial intelligence assistant. "
         "The assistant gives helpful, detailed, and polite answers to the user's questions.",
         roles=("USER", "ASSISTANT"),
@@ -830,7 +830,7 @@ register_conv_template(
 )
 
 if __name__ == "__main__":
-    conv = get_conv_template("vicuna_v1.1")
+    conv = get_conv_template("vicuna_v1.3")
     conv.append_message(conv.roles[0], "Hello!")
     conv.append_message(conv.roles[1], "Hi!")
     conv.append_message(conv.roles[0], "How are you?")

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -485,7 +485,7 @@ class VicunaAdapter(BaseModelAdapter):
     def get_default_conv_template(self, model_path: str) -> Conversation:
         if "v0" in remove_parent_directory_name(model_path):
             return get_conv_template("one_shot")
-        return get_conv_template("vicuna_v1.1")
+        return get_conv_template("vicuna_v1.3")
 
     def raise_warning_for_old_weights(self, model):
         if isinstance(model, LlamaForCausalLM) and model.model.vocab_size > 32000:
@@ -554,7 +554,7 @@ class LongChatAdapter(BaseModelAdapter):
         return model, tokenizer
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
-        return get_conv_template("vicuna_v1.1")
+        return get_conv_template("vicuna_v1.3")
 
 
 class CodeT5pAdapter(BaseModelAdapter):
@@ -934,7 +934,7 @@ class WizardLMAdapter(BaseModelAdapter):
     def get_default_conv_template(self, model_path: str) -> Conversation:
         model_path = model_path.lower()
         if "13b" in model_path or "30b" in model_path:
-            return get_conv_template("vicuna_v1.1")
+            return get_conv_template("vicuna_v1.3")
         else:
             # TODO: use the recommended template for 7B
             # (https://huggingface.co/WizardLM/WizardLM-13B-V1.0)
@@ -996,7 +996,7 @@ class CamelAdapter(BaseModelAdapter):
         return "camel" in model_path
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
-        return get_conv_template("vicuna_v1.1")
+        return get_conv_template("vicuna_v1.3")
 
 
 class TuluAdapter(BaseModelAdapter):
@@ -1161,7 +1161,6 @@ class StarChatAdapter(BaseModelAdapter):
 
 # Note: the registration order matters.
 # The one registered earlier has a higher matching priority.
-register_model_adapter(PeftModelAdapter)
 register_model_adapter(VicunaAdapter)
 register_model_adapter(AiroborosAdapter)
 register_model_adapter(LongChatAdapter)
@@ -1202,6 +1201,7 @@ register_model_adapter(NousHermesAdapter)
 register_model_adapter(PythiaAdapter)
 register_model_adapter(InternLMChatAdapter)
 register_model_adapter(StarChatAdapter)
+register_model_adapter(PeftModelAdapter)
 
 # After all adapters, try the default base adapter.
 register_model_adapter(BaseModelAdapter)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
1. The matching logic of PEFT here is not very consistent with the other adapters, 'model_path' may be a keyword in transmission. PEFT is understood as a true path in priority matching and may attempt to request the network, which can easily cause execution failure. Here, PEFT is moved to the final matching temporary correction, and it is best not to rely on the path file itself for its judgment.
2. Update the name of the Vicuna template to 'vicuna_v1.3'

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
