### PR TITLE
feat: get_context_length support rope_scaling

### DIFF
--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -289,8 +289,10 @@ SEQUENCE_LENGTH_KEYS = [
 
 def get_context_length(config):
     """Get the context length of a model from a huggingface model config."""
+    rope_scaling = getattr(config, "rope_scaling", {})
+    rope_factor = rope_scaling.get("factor", 1)
     for key in SEQUENCE_LENGTH_KEYS:
         val = getattr(config, key, None)
         if val is not None:
-            return val
+            return int(rope_factor * val)
     return 2048


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Huggingface transformers has already support rope position embedding scaling, the `get_context_length` should consider that.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
