### PR TITLE
feat: consider template's stop_token_ids in gen_model_answer

### DIFF
--- a/fastchat/llm_judge/gen_model_answer.py
+++ b/fastchat/llm_judge/gen_model_answer.py
@@ -124,7 +124,11 @@ def get_model_answers(
 
                     # be consistent with the template's stop_token_ids
                     if conv.stop_token_ids:
-                        stop_token_ids_index = [i for i, id in enumerate(output_ids) if id in conv.stop_token_ids]
+                        stop_token_ids_index = [
+                            i
+                            for i, id in enumerate(output_ids)
+                            if id in conv.stop_token_ids
+                        ]
                         if len(stop_token_ids_index) > 0:
                             output_ids = output_ids[:stop_token_ids_index[0]]
 

--- a/fastchat/llm_judge/gen_model_answer.py
+++ b/fastchat/llm_judge/gen_model_answer.py
@@ -121,6 +121,13 @@ def get_model_answers(
                         output_ids = output_ids[0]
                     else:
                         output_ids = output_ids[0][len(input_ids[0]) :]
+
+                    # be consistent with the template's stop_token_ids
+                    if conv.stop_token_ids:
+                        stop_token_ids_index = [i for i, id in enumerate(output_ids) if id in conv.stop_token_ids]
+                        if len(stop_token_ids_index) > 0:
+                            output_ids = output_ids[:stop_token_ids_index[0]]
+
                     output = tokenizer.decode(
                         output_ids,
                         spaces_between_special_tokens=False,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The template's stop_token_ids in gen_model_answer should be considered if it is specified, since developers may use it during training.
<!-- Please give a short summary of the change and the problem this solves. -->
Add the stop_token_ids checking in gen_model_answer phase.
## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
