### PR TITLE
Update conversation.py

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -228,8 +228,7 @@ class Conversation:
 
     def to_openai_api_messages(self):
         """Convert the conversation to OpenAI chat completion format."""
-        system_prompt = self.system_template.format(system_message=self.system_message)
-        ret = [{"role": "system", "content": system_prompt}]
+        ret = [{"role": "system", "content": self.system_message}]
 
         for i, (_, msg) in enumerate(self.messages[self.offset :]):
             if i % 2 == 0:


### PR DESCRIPTION
OpenAI chat completion API does NOT require the prompt at the start of the `system` message (e.g., do not include `<|im_start|>system\n`) - just the system message itself.

Docs: https://platform.openai.com/docs/guides/gpt/chat-completions-api

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
