### PR TITLE
drop scores for API error judgments

### DIFF
--- a/fastchat/llm_judge/show_result.py
+++ b/fastchat/llm_judge/show_result.py
@@ -17,6 +17,7 @@ def display_result_single(args):
     print(f"Input file: {input_file}")
     df_all = pd.read_json(input_file, lines=True)
     df = df_all[["model", "score", "turn"]]
+    df = df[df["score"] != -1]
 
     if args.model_list is not None:
         df = df[df["model"].isin(args.model_list)]
@@ -45,6 +46,8 @@ def display_result_pairwise(args):
 
     print(f"Input file: {input_file}")
     df_all = pd.read_json(input_file, lines=True)
+    df_all = df_all[(df_all["g1_winner"] != "error") & (df_all["g2_winner"] != "error")]
+
     model_list = (
         df_all["model_1"].unique().tolist() + df_all["model_2"].unique().tolist()
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Drop the `error` scores in llm-judge, otherwise it would be counted as `-1` in results, which is incorrect.

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
