### PR TITLE
Lazy import torch in utils.py

### DIFF
--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -12,7 +12,6 @@ from typing import AsyncGenerator, Generator
 import warnings
 
 import requests
-import torch
 
 from fastchat.constants import LOGDIR
 
@@ -122,6 +121,8 @@ def disable_torch_init():
 
 def get_gpu_memory(max_gpus=None):
     """Get available memory for each GPU."""
+    import torch
+
     gpu_memory = []
     num_gpus = (
         torch.cuda.device_count()
@@ -161,6 +162,8 @@ def clean_flant5_ckpt(ckpt_path):
     Flan-t5 trained with HF+FSDP saves corrupted  weights for shared embeddings,
     Use this function to make sure it can be correctly loaded.
     """
+    import torch
+
     index_file = os.path.join(ckpt_path, "pytorch_model.bin.index.json")
     index_json = json.load(open(index_file, "r"))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It appears that torch is being used in the `disable_torch_init`, `get_gpu_memory`, and `clean_flant5_ckpt` functions. However as it is declared as a top level import it will also be pulled as a required dependency through the `build_logger` into components that should be able to run without `torch` e.g. the FastChat controller.

Using a lazy import on the function level removes this restriction and allows other components to run without `torch`.

## Related issue number (if applicable)

Closes #2045

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
