### PR TITLE
Fixed character overlap issue when api streaming output

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -435,7 +435,7 @@ async def chat_completion_stream_generator(
                 return
             decoded_unicode = content["text"].replace("\ufffd", "")
             delta_text = decoded_unicode[len(previous_text) :]
-            previous_text = decoded_unicode
+            previous_text = decoded_unicode if len(decoded_unicode) > len(previous_text) else previous_text
 
             if len(delta_text) == 0:
                 delta_text = None
@@ -554,7 +554,7 @@ async def generate_completion_stream_generator(
                     return
                 decoded_unicode = content["text"].replace("\ufffd", "")
                 delta_text = decoded_unicode[len(previous_text) :]
-                previous_text = decoded_unicode
+                previous_text = decoded_unicode if len(decoded_unicode) > len(previous_text) else previous_text
                 # todo: index is not apparent
                 choice_data = CompletionResponseStreamChoice(
                     index=i,


### PR DESCRIPTION
The model generates non-streaming output "初诊招待的工作程序包括以下....." when asking "以下是《技能操作》（心理咨询师考试）科目的问题，请解答并把回复控制在50个汉字左右。\n简述初诊招待的工作程序。".

without this fix, the streaming output of the model will look like this:
"初"
"诊"
"诊招"
"诊招待"
"的"
"工"
"作"
"程"
....