### PR TITLE
[fix] lm-sys/FastChat/issues/2295

### DIFF
--- a/fastchat/model/compression.py
+++ b/fastchat/model/compression.py
@@ -167,12 +167,18 @@ def load_compress_model(model_path, device, torch_dtype, use_fast, revision="mai
         tmp_state_dict = torch.load(filename, map_location=lambda storage, loc: storage)
         for name in tmp_state_dict:
             if name in linear_weights:
-                tensor = tmp_state_dict[name].to(device).data.to(torch_dtype)
+                if device == 'mps':
+                    tensor = tmp_state_dict[name].half().to(device).data.to(torch_dtype)
+                else:
+                    tensor = tmp_state_dict[name].to(device).data.to(torch_dtype)
                 compressed_state_dict[name] = compress(
                     tensor, default_compression_config
                 )
             else:
-                compressed_state_dict[name] = tmp_state_dict[name].to(device)
+                if device == 'mps':
+                    compressed_state_dict[name] = tmp_state_dict[name].to(device)
+                else:
+                    compressed_state_dict[name] = tmp_state_dict[name].half().to(device)
             tmp_state_dict[name] = None
             tensor = None
             gc.collect()

--- a/fastchat/model/compression.py
+++ b/fastchat/model/compression.py
@@ -176,9 +176,9 @@ def load_compress_model(model_path, device, torch_dtype, use_fast, revision="mai
                 )
             else:
                 if device == "mps":
-                    compressed_state_dict[name] = tmp_state_dict[name].to(device)
-                else:
                     compressed_state_dict[name] = tmp_state_dict[name].half().to(device)
+                else:
+                    compressed_state_dict[name] = tmp_state_dict[name].to(device)
             tmp_state_dict[name] = None
             tensor = None
             gc.collect()

--- a/fastchat/model/compression.py
+++ b/fastchat/model/compression.py
@@ -167,7 +167,7 @@ def load_compress_model(model_path, device, torch_dtype, use_fast, revision="mai
         tmp_state_dict = torch.load(filename, map_location=lambda storage, loc: storage)
         for name in tmp_state_dict:
             if name in linear_weights:
-                if device == 'mps':
+                if device == "mps":
                     tensor = tmp_state_dict[name].half().to(device).data.to(torch_dtype)
                 else:
                     tensor = tmp_state_dict[name].to(device).data.to(torch_dtype)
@@ -175,7 +175,7 @@ def load_compress_model(model_path, device, torch_dtype, use_fast, revision="mai
                     tensor, default_compression_config
                 )
             else:
-                if device == 'mps':
+                if device == "mps":
                     compressed_state_dict[name] = tmp_state_dict[name].to(device)
                 else:
                     compressed_state_dict[name] = tmp_state_dict[name].half().to(device)

--- a/fastchat/model/compression.py
+++ b/fastchat/model/compression.py
@@ -167,18 +167,12 @@ def load_compress_model(model_path, device, torch_dtype, use_fast, revision="mai
         tmp_state_dict = torch.load(filename, map_location=lambda storage, loc: storage)
         for name in tmp_state_dict:
             if name in linear_weights:
-                if device == "mps":
-                    tensor = tmp_state_dict[name].half().to(device).data.to(torch_dtype)
-                else:
-                    tensor = tmp_state_dict[name].to(device).data.to(torch_dtype)
+                tensor = tmp_state_dict[name].to(device, dtype=torch_dtype)
                 compressed_state_dict[name] = compress(
                     tensor, default_compression_config
                 )
             else:
-                if device == "mps":
-                    compressed_state_dict[name] = tmp_state_dict[name].half().to(device)
-                else:
-                    compressed_state_dict[name] = tmp_state_dict[name].to(device)
+                compressed_state_dict[name] = tmp_state_dict[name].to(device, dtype=torch_dtype)
             tmp_state_dict[name] = None
             tensor = None
             gc.collect()

--- a/fastchat/model/compression.py
+++ b/fastchat/model/compression.py
@@ -172,7 +172,9 @@ def load_compress_model(model_path, device, torch_dtype, use_fast, revision="mai
                     tensor, default_compression_config
                 )
             else:
-                compressed_state_dict[name] = tmp_state_dict[name].to(device, dtype=torch_dtype)
+                compressed_state_dict[name] = tmp_state_dict[name].to(
+                    device, dtype=torch_dtype
+                )
             tmp_state_dict[name] = None
             tensor = None
             gc.collect()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
> First,I use  python -m fastchat.serve.cli --model-path /my/mac/path/llm_models/chatglm2-6b --load-8bit --device mps
to run chatglm2-6b.But I got this error: Trying to convert BFloat16 to the MPS backend but it does not have support for that dtype.

## Related issue number (if applicable)
#2295 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
