### PR TITLE
Fix loading model error. Updated pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-    "accelerate", "fastapi", "gradio==3.35.2", "httpx", "markdown2[all]", "nh3", "numpy",
+    "accelerate", "fastapi", "gradio", "httpx", "markdown2[all]", "nh3", "numpy",
     "peft", "prompt_toolkit>=3.0.0", "pydantic<=2.0", "requests", "rich>=10.0.0", "sentencepiece",
     "shortuuid", "shortuuid", "tiktoken", "tokenizers>=0.12.1", "torch",
     "transformers>=4.28.0,<4.29.0", "uvicorn", "wandb",


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For #1925 Gradio model forever loading issue, fschat 0.2.18 requires gradio==3.35.2, but you have gradio 3.36.1 which is incompatible. This caused issues in some environments. Upgrading gradio dependency solves this.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

Closes #1925

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
