### PR TITLE
Fix Llama2 formatting

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -847,17 +847,17 @@ register_conv_template(
 register_conv_template(
     Conversation(
         name="llama-2",
-        system="<s>[INST] <<SYS>>\nYou are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe.  "
+        system="<s>[INST] <<SYS>>\nYou are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. "
         "Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. "
         "Please ensure that your responses are socially unbiased and positive in nature.\n\n"
         "If a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. "
-        "If you don't know the answer to a question, please don't share false information.\n<</SYS>>\n\n ",
+        "If you don't know the answer to a question, please don't share false information.\n<</SYS>>\n\n",
         roles=("[INST]", "[/INST]"),
         messages=(),
         offset=0,
         sep_style=SeparatorStyle.LLAMA2,
         sep=" ",
-        sep2="</s><s>",
+        sep2=" </s><s>",
         stop_token_ids=[2],
     )
 )


### PR DESCRIPTION
Following: https://github.com/facebookresearch/llama/blob/cfc3fc8c1968d390eb830e65c63865e980873a06/llama/generation.py#L212

- Double spacing in sys prompt
- No need for whitespace between system prompt and first message
- Whitespace needed between assistant message and EOS token