### PR TITLE
[WIP] Add microsoft/phi-1_5

### DIFF
--- a/docs/model_support.md
+++ b/docs/model_support.md
@@ -45,6 +45,7 @@
 - [WizardLM/WizardLM-13B-V1.0](https://huggingface.co/WizardLM/WizardLM-13B-V1.0)
 - [WizardLM/WizardCoder-15B-V1.0](https://huggingface.co/WizardLM/WizardCoder-15B-V1.0)
 - [HuggingFaceH4/starchat-beta](https://huggingface.co/HuggingFaceH4/starchat-beta)
+- [microsoft/phi-1_5](https://huggingface.co/microsoft/phi-1_5)
 - Any [EleutherAI](https://huggingface.co/EleutherAI) pythia model such as [pythia-6.9b](https://huggingface.co/EleutherAI/pythia-6.9b)
 - Any [Peft](https://github.com/huggingface/peft) adapter trained on top of a
   model above.  To activate, must have `peft` in the model path.  Note: If

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -980,6 +980,17 @@ register_conv_template(
     )
 )
 
+# phi-1_5 template
+# source: https://huggingface.co/microsoft/phi-1_5
+register_conv_template(
+    Conversation(
+        name="phi-1_5",
+        roles=("User", "Assistant"),
+        offset=0,
+        sep_style=SeparatorStyle.ADD_COLON_SINGLE,
+        sep="\n",
+    )
+)
 
 if __name__ == "__main__":
     print("Vicuna template:")

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1629,6 +1629,16 @@ class PhindCodeLlamaAdapter(CodeLlamaAdapter):
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("phind")
 
+class PhiAdapter(BaseModelAdapter):
+    """The model adapter for microsoft/phi-1_5"""
+
+    use_fast_tokenizer = False
+
+    def match(self, model_path: str):
+        return "phi-1_5" in model_path.lower()
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("phi-1_5")
 
 # Note: the registration order matters.
 # The one registered earlier has a higher matching priority.
@@ -1690,6 +1700,7 @@ register_model_adapter(OpenLLaMaOpenInstructAdapter)
 register_model_adapter(ReaLMAdapter)
 register_model_adapter(PhindCodeLlamaAdapter)
 register_model_adapter(CodeLlamaAdapter)
+register_model_adapter(PhiAdapter)
 
 # After all adapters, try the default base adapter.
 register_model_adapter(BaseModelAdapter)

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1629,6 +1629,7 @@ class PhindCodeLlamaAdapter(CodeLlamaAdapter):
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("phind")
 
+
 class PhiAdapter(BaseModelAdapter):
     """The model adapter for microsoft/phi-1_5"""
 
@@ -1639,6 +1640,7 @@ class PhiAdapter(BaseModelAdapter):
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("phi-1_5")
+
 
 # Note: the registration order matters.
 # The one registered earlier has a higher matching priority.


### PR DESCRIPTION
## Why are these changes needed?
Adding the `microsoft/phi-1_5` model from the recent paper: https://arxiv.org/pdf/2309.05463.pdf

Note that the model has not gone through instruction tuning, so it's chat capabilities are actually quite limited, especially since it's only a 1.3B model. We attempt to get it into "chat mode" by using the prompt “Person A: [chat]/nPerson B:” (check page 10 of the paper above).

## Related issue number (if applicable)

#2435 

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
