### PR TITLE
Make all tensors to be on the same device

### DIFF
--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -95,12 +95,12 @@ def generate_stream(
 
     if model.config.is_encoder_decoder:
         encoder_output = model.encoder(
-            input_ids=torch.as_tensor([input_ids], device=device)
+            input_ids=torch.as_tensor([input_ids], device=model.device)
         )[0]
         start_ids = torch.as_tensor(
             [[model.generation_config.decoder_start_token_id]],
             dtype=torch.int64,
-            device=device,
+            device=model.device,
         )
 
     past_key_values = out = None
@@ -115,14 +115,14 @@ def generate_stream(
                 )
                 logits = model.lm_head(out[0])
             else:
-                out = model(torch.as_tensor([input_ids], device=device), use_cache=True)
+                out = model(torch.as_tensor([input_ids], device=model.device), use_cache=True)
                 logits = out.logits
             past_key_values = out.past_key_values
         else:  # decoding
             if model.config.is_encoder_decoder:
                 out = model.decoder(
                     input_ids=torch.as_tensor(
-                        [[token] if not sent_interrupt else output_ids], device=device
+                        [[token] if not sent_interrupt else output_ids], device=model.device
                     ),
                     encoder_hidden_states=encoder_output,
                     use_cache=True,
@@ -134,7 +134,7 @@ def generate_stream(
             else:
                 out = model(
                     input_ids=torch.as_tensor(
-                        [[token] if not sent_interrupt else output_ids], device=device
+                        [[token] if not sent_interrupt else output_ids], device=model.device
                     ),
                     use_cache=True,
                     past_key_values=past_key_values if not sent_interrupt else None,

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -115,14 +115,17 @@ def generate_stream(
                 )
                 logits = model.lm_head(out[0])
             else:
-                out = model(torch.as_tensor([input_ids], device=model.device), use_cache=True)
+                out = model(
+                    torch.as_tensor([input_ids], device=model.device), use_cache=True
+                )
                 logits = out.logits
             past_key_values = out.past_key_values
         else:  # decoding
             if model.config.is_encoder_decoder:
                 out = model.decoder(
                     input_ids=torch.as_tensor(
-                        [[token] if not sent_interrupt else output_ids], device=model.device
+                        [[token] if not sent_interrupt else output_ids],
+                        device=model.device,
                     ),
                     encoder_hidden_states=encoder_output,
                     use_cache=True,
@@ -134,7 +137,8 @@ def generate_stream(
             else:
                 out = model(
                     input_ids=torch.as_tensor(
-                        [[token] if not sent_interrupt else output_ids], device=model.device
+                        [[token] if not sent_interrupt else output_ids],
+                        device=model.device,
                     ),
                     use_cache=True,
                     past_key_values=past_key_values if not sent_interrupt else None,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I found a bug while the llm model running on the specified gpu, such as gpu: 6. It reports "Expected all tensors to be on the same device, but found at least two devices, cuda:6 and cuda:0!".

After researching, I found the input tensors located at the different gpu from the model.

## Related issue number (if applicable)

Closes #2286

## Checks

I try changing the following codes to place the input tensors and the model on the same GPU, and it will not report this error.
