### PR TITLE
Add Support of bge model family for embedding generation

### DIFF
--- a/docs/model_support.md
+++ b/docs/model_support.md
@@ -7,6 +7,7 @@
    - example: `python3 -m fastchat.serve.cli --model-path lmsys/vicuna-7b-v1.3`
 - [BlinkDL/RWKV-4-Raven](https://huggingface.co/BlinkDL/rwkv-4-raven)
    - example: `python3 -m fastchat.serve.cli --model-path ~/model_weights/RWKV-4-Raven-7B-v11x-Eng99%-Other1%-20230429-ctx8192.pth`
+- [BAAI/bge-large-en](https://huggingface.co/BAAI/bge-large-en#using-huggingface-transformers)
 - [camel-ai/CAMEL-13B-Combined-Data](https://huggingface.co/camel-ai/CAMEL-13B-Combined-Data)
 - [databricks/dolly-v2-12b](https://huggingface.co/databricks/dolly-v2-12b)
 - [FreedomIntelligence/phoenix-inst-chat-7b](https://huggingface.co/FreedomIntelligence/phoenix-inst-chat-7b)

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1323,6 +1323,36 @@ class QwenChatAdapter(BaseModelAdapter):
         return get_conv_template("qwen-7b-chat")
 
 
+class BGEAdapter(BaseModelAdapter):
+    """The model adapter for BGE"""
+
+    use_fast_tokenizer = False
+
+    def match(self, model_path: str):
+        return "bge" in model_path.lower()
+
+    def load_model(self, model_path: str, from_pretrained_kwargs: dict):
+        revision = from_pretrained_kwargs.get("revision", "main")
+        # config = AutoConfig.from_pretrained(
+        #     model_path,
+        #     trust_remote_code=True,
+        # )
+        # config.use_flash_attn = False
+        # config.fp16 = True
+        model = AutoModel.from_pretrained(
+            model_path,
+            **from_pretrained_kwargs,
+        )
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_path, trust_remote_code=True, revision=revision
+        )
+        return model, tokenizer
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("one_shot")
+
+
 class AquilaChatAdapter(BaseModelAdapter):
     """The model adapter for BAAI/AquilaChat-7B"""
 
@@ -1396,6 +1426,7 @@ register_model_adapter(OpenOrcaAdapter)
 register_model_adapter(WizardCoderAdapter)
 register_model_adapter(QwenChatAdapter)
 register_model_adapter(AquilaChatAdapter)
+register_model_adapter(BGEAdapter)
 
 # After all adapters, try the default base adapter.
 register_model_adapter(BaseModelAdapter)

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1333,17 +1333,10 @@ class BGEAdapter(BaseModelAdapter):
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
         revision = from_pretrained_kwargs.get("revision", "main")
-        # config = AutoConfig.from_pretrained(
-        #     model_path,
-        #     trust_remote_code=True,
-        # )
-        # config.use_flash_attn = False
-        # config.fp16 = True
         model = AutoModel.from_pretrained(
             model_path,
             **from_pretrained_kwargs,
         )
-
         tokenizer = AutoTokenizer.from_pretrained(
             model_path, trust_remote_code=True, revision=revision
         )

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -276,6 +276,8 @@ class ModelWorker(BaseModelWorker):
             )  # llama supports batch inference
             is_chatglm = "chatglm" in str(type(self.model))
             is_t5 = "t5" in str(type(self.model))
+            is_bert = "bert" in str(type(self.model))
+            
             if is_llama:
                 encoding = tokenizer.batch_encode_plus(
                     params["input"], padding=True, return_tensors="pt"
@@ -295,6 +297,22 @@ class ModelWorker(BaseModelWorker):
                 ret = {
                     "embedding": normalized_embeddings.tolist(),
                     "token_num": torch.sum(attention_mask).item(),
+                }
+            elif is_bert:
+                embedding = []
+                token_num = 0
+                for text in params["input"]:
+                    input_ids = tokenizer.encode(text, return_tensors="pt").to(
+                        self.device
+                    )
+                    model_output = self.model(input_ids)
+                    data = model_output[0][:, 0]
+                    data = F.normalize(torch.mean(data, dim=0), p=2, dim=0)
+                    embedding.append(data.tolist())
+                    token_num += len(input_ids[0])
+                ret = {
+                    "embedding": embedding,
+                    "token_num": token_num,
                 }
             else:
                 embedding = []


### PR DESCRIPTION
Hello,
I would like to propose you to add the support of embedding generation with BAAI/bge-large-en which is currently the best in the HF leader board.

[model page](https://huggingface.co/BAAI/bge-large-en#using-huggingface-transformers)
[leader board](https://huggingface.co/spaces/mteb/leaderboard)

What do you think?

## Why are these changes needed?

Being able to generate embedding with dedicated models through self hosted OpenAI-like API.

## Related issue number (if applicable)

NA

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
