### PR TITLE
hotfix train_lora deepspeed problem

### DIFF
--- a/fastchat/train/train_lora.py
+++ b/fastchat/train/train_lora.py
@@ -180,7 +180,7 @@ def train():
     trainer.save_state()
 
     # check if zero3 mode enabled
-    if deepspeed.is_deepspeed_zero3_enabled():
+    if trainer.args.deepspeed and trainer.hf_deepspeed_config_orig.is_zero3():
         # use deepspeed engine internal function to gather state dict
         # state_dict_zero3 contains whole parameters of base and lora adapters
         # we will not extract lora parameters since peft save_pretrained will do that


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

@ZYHowell 

## Why are these changes needed?

fix the problem that Trainer do not have deepspeed related attribute when deepspeed is not enabled. https://github.com/lm-sys/FastChat/issues/1458#issuecomment-1598246856

Closes https://github.com/lm-sys/FastChat/issues/1458

## Checks

- [X] I've run `format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed.
- [X] I've made sure the relevant tests are passing (if applicable).
