### PR TITLE
fix(compression): update torch.load to handle different storage locat…

### DIFF
--- a/fastchat/model/compression.py
+++ b/fastchat/model/compression.py
@@ -152,7 +152,7 @@ def load_compress_model(model_path, device, torch_dtype, use_fast, revision="mai
     compressed_state_dict = {}
 
     for filename in tqdm(files):
-        tmp_state_dict = torch.load(filename)
+        tmp_state_dict = torch.load(filename, map_location=lambda storage, loc: storage)
         for name in tmp_state_dict:
             if name in linear_weights:
                 tensor = tmp_state_dict[name].to(device).data.to(torch_dtype)


### PR DESCRIPTION

## Why are these changes needed?

torch.load may fails because the run time system doesn’t have certain devices
using the map_location argument can be dynamically remapped to an alternative set of devices

## Related issue number (if applicable)
#2084 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
