### PR TITLE
add logdir as a envvar for #1993

### DIFF
--- a/fastchat/constants.py
+++ b/fastchat/constants.py
@@ -17,7 +17,7 @@ CONVERSATION_TURN_LIMIT = 50
 # Session expiration time
 SESSION_EXPIRATION_TIME = 3600
 # The output dir of log files
-LOGDIR = "."
+LOGDIR = os.getenv("LOGDIR", ".")
 
 
 ##### For the controller and workers (could be overwritten through ENV variables.)


### PR DESCRIPTION
## Why are these changes needed?

The logs pollute the source code. This ensures that one sets LOGDIR as an environment variable and the logs all end up in a more sane location

## Related issue number (if applicable)

Closes #1993

## Checks

- [X] I've run `format.sh` to lint the changes in this PR.
