### PR TITLE
[Minor] Update the warning to follow the new conv_template file

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -535,7 +535,7 @@ class VicunaAdapter(BaseModelAdapter):
                 "which will generate unexpected results with the "
                 "current fastchat.\nYou can try one of the following methods:\n"
                 "1. Upgrade your weights to the new Vicuna-v1.3: https://github.com/lm-sys/FastChat#vicuna-weights.\n"
-                "2. Use the old conversation template by `python3 -m fastchat.serve.cli --model-path /path/to/vicuna-v0 --conv-template conv_one_shot`\n"
+                "2. Use the old conversation template by `python3 -m fastchat.serve.cli --model-path /path/to/vicuna-v0 --conv-template one_shot`\n"
                 "3. Downgrade fschat to fschat==0.1.10 (Not recommonded).\n"
             )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In the commit #1008 , fastchat updated the model and conversation template, but ignored to sync the warning message in the `model_adapter.py`, which will cause a template cannot find error if user follows the command in the warning.

## Related issue number (if applicable)

In several closed issues (#408 #422 ), the authors of fastchat quoted this warning message, this warning should be updated synchronously with the conv template.

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).

As this is only an updating of warning message, I think there is no related tests and docs to check here.
