### PR TITLE
Update llama_flash_attn_monkey_patch.py for flash attention 2

### DIFF
--- a/fastchat/train/llama_flash_attn_monkey_patch.py
+++ b/fastchat/train/llama_flash_attn_monkey_patch.py
@@ -9,7 +9,7 @@ from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
 
 from einops import rearrange
 
-from flash_attn.flash_attn_interface import flash_attn_unpadded_qkvpacked_func
+from flash_attn.flash_attn_interface import flash_attn_varlen_qkvpacked_func
 from flash_attn.bert_padding import unpad_input, pad_input
 
 
@@ -75,7 +75,7 @@ def forward(
         cu_q_lens = torch.arange(
             0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32, device=qkv.device
         )
-        output = flash_attn_unpadded_qkvpacked_func(
+        output = flash_attn_varlen_qkvpacked_func(
             qkv, cu_q_lens, max_s, 0.0, softmax_scale=None, causal=True
         )
         output = rearrange(output, "(b s) ... -> b s ...", b=bsz)
@@ -86,7 +86,7 @@ def forward(
         x_unpad = rearrange(
             x_unpad, "nnz (three h d) -> nnz three h d", three=3, h=nheads
         )
-        output_unpad = flash_attn_unpadded_qkvpacked_func(
+        output_unpad = flash_attn_varlen_qkvpacked_func(
             x_unpad, cu_q_lens, max_s, 0.0, softmax_scale=None, causal=True
         )
         output = rearrange(


### PR DESCRIPTION
Upgrading from FlashAttention (1.x) to FlashAttention-2

These functions have been renamed:

flash_attn_unpadded_qkvpacked_func -> flash_attn_varlen_qkvpacked_func

You can check how they made the update: https://github.com/Dao-AILab/flash-attention

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The function `flash_attn_unpadded_qkvpacked_func` is not included anymore in 
flash-attention, so causing issue with fine-tuning. This will fix the problem.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
    - https://github.com/Dao-AILab/flash-attention
- [x] I've made sure the relevant tests are passing (if applicable).
