### PR TITLE
Add instructions for testing peft models

### DIFF
--- a/docs/commands/test_process.md
+++ b/docs/commands/test_process.md
@@ -37,3 +37,15 @@ CUDA_VISIBLE_DEVICES=7 python3 -m fastchat.serve.model_worker --model-path ~/mod
 ```
 python3 -m fastchat.serve.gradio_web_server_multi
 ```
+
+### Test Peft Serving
+
+```
+python3 -m fastchat.serve.controller
+```
+
+```
+PEFT_SHARE_BASE_WEIGHTS=true python3 -m fastchat.serve.multi_model_worker \
+  --model-path SurfaceData/dummy_pythia160m_lora16_peft_chat \
+  --model-path SurfaceData/dummy_pythia160m_lora8_peft_chat
+```


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This adds instructions for ensuring the multi model worker can load two peft models and share their weights.  This uses two dummy pythia 160m models I trained and put up on HuggingFace.  They don't do anything useful but are fast to download and load for testing purposes.

## Related issue number (if applicable)


## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
