### PR TITLE
Bug on llama2-chinese conversation templates

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -942,7 +942,7 @@ register_conv_template(
 register_conv_template(
     Conversation(
         name="llama2-chinese",
-        system_message="<s>{system_message}</s>",
+        system_template="<s>{system_message}</s>",
         roles=("Human", "Assistant", "System"),
         messages=(),
         offset=0,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For llama2-chinese, in fastchat/conversations.py line 945: register_conv_template(
    Conversation(
        name="llama2-chinese",
        system_message="<s>{system_message}</s>",
        roles=("Human", "Assistant", "System"),
        messages=(),
        offset=0,

system_message should be changed to system_template.

## Related issue number (if applicable)

Closes #2280


