### PR TITLE
Ensure `get_worker_address` only get called once in all openai API calls

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -377,7 +377,7 @@ async def create_chat_completion(request: ChatCompletionRequest):
         choices = []
         chat_completions = []
         for i in range(request.n):
-            content = asyncio.create_task(generate_completion(gen_params))
+            content = asyncio.create_task(generate_completion(gen_params, worker_addr))
             chat_completions.append(content)
         try:
             all_tasks = await asyncio.gather(*chat_completions)
@@ -495,7 +495,9 @@ async def create_completion(request: CompletionRequest):
                     stop=request.stop,
                 )
                 for i in range(request.n):
-                    content = asyncio.create_task(generate_completion(gen_params))
+                    content = asyncio.create_task(
+                        generate_completion(gen_params, worker_addr)
+                    )
                     text_completions.append(content)
 
             try:
@@ -597,10 +599,8 @@ async def generate_completion_stream(payload: Dict[str, Any], worker_addr: str):
                     yield data
 
 
-async def generate_completion(payload: Dict[str, Any]):
+async def generate_completion(payload: Dict[str, Any], worker_addr: str):
     async with httpx.AsyncClient() as client:
-        worker_addr = await get_worker_address(payload["model"], client)
-
         response = await client.post(
             worker_addr + "/worker_generate",
             headers=headers,
@@ -764,7 +764,7 @@ async def create_chat_completion(request: APIChatCompletionRequest):
         choices = []
         chat_completions = []
         for i in range(request.n):
-            content = asyncio.create_task(generate_completion(gen_params))
+            content = asyncio.create_task(generate_completion(gen_params, worker_addr))
             chat_completions.append(content)
         try:
             all_tasks = await asyncio.gather(*chat_completions)

--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -343,52 +343,55 @@ async def create_chat_completion(request: ChatCompletionRequest):
     if error_check_ret is not None:
         return error_check_ret
 
-    gen_params = await get_gen_params(
-        request.model,
-        request.messages,
-        temperature=request.temperature,
-        top_p=request.top_p,
-        max_tokens=request.max_tokens,
-        echo=False,
-        stream=request.stream,
-        stop=request.stop,
-    )
-    error_check_ret = await check_length(
-        request, gen_params["prompt"], gen_params["max_new_tokens"]
-    )
-    if error_check_ret is not None:
-        return error_check_ret
+    async with httpx.AsyncClient() as client:
+        worker_addr = await get_worker_address(request.model, client)
 
-    if request.stream:
-        generator = chat_completion_stream_generator(
-            request.model, gen_params, request.n
+        gen_params = await get_gen_params(
+            request.model,
+            request.messages,
+            temperature=request.temperature,
+            top_p=request.top_p,
+            max_tokens=request.max_tokens,
+            echo=False,
+            stream=request.stream,
+            stop=request.stop,
         )
-        return StreamingResponse(generator, media_type="text/event-stream")
+        error_check_ret = await check_length(
+            request, gen_params["prompt"], gen_params["max_new_tokens"], worker_addr, client
+        )
+        if error_check_ret is not None:
+            return error_check_ret
 
-    choices = []
-    chat_completions = []
-    for i in range(request.n):
-        content = asyncio.create_task(generate_completion(gen_params))
-        chat_completions.append(content)
-    try:
-        all_tasks = await asyncio.gather(*chat_completions)
-    except Exception as e:
-        return create_error_response(ErrorCode.INTERNAL_ERROR, str(e))
-    usage = UsageInfo()
-    for i, content in enumerate(all_tasks):
-        if content["error_code"] != 0:
-            return create_error_response(content["error_code"], content["text"])
-        choices.append(
-            ChatCompletionResponseChoice(
-                index=i,
-                message=ChatMessage(role="assistant", content=content["text"]),
-                finish_reason=content.get("finish_reason", "stop"),
+        if request.stream:
+            generator = chat_completion_stream_generator(
+                request.model, gen_params, request.n
             )
-        )
-        if "usage" in content:
-            task_usage = UsageInfo.parse_obj(content["usage"])
-            for usage_key, usage_value in task_usage.dict().items():
-                setattr(usage, usage_key, getattr(usage, usage_key) + usage_value)
+            return StreamingResponse(generator, media_type="text/event-stream")
+
+        choices = []
+        chat_completions = []
+        for i in range(request.n):
+            content = asyncio.create_task(generate_completion(gen_params))
+            chat_completions.append(content)
+        try:
+            all_tasks = await asyncio.gather(*chat_completions)
+        except Exception as e:
+            return create_error_response(ErrorCode.INTERNAL_ERROR, str(e))
+        usage = UsageInfo()
+        for i, content in enumerate(all_tasks):
+            if content["error_code"] != 0:
+                return create_error_response(content["error_code"], content["text"])
+            choices.append(
+                ChatCompletionResponseChoice(
+                    index=i,
+                    message=ChatMessage(role="assistant", content=content["text"]),
+                    finish_reason=content.get("finish_reason", "stop"),
+                )
+            )
+            if "usage" in content:
+                task_usage = UsageInfo.parse_obj(content["usage"])
+                for usage_key, usage_value in task_usage.dict().items():
+                    setattr(usage, usage_key, getattr(usage, usage_key) + usage_value)
 
     return ChatCompletionResponse(model=request.model, choices=choices, usage=usage)
 
@@ -708,55 +711,58 @@ async def create_chat_completion(request: APIChatCompletionRequest):
     if error_check_ret is not None:
         return error_check_ret
 
-    gen_params = await get_gen_params(
-        request.model,
-        request.messages,
-        temperature=request.temperature,
-        top_p=request.top_p,
-        max_tokens=request.max_tokens,
-        echo=False,
-        stream=request.stream,
-        stop=request.stop,
-    )
+    async with httpx.AsyncClient() as client:
+        worker_addr = await get_worker_address(request.model, client)
 
-    if request.repetition_penalty is not None:
-        gen_params["repetition_penalty"] = request.repetition_penalty
-
-    error_check_ret = await check_length(
-        request, gen_params["prompt"], gen_params["max_new_tokens"]
-    )
-    if error_check_ret is not None:
-        return error_check_ret
-
-    if request.stream:
-        generator = chat_completion_stream_generator(
-            request.model, gen_params, request.n
+        gen_params = await get_gen_params(
+            request.model,
+            request.messages,
+            temperature=request.temperature,
+            top_p=request.top_p,
+            max_tokens=request.max_tokens,
+            echo=False,
+            stream=request.stream,
+            stop=request.stop,
         )
-        return StreamingResponse(generator, media_type="text/event-stream")
 
-    choices = []
-    chat_completions = []
-    for i in range(request.n):
-        content = asyncio.create_task(generate_completion(gen_params))
-        chat_completions.append(content)
-    try:
-        all_tasks = await asyncio.gather(*chat_completions)
-    except Exception as e:
-        return create_error_response(ErrorCode.INTERNAL_ERROR, str(e))
-    usage = UsageInfo()
-    for i, content in enumerate(all_tasks):
-        if content["error_code"] != 0:
-            return create_error_response(content["error_code"], content["text"])
-        choices.append(
-            ChatCompletionResponseChoice(
-                index=i,
-                message=ChatMessage(role="assistant", content=content["text"]),
-                finish_reason=content.get("finish_reason", "stop"),
+        if request.repetition_penalty is not None:
+            gen_params["repetition_penalty"] = request.repetition_penalty
+
+        error_check_ret = await check_length(
+            request, gen_params["prompt"], gen_params["max_new_tokens"], worker_addr, client
+        )
+        if error_check_ret is not None:
+            return error_check_ret
+
+        if request.stream:
+            generator = chat_completion_stream_generator(
+                request.model, gen_params, request.n
             )
-        )
-        task_usage = UsageInfo.parse_obj(content["usage"])
-        for usage_key, usage_value in task_usage.dict().items():
-            setattr(usage, usage_key, getattr(usage, usage_key) + usage_value)
+            return StreamingResponse(generator, media_type="text/event-stream")
+
+        choices = []
+        chat_completions = []
+        for i in range(request.n):
+            content = asyncio.create_task(generate_completion(gen_params))
+            chat_completions.append(content)
+        try:
+            all_tasks = await asyncio.gather(*chat_completions)
+        except Exception as e:
+            return create_error_response(ErrorCode.INTERNAL_ERROR, str(e))
+        usage = UsageInfo()
+        for i, content in enumerate(all_tasks):
+            if content["error_code"] != 0:
+                return create_error_response(content["error_code"], content["text"])
+            choices.append(
+                ChatCompletionResponseChoice(
+                    index=i,
+                    message=ChatMessage(role="assistant", content=content["text"]),
+                    finish_reason=content.get("finish_reason", "stop"),
+                )
+            )
+            task_usage = UsageInfo.parse_obj(content["usage"])
+            for usage_key, usage_value in task_usage.dict().items():
+                setattr(usage, usage_key, getattr(usage, usage_key) + usage_value)
 
     return ChatCompletionResponse(model=request.model, choices=choices, usage=usage)
 

--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -115,11 +115,9 @@ async def check_model(request) -> Optional[JSONResponse]:
     controller_address = app_settings.controller_address
     ret = None
     async with httpx.AsyncClient() as client:
-        try:
-            _worker_addr = await get_worker_address(request.model, client)
-        except:
-            models_ret = await client.post(controller_address + "/list_models")
-            models = models_ret.json()["models"]
+        models_ret = await client.post(controller_address + "/list_models")
+        models = models_ret.json()["models"]
+        if request.model not in models:
             ret = create_error_response(
                 ErrorCode.INVALID_MODEL,
                 f"Only {'&&'.join(models)} allowed now, your model {request.model}",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When using dispatch method `shortest_queue`, each call to the [get_worker_address](https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/openai_api_server.py#L286) will call the corresponding method in the controller's [get_worker_address](https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/controller.py#L163).  

The controller's `get_worker_address` method will increase the `queue_length` of the selected worker ([code](https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/controller.py#L174)).  I guess we need to increase the `queue_length` manually because we need to maintain the queue state between heartbeats. 

However, if we are calling `get_worker_address` multiple times during an API call, then the queue state will be incorrect.  The queue length is increased without sending real workload to the worker.

In `openai_api_server.py`, you can find an API call invoke `get_worker_address` multiple times.  Check [here](https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/openai_api_server.py#L119) and [here](https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/openai_api_server.py#L132), this will lead to an incorrect queue state for workers.

## Related issue number (if applicable)
https://github.com/lm-sys/FastChat/issues/2128
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).


![after_change](https://github.com/lm-sys/FastChat/assets/110874468/89997b3f-376b-4213-b1f3-aac9641cf2c2)
