### PR TITLE
update the openai-api doc to support the `api_key`

### DIFF
--- a/docs/openai_api.md
+++ b/docs/openai_api.md
@@ -40,7 +40,9 @@ pip install --upgrade openai
 Then, interact with model vicuna:
 ```python
 import openai
-openai.api_key = "EMPTY" # Not support yet
+# to get proper authentication, make sure to use a valid key that's listed in
+# the --api-keys flag. if no flag value is provided, the `api_key` will be ignored.
+openai.api_key = "EMPTY"
 openai.api_base = "http://localhost:8000/v1"
 
 model = "vicuna-7b-v1.3"
@@ -146,5 +148,4 @@ Some features to be implemented:
 - [ ] Support more parameters like `logprobs`, `logit_bias`, `user`, `presence_penalty` and `frequency_penalty`
 - [ ] Model details (permissions, owner and create time)
 - [ ] Edits API
-- [ ] Authentication and API key
 - [ ] Rate Limitation Settings


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Since the [api-key support pr](https://github.com/lm-sys/FastChat/pull/1520) has been landed, I believe, the openai-api compatible server has been supporting the authentication. however, the doc does not sync up well with the change.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- ~[ ] I've run `format.sh` to lint the changes in this PR.~
- [X] I've included any doc changes needed.
- ~[ ] I've made sure the relevant tests are passing (if applicable).~
