### PR TITLE
Support no user message in llama2

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -122,11 +122,11 @@ class Conversation:
             return ret
         elif self.sep_style == SeparatorStyle.LLAMA2:
             seps = [self.sep, self.sep2]
-            ret = ""
+            ret = system_prompt
             for i, (role, message) in enumerate(self.messages):
                 if message:
                     if i == 0:
-                        ret += system_prompt + message + " "
+                        ret += message + " "
                     else:
                         ret += role + " " + message + seps[i % 2]
                 else:


### PR DESCRIPTION

## Why are these changes needed?

The GPT-4 and GPT-3.5 support it.

Originally, the following code will results in

```
    conv = get_conv_template("llama-2")
    conv.set_system_message("You are a helpful, respectful and honest assistant.")
    conv.append_message(conv.roles[1], None)
    print(conv.get_prompt())
```

```
[/INST]
```

With the change, it will be

```
[INST] <<SYS>>
You are a helpful, respectful and honest assistant.
<</SYS>>

[/INST]
```

## Related issue number (if applicable)

None

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
