### PR TITLE
make fastchat api server run in multiprocessing easily

### DIFF
--- a/fastchat/serve/controller.py
+++ b/fastchat/serve/controller.py
@@ -308,7 +308,7 @@ async def worker_api_get_status(request: Request):
     return "success"
 
 
-if __name__ == "__main__":
+def create_controller():
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", type=str, default="localhost")
     parser.add_argument("--port", type=int, default=21001)
@@ -322,4 +322,9 @@ if __name__ == "__main__":
     logger.info(f"args: {args}")
 
     controller = Controller(args.dispatch_method)
+    return args, controller
+
+
+if __name__ == "__main__":
+    args, controller = create_controller()
     uvicorn.run(app, host=args.host, port=args.port, log_level="info")

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -92,7 +92,7 @@ class BaseModelWorker:
     def init_heart_beat(self):
         self.register_to_controller()
         self.heart_beat_thread = threading.Thread(
-            target=heart_beat_worker, args=(self,)
+            target=heart_beat_worker, args=(self,), daemon=True,
         )
         self.heart_beat_thread.start()
 
@@ -417,7 +417,7 @@ async def api_model_details(request: Request):
     return {"context_length": worker.context_len}
 
 
-if __name__ == "__main__":
+def create_model_worker():
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", type=str, default="localhost")
     parser.add_argument("--port", type=int, default=21002)
@@ -482,4 +482,9 @@ if __name__ == "__main__":
         stream_interval=args.stream_interval,
         conv_template=args.conv_template,
     )
+    return args, worker
+
+
+if __name__ == "__main__":
+    args, worker = create_model_worker()
     uvicorn.run(app, host=args.host, port=args.port, log_level="info")

--- a/fastchat/serve/multi_model_worker.py
+++ b/fastchat/serve/multi_model_worker.py
@@ -152,7 +152,7 @@ async def api_model_details(request: Request):
     return {"context_length": worker.context_len}
 
 
-if __name__ == "__main__":
+def create_multi_model_worker():
     # Note: Ensure we resolve arg conflicts.  We let `add_model_args` add MOST
     # of the model args but we'll override one to have an append action that
     # supports multiple values.
@@ -238,4 +238,9 @@ if __name__ == "__main__":
     r = requests.post(url, json=data)
     assert r.status_code == 200
 
+    return args, workers
+
+
+if __name__ == "__main__":
+    args, workers = create_multi_model_worker()
     uvicorn.run(app, host=args.host, port=args.port, log_level="info")

--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -791,7 +791,7 @@ async def create_chat_completion(request: APIChatCompletionRequest):
 ### END GENERAL API - NOT OPENAI COMPATIBLE ###
 
 
-if __name__ == "__main__":
+def create_openai_api_server():
     parser = argparse.ArgumentParser(
         description="FastChat ChatGPT-Compatible RESTful API server."
     )
@@ -830,5 +830,9 @@ if __name__ == "__main__":
     app_settings.api_keys = args.api_keys
 
     logger.info(f"args: {args}")
+    return args
 
+
+if __name__ == "__main__":
+    args = create_openai_api_server()
     uvicorn.run(app, host=args.host, port=args.port, log_level="info")


### PR DESCRIPTION
user can import create_xxx, app from corresponding serve module, and run the app[s] in sub processes using uvicorn.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

typically fastcat servers run with command `python -m fastchat.serve.xxx --arguments`

by wrapping the argparse and initing codes to a function, user can call the function to init the app and needed variables in multiple process easily.

for example:
```python3
# run controller
from multiprocessing import Process

def run():
    from fastchat.serve.controller import create_controller, app
    import uvicorn

    args, controller = create_controller()
    # any customization
    uvicorn.run(app, host=args.host) # etc.

process = Process(target=run)
process.start()
```

and so on, user can startup several api servers in one script. This modification will not affect the existing running method

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
