### PR TITLE
Bump Pydantic v1 to v2

### DIFF
--- a/fastchat/protocol/api_protocol.py
+++ b/fastchat/protocol/api_protocol.py
@@ -69,7 +69,7 @@ class ChatMessage(BaseModel):
 class ChatCompletionResponseChoice(BaseModel):
     index: int
     message: ChatMessage
-    finish_reason: Optional[Literal["stop", "length"]]
+    finish_reason: Optional[Literal["stop", "length"]] = None
 
 
 class ChatCompletionResponse(BaseModel):
@@ -89,7 +89,7 @@ class DeltaMessage(BaseModel):
 class ChatCompletionResponseStreamChoice(BaseModel):
     index: int
     delta: DeltaMessage
-    finish_reason: Optional[Literal["stop", "length"]]
+    finish_reason: Optional[Literal["stop", "length"]] = None
 
 
 class ChatCompletionStreamResponse(BaseModel):
@@ -141,7 +141,7 @@ class CompletionResponseChoice(BaseModel):
     index: int
     text: str
     logprobs: Optional[int] = None
-    finish_reason: Optional[Literal["stop", "length"]]
+    finish_reason: Optional[Literal["stop", "length"]] = None
 
 
 class CompletionResponse(BaseModel):

--- a/fastchat/protocol/openai_api_protocol.py
+++ b/fastchat/protocol/openai_api_protocol.py
@@ -70,7 +70,7 @@ class ChatMessage(BaseModel):
 class ChatCompletionResponseChoice(BaseModel):
     index: int
     message: ChatMessage
-    finish_reason: Optional[Literal["stop", "length"]]
+    finish_reason: Optional[Literal["stop", "length"]] = None
 
 
 class ChatCompletionResponse(BaseModel):
@@ -90,7 +90,7 @@ class DeltaMessage(BaseModel):
 class ChatCompletionResponseStreamChoice(BaseModel):
     index: int
     delta: DeltaMessage
-    finish_reason: Optional[Literal["stop", "length"]]
+    finish_reason: Optional[Literal["stop", "length"]] = None
 
 
 class ChatCompletionStreamResponse(BaseModel):
@@ -156,7 +156,7 @@ class CompletionResponseChoice(BaseModel):
     index: int
     text: str
     logprobs: Optional[int] = None
-    finish_reason: Optional[Literal["stop", "length"]]
+    finish_reason: Optional[Literal["stop", "length"]] = None
 
 
 class CompletionResponse(BaseModel):

--- a/fastchat/serve/bard_worker.py
+++ b/fastchat/serve/bard_worker.py
@@ -28,8 +28,8 @@ class Message(BaseModel):
 
 class Response(BaseModel):
     content: str
-    factualityQueries: Optional[List]
-    textQuery: Optional[Union[str, List]]
+    factualityQueries: Optional[List] = None
+    textQuery: Optional[Union[str, List]] = None
     choices: List[dict]
     state: ConversationState
 

--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -21,6 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse, JSONResponse
 from fastapi.security.http import HTTPAuthorizationCredentials, HTTPBearer
 import httpx
+from pydantic_settings import BaseSettings
 import shortuuid
 import tiktoken
 import uvicorn
@@ -60,7 +61,6 @@ from fastchat.protocol.api_protocol import (
     APITokenCheckResponse,
     APITokenCheckResponseItem,
 )
-from pydantic_settings import BaseSettings
 
 logger = logging.getLogger(__name__)
 

--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -21,7 +21,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse, JSONResponse
 from fastapi.security.http import HTTPAuthorizationCredentials, HTTPBearer
 import httpx
-from pydantic import BaseSettings
 import shortuuid
 import tiktoken
 import uvicorn
@@ -61,6 +60,7 @@ from fastchat.protocol.api_protocol import (
     APITokenCheckResponse,
     APITokenCheckResponseItem,
 )
+from pydantic_settings import BaseSettings
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
     "accelerate>=0.21", "einops", "fastapi", "gradio", "httpx", "markdown2[all]", "nh3", "numpy",
-    "peft", "prompt_toolkit>=3.0.0", "pydantic<=2.0", "requests", "rich>=10.0.0", "sentencepiece",
+    "peft", "prompt_toolkit>=3.0.0", "pydantic>=2.0", "pydantic-settings", "requests", "rich>=10.0.0", "sentencepiece",
     "shortuuid", "shortuuid", "tiktoken", "tokenizers>=0.12.1", "torch",
     "transformers>=4.31.0", "uvicorn", "wandb"
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The original setting `pydantic<=2.0` may install `pydantic==2.0`, this will cause an error:

<img width="1660" alt="image" src="https://github.com/lm-sys/FastChat/assets/110874468/c6707f4a-7fbc-44b4-9745-0d1938533543">

With `pydanatic==1.10.x`, we can fix this issue.

<img width="1398" alt="image" src="https://github.com/lm-sys/FastChat/assets/110874468/c985ecc0-7bf0-4318-b6fe-9e43924f578a">

**However, a better solution is to migrate pydantic from v1 to v2.**

## Related issue number (if applicable)

https://github.com/lm-sys/FastChat/issues/2077

Some other related issues and prs:
https://github.com/lm-sys/FastChat/pull/1903
https://github.com/lm-sys/FastChat/pull/1897

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
