### PR TITLE
Add support for Phind-CodeLlama models (#2415)

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -930,6 +930,19 @@ register_conv_template(
     )
 )
 
+# Phind template
+register_conv_template(
+    Conversation(
+        name="phind",
+        system_message="### System Prompt\nYou are an intelligent programming assistant.",
+        roles=("### User Message", "### Assistant"),
+        messages=(),
+        offset=0,
+        sep_style=SeparatorStyle.ADD_COLON_SINGLE,
+        sep="\n\n",
+    )
+)
+
 
 if __name__ == "__main__":
     print("Vicuna template:")

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1593,6 +1593,16 @@ class CodeLlamaAdapter(BaseModelAdapter):
         return get_conv_template("llama-2")
 
 
+class PhindCodeLlamaAdapter(CodeLlamaAdapter):
+    """The model adapter for Phind Code Llama"""
+
+    def match(self, model_path: str):
+        return "Phind" in model_path
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("phind")
+
+
 # Note: the registration order matters.
 # The one registered earlier has a higher matching priority.
 register_model_adapter(PeftModelAdapter)
@@ -1650,6 +1660,7 @@ register_model_adapter(VigogneInstructAdapter)
 register_model_adapter(VigogneChatAdapter)
 register_model_adapter(OpenLLaMaOpenInstructAdapter)
 register_model_adapter(ReaLMAdapter)
+register_model_adapter(PhindCodeLlamaAdapter)
 register_model_adapter(CodeLlamaAdapter)
 
 # After all adapters, try the default base adapter.

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1597,7 +1597,7 @@ class PhindCodeLlamaAdapter(CodeLlamaAdapter):
     """The model adapter for Phind Code Llama"""
 
     def match(self, model_path: str):
-        return "Phind" in model_path
+        return "phind-codellama-" in model_path.lower()
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("phind")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
 
<!-- Please give a short summary of the change and the problem this solves. -->
Phind-Codellama was trained on a different instruction template than Code Llama.
The rest is the same.
So we add the conversation template and inherit from the model adapter of Code Llama to override `get_default_conv_template`.
## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->
Closes #2415.

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
