### PR TITLE
Fix rope scaling in the training code

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ MT-bench is the new recommended way to benchmark your models. If you are still l
 ## Fine-tuning
 ### Data
 
-Vicuna is created by fine-tuning a LLaMA base model using approximately 140K user-shared conversations gathered from ShareGPT.com with public APIs. To ensure data quality, we convert the HTML back to markdown and filter out some inappropriate or low-quality samples. Additionally, we divide lengthy conversations into smaller segments that fit the model's maximum context length. For detailed instructions to clean the ShareGPT data, check out [here](docs/commands/data_cleaning.md).
+Vicuna is created by fine-tuning a LLaMA base model using approximately 125K user-shared conversations gathered from ShareGPT.com with public APIs. To ensure data quality, we convert the HTML back to markdown and filter out some inappropriate or low-quality samples. Additionally, we divide lengthy conversations into smaller segments that fit the model's maximum context length. For detailed instructions to clean the ShareGPT data, check out [here](docs/commands/data_cleaning.md).
 
 We will not release the ShareGPT dataset. If you would like to try the fine-tuning code, you can run it with some dummy conversations in [dummy_conversation.json](data/dummy_conversation.json). You can follow the same format and plug in your own data.
 
@@ -267,8 +267,7 @@ torchrun --nproc_per_node=4 --master_port=20001 fastchat/train/train_mem.py \
     --tf32 True \
     --model_max_length 2048 \
     --gradient_checkpointing True \
-    --lazy_preprocess True \
-    --disable_tqdm False
+    --lazy_preprocess True
 ```
 
 - If you meet out-of-memory due to "FSDP Warning: When using FSDP, it is efficient and recommended... ", see solutions [here](https://github.com/huggingface/transformers/issues/24724#issuecomment-1645189539).

--- a/fastchat/train/train.py
+++ b/fastchat/train/train.py
@@ -241,18 +241,23 @@ def train():
     )
     model_args, data_args, training_args = parser.parse_args_into_dataclasses()
     local_rank = training_args.local_rank
+
+    # Set RoPE scaling factor
+    config = transformers.AutoConfig.from_pretrained(
+        model_args.model_name_or_path,
+        cache_dir=training_args.cache_dir,
+    )
+    orig_ctx_len = getattr(config, "max_position_embeddings", None)
+    if orig_ctx_len and training_args.model_max_length > orig_ctx_len:
+        scaling_factor = float(math.ceil(training_args.model_max_length / orig_ctx_len))
+        config.rope_scaling = {"type": "linear", "factor": scaling_factor}
+    config.use_cache = False
+
+    # Load model and tokenizer
     model = transformers.AutoModelForCausalLM.from_pretrained(
         model_args.model_name_or_path,
         cache_dir=training_args.cache_dir,
     )
-    model.config.use_cache = False
-
-    # Set RoPE scaling factor
-    orig_ctx_len = getattr(model.config, "max_position_embeddings", None)
-    if orig_ctx_len and training_args.model_max_length > orig_ctx_len:
-        scaling_factor = math.ceil(training_args.model_max_length / orig_ctx_len)
-        model.config.rope_scaling = {"type": "linear", "factor": scaling_factor}
-
     tokenizer = transformers.AutoTokenizer.from_pretrained(
         model_args.model_name_or_path,
         cache_dir=training_args.cache_dir,
@@ -261,8 +266,11 @@ def train():
         use_fast=False,
     )
     tokenizer.pad_token = tokenizer.unk_token
+
+    # Load data
     data_module = make_supervised_data_module(tokenizer=tokenizer, data_args=data_args)
 
+    # Start trainner
     trainer = Trainer(
         model=model, tokenizer=tokenizer, args=training_args, **data_module
     )

--- a/fastchat/train/train.py
+++ b/fastchat/train/train.py
@@ -256,6 +256,7 @@ def train():
     # Load model and tokenizer
     model = transformers.AutoModelForCausalLM.from_pretrained(
         model_args.model_name_or_path,
+        config=config,
         cache_dir=training_args.cache_dir,
     )
     tokenizer = transformers.AutoTokenizer.from_pretrained(

--- a/scripts/test_readme_train.sh
+++ b/scripts/test_readme_train.sh
@@ -21,5 +21,4 @@ torchrun --nproc_per_node=4 --master_port=20001 fastchat/train/train_mem.py \
     --tf32 True \
     --model_max_length 2048 \
     --gradient_checkpointing True \
-    --lazy_preprocess True \
-    --disable_tqdm False
+    --lazy_preprocess True


### PR DESCRIPTION
The `config` for rope scaling should be modified before calling the initialization function of `AutoModelForCausalLM`. Otherwise, it won't take effect.

cc @Trangle. I only updated `train.py`.  Another script `train_baichuan.py` should be updated as well.
