### PR TITLE
Add Optional SSL Support to controller.py

### DIFF
--- a/fastchat/serve/controller.py
+++ b/fastchat/serve/controller.py
@@ -8,6 +8,7 @@ import dataclasses
 from enum import Enum, auto
 import json
 import logging
+import os
 import time
 from typing import List, Union
 import threading

--- a/fastchat/serve/controller.py
+++ b/fastchat/serve/controller.py
@@ -318,6 +318,13 @@ def create_controller():
         choices=["lottery", "shortest_queue"],
         default="shortest_queue",
     )
+    parser.add_argument(
+        "--ssl",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Enable SSL. Requires OS Environment variables 'SSL_KEYFILE' and 'SSL_CERTFILE'.",
+    )
     args = parser.parse_args()
     logger.info(f"args: {args}")
 
@@ -327,4 +334,13 @@ def create_controller():
 
 if __name__ == "__main__":
     args, controller = create_controller()
-    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+    if args.ssl:
+        uvicorn.run(
+            app, 
+            host=args.host, 
+            port=args.port, 
+            log_level="info", 
+            ssl_keyfile=os.environ["SSL_KEYFILE"], 
+            ssl_certfile=os.environ["SSL_CERTFILE"])
+    else:
+        uvicorn.run(app, host=args.host, port=args.port, log_level="info")

--- a/fastchat/serve/controller.py
+++ b/fastchat/serve/controller.py
@@ -341,6 +341,7 @@ if __name__ == "__main__":
             port=args.port, 
             log_level="info", 
             ssl_keyfile=os.environ["SSL_KEYFILE"], 
-            ssl_certfile=os.environ["SSL_CERTFILE"])
+            ssl_certfile=os.environ["SSL_CERTFILE"]
+        )
     else:
         uvicorn.run(app, host=args.host, port=args.port, log_level="info")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
By default, controller.py launches a server that does not support SSL. This adds an optional parameter that allows the user to add SSL support once they set two environment variables.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
