### PR TITLE
Document turning off proxy_buffering when api is streaming

### DIFF
--- a/docs/openai_api.md
+++ b/docs/openai_api.md
@@ -62,7 +62,7 @@ completion = openai.ChatCompletion.create(
 print(completion.choices[0].message.content)
 ```
 
-Streaming is also supported. See [test_openai_api.py](../tests/test_openai_api.py).
+Streaming is also supported. See [test_openai_api.py](../tests/test_openai_api.py).  If your api server is behind a proxy you'll need to turn off buffering, you can do so in Nginx by setting `proxy_buffering off;` in the location block for the proxy.
 
 ### cURL
 cURL is another good tool for observing the output of the api.


### PR DESCRIPTION
I hit this when running the api service behind an nginx proxy.  The responses were streamed as chunks but they all arrived to the browser at the some time.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

 I'm guessing that running behind an web server proxy is a pretty standard way to add fast chat to an existing domain with SSL and mentioning it here might help someone out.

<!-- Please give a short summary of the change and the problem this solves. -->

Document turning of buffering when running behind a proxy.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
