### PR TITLE
Fix a slicing issue when `conv.stop_str` is not found in model output.

### DIFF
--- a/fastchat/llm_judge/gen_model_answer.py
+++ b/fastchat/llm_judge/gen_model_answer.py
@@ -126,7 +126,8 @@ def get_model_answers(
                         spaces_between_special_tokens=False,
                     )
                     if conv.stop_str:
-                        output = output[: output.find(conv.stop_str)]
+                        if output.find(conv.stop_str) > 0:
+                            output = output[: output.find(conv.stop_str)]
                     for special_token in tokenizer.special_tokens_map.values():
                         if isinstance(special_token, list):
                             for special_tok in special_token:

--- a/fastchat/llm_judge/gen_model_answer.py
+++ b/fastchat/llm_judge/gen_model_answer.py
@@ -125,9 +125,8 @@ def get_model_answers(
                         output_ids,
                         spaces_between_special_tokens=False,
                     )
-                    if conv.stop_str:
-                        if output.find(conv.stop_str) > 0:
-                            output = output[: output.find(conv.stop_str)]
+                    if conv.stop_str and output.find(conv.stop_str) > 0:
+                        output = output[: output.find(conv.stop_str)]
                     for special_token in tokenizer.special_tokens_map.values():
                         if isinstance(special_token, list):
                             for special_tok in special_token:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To fix a slicing op that may unexpectedly discard the last character of a model's output.
When `conv.stop_str` is not found in the output, `output.find(conv.stop_str)` will return `-1`. Then the slicing op `output = output[:-1]` will discard the last character of the output, which I assume is not intended.  

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
