### PR TITLE
Add Ascend NPU support

### DIFF
--- a/fastchat/model/compression.py
+++ b/fastchat/model/compression.py
@@ -193,6 +193,8 @@ def load_compress_model(model_path, device, torch_dtype, use_fast, revision="mai
             torch.cuda.empty_cache()
             if device == "xpu":
                 torch.xpu.empty_cache()
+            if device == "npu":
+                torch.npu.empty_cache()
 
     for name in model.state_dict():
         if name not in linear_weights:

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -206,6 +206,13 @@ def load_model(
             warnings.warn(
                 "Intel Extension for PyTorch is not installed, but is required for xpu inference."
             )
+    elif device == "npu":
+        kwargs = {"torch_dtype": torch.float16}
+        # Try to load ipex, while it looks unused, it links into torch for xpu support
+        try:
+            import torch_npu
+        except ImportError:
+            warnings.warn("Ascend Extension for PyTorch is not installed.")
     else:
         raise ValueError(f"Invalid device: {device}")
 
@@ -288,6 +295,7 @@ def load_model(
     if (device == "cuda" and num_gpus == 1 and not cpu_offloading) or device in (
         "mps",
         "xpu",
+        "npu",
     ):
         model.to(device)
 
@@ -369,7 +377,7 @@ def add_model_args(parser):
     parser.add_argument(
         "--device",
         type=str,
-        choices=["cpu", "cuda", "mps", "xpu"],
+        choices=["cpu", "cuda", "mps", "xpu", "npu"],
         default="cuda",
         help="The device type",
     )

--- a/fastchat/model/model_codet5p.py
+++ b/fastchat/model/model_codet5p.py
@@ -104,3 +104,5 @@ def generate_stream_codet5p(
     torch.cuda.empty_cache()
     if device == "xpu":
         torch.xpu.empty_cache()
+    if device == "npu":
+        torch.npu.empty_cache()

--- a/fastchat/model/model_falcon.py
+++ b/fastchat/model/model_falcon.py
@@ -136,3 +136,5 @@ def generate_stream_falcon(
     torch.cuda.empty_cache()
     if device == "xpu":
         torch.xpu.empty_cache()
+    if device == "npu":
+        torch.npu.empty_cache()

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -263,6 +263,8 @@ def generate_stream(
     torch.cuda.empty_cache()
     if device == "xpu":
         torch.xpu.empty_cache()
+    if device == "npu":
+        torch.npu.empty_cache()
 
 
 class ChatIO(abc.ABC):

--- a/fastchat/serve/launch_all_serve.py
+++ b/fastchat/serve/launch_all_serve.py
@@ -66,7 +66,7 @@ parser.add_argument(
 parser.add_argument(
     "--device",
     type=str,
-    choices=["cpu", "cuda", "mps", "xpu"],
+    choices=["cpu", "cuda", "mps", "xpu", "npu"],
     default="cuda",
     help="The device type",
 )

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -370,6 +370,8 @@ class ModelWorker(BaseModelWorker):
             torch.cuda.empty_cache()
             if self.device == "xpu":
                 torch.xpu.empty_cache()
+            if self.device == "npu":
+                torch.npu.empty_cache()
         except torch.cuda.OutOfMemoryError as e:
             ret = {
                 "text": f"{SERVER_ERROR_MSG}\n\n({e})",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR integrates Ascend NPU hardware capabilities into the FastChat,  and enables users to leverage the NPUs for training, inference and serving of LLMs. 

[Ascend NPU](https://www.hiascend.com/en/) is an AI processor that support AI frameworks like PyTorch, TensorFlow, which has already integrated by [huggingface](https://github.com/huggingface/accelerate/commit/c33adecc9f92808cbaeb0d34928e52e34180f964), [deepspeed](https://github.com/microsoft/DeepSpeed/commit/23a11a39510e2aefb48236e3d2672a7dcbfc42a3) and others popular LLM related software and tools.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->
N/A
## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).

## Use Cases

### inference with cli test with 1 * Ascend 910B
```shell
$ python -m fastchat.serve.cli --model-path ~/vicuna-7b-v1.5-16k --device npu 

USER: hello
ASSISTANT: Hello! How can I assist you today?
USER: Provide three most famous deep learning frameworks
ASSISTANT: Sure, here are three of the most famous deep learning frameworks:

1. TensorFlow: Developed by Google, TensorFlow is an open-source deep learning framework that is widely used for building and deploying machine learning models. It is known for its flexibility and scalability, and is used by researchers and developers alike.
2. PyTorch: Developed by Facebook, PyTorch is another popular deep learning framework that is known for its ease of use and flexibility. It is often used for research purposes, as well as for building and deploying machine learning models.
3. Keras: Keras is a high-level deep learning framework that is built on top of TensorFlow. It is designed to be user-friendly and easy to use, making it a popular choice for beginners and researchers alike. Keras is also known for its ability to quickly prototype and test new ideas.
USER: 
```

### Fine-tuning test with 4 * Ascend 910B

```shell
torchrun --nproc_per_node=4 --master_port=20001 fastchat/train/train.py \
    --model_name_or_path ~/vicuna-7b-v1.5-16k  \
    --data_path data/dummy_conversation.json \
    --fp16 True \
    --output_dir output_vicuna \
    --num_train_epochs 3 \
    --per_device_train_batch_size 8 \
    --per_device_eval_batch_size 1 \
    --gradient_accumulation_steps 1 \
    --evaluation_strategy "no" \
    --save_strategy "steps" \
    --save_steps 2000 \
    --save_total_limit 200 \
    --learning_rate 1e-5 \
    --weight_decay 0. \
    --lr_scheduler_type "cosine" \
    --logging_steps 1 \
    --fsdp "full_shard auto_wrap" \
    --fsdp_transformer_layer_cls_to_wrap 'LlamaDecoderLayer' \
    --tf32 False \
    --model_max_length 512 \
    --gradient_checkpointing True \
    --lazy_preprocess True | tee train.log
```

```log
[2023-09-13 10:20:36,763] torch.distributed.run: [WARNING] 
[2023-09-13 10:20:36,763] torch.distributed.run: [WARNING] *****************************************
[2023-09-13 10:20:36,763] torch.distributed.run: [WARNING] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
[2023-09-13 10:20:36,763] torch.distributed.run: [WARNING] *****************************************
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:12<00:00,  6.04s/it]
Loading checkpoint shards:  50%|███████████████████████████████████████████                                           | 1/2 [00:13<00:13, 13.34s/it][W LegacyTypeDispatch.h:74] Warning: AutoNonVariableTypeMode is deprecated and will be removed in 1.10 release. For kernel implementations please use AutoDispatchBelowADInplaceOrView instead, If you are looking for a user facing API to enable running your inference-only workload, please use c10::InferenceMode. Using AutoDispatchBelowADInplaceOrView in user code is under risk of producing silent wrong result in some edge cases. See Note [AutoDispatchBelowAutograd] for more details. (function operator())
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:17<00:00,  8.99s/it]
[W LegacyTypeDispatch.h:74] Warning: AutoNonVariableTypeMode is deprecated and will be removed in 1.10 release. For kernel implementations please use AutoDispatchBelowADInplaceOrView instead, If you are looking for a user facing API to enable running your inference-only workload, please use c10::InferenceMode. Using AutoDispatchBelowADInplaceOrView in user code is under risk of producing silent wrong result in some edge cases. See Note [AutoDispatchBelowAutograd] for more details. (function operator())
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:18<00:00,  9.24s/it]
[W LegacyTypeDispatch.h:74] Warning: AutoNonVariableTypeMode is deprecated and will be removed in 1.10 release. For kernel implementations please use AutoDispatchBelowADInplaceOrView instead, If you are looking for a user facing API to enable running your inference-only workload, please use c10::InferenceMode. Using AutoDispatchBelowADInplaceOrView in user code is under risk of producing silent wrong result in some edge cases. See Note [AutoDispatchBelowAutograd] for more details. (function operator())
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:49<00:00, 24.53s/it]
Loading data...
Formatting inputs...Skip in lazy mode
[W LegacyTypeDispatch.h:74] Warning: AutoNonVariableTypeMode is deprecated and will be removed in 1.10 release. For kernel implementations please use AutoDispatchBelowADInplaceOrView instead, If you are looking for a user facing API to enable running your inference-only workload, please use c10::InferenceMode. Using AutoDispatchBelowADInplaceOrView in user code is under risk of producing silent wrong result in some edge cases. See Note [AutoDispatchBelowAutograd] for more details. (function operator())
  0%|                                                                                                                        | 0/87 [00:00<?, ?it/s][W OpCommand.cpp:117] Warning: [Check][offset] Check input storage_offset[%ld] = 0 failed, result is untrustworthy16777216 (function operator())
[W OpCommand.cpp:117] Warning: [Check][offset] Check input storage_offset[%ld] = 0 failed, result is untrustworthy16777216 (function operator())
[W OpCommand.cpp:117] Warning: [Check][offset] Check input storage_offset[%ld] = 0 failed, result is untrustworthy16777216 (function operator())
[W OpCommand.cpp:117] Warning: [Check][offset] Check input storage_offset[%ld] = 0 failed, result is untrustworthy16777216 (function operator())
[W VariableFallbackKernel.cpp:40] Warning: The operator 'aten::linalg_vector_norm.out' is not currently supported on the NPU backend and will fall back to run on the CPU. This may have performance implications. (function operator())
[W VariableFallbackKernel.cpp:40] Warning: The operator 'aten::linalg_vector_norm.out' is not currently supported on the NPU backend and will fall back to run on the CPU. This may have performance implications. (function operator())
[W VariableFallbackKernel.cpp:40] Warning: The operator 'aten::linalg_vector_norm.out' is not currently supported on the NPU backend and will fall back to run on the CPU. This may have performance implications. (function operator())
[W VariableFallbackKernel.cpp:40] Warning: The operator 'aten::linalg_vector_norm.out' is not currently supported on the NPU backend and will fall back to run on the CPU. This may have performance implications. (function operator())
  1%|█▎                                                                                                           | 1/87 [02:38<3:47:11, 158.51s/it]{'loss': 0.2701, 'learning_rate': 9.996740476948386e-06, 'epoch': 0.03}                                                                             
{'loss': 0.9416, 'learning_rate': 9.986966157589751e-06, 'epoch': 0.07}                                                                             
{'loss': 0.2061, 'learning_rate': 9.970689785771798e-06, 'epoch': 0.1}                                                                              
{'loss': 0.3403, 'learning_rate': 9.947932582778188e-06, 'epoch': 0.14}                                                                             

// ... ...
                                                                          
{'loss': 0.1071, 'learning_rate': 5.206741722181385e-08, 'epoch': 2.86}                                                                             
{'loss': 0.1074, 'learning_rate': 2.9310214228202016e-08, 'epoch': 2.9}                                                                             
{'loss': 0.1088, 'learning_rate': 1.3033842410251074e-08, 'epoch': 2.93}                                                                            
{'loss': 0.1061, 'learning_rate': 3.2595230516152543e-09, 'epoch': 2.97}                                                                            
{'loss': 0.1076, 'learning_rate': 0.0, 'epoch': 3.0}                                                                                                
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 87/87 [2:19:10<00:00, 93.97s/it]{'train_runtime': 8350.1159, 'train_samples_per_second': 0.327, 'train_steps_per_second': 0.01, 'train_loss': 0.14017466147398128, 'epoch': 3.0}    
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 87/87 [2:19:16<00:00, 96.05s/it]
```