### PR TITLE
Update openai_api_server.py to add an SSL option

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -803,6 +803,13 @@ def create_openai_api_server():
         type=lambda s: s.split(","),
         help="Optional list of comma separated API keys",
     )
+    parser.add_argument(
+        "--ssl",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Enable SSL. Requires OS Environment variables 'SSL_KEYFILE' and 'SSL_CERTFILE'.",
+    )
     args = parser.parse_args()
 
     app.add_middleware(
@@ -821,4 +828,14 @@ def create_openai_api_server():
 
 if __name__ == "__main__":
     args = create_openai_api_server()
-    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+    if args.ssl:
+        uvicorn.run(
+            app,
+            host=args.host,
+            port=args.port,
+            log_level="info",
+            ssl_keyfile=os.environ["SSL_KEYFILE"],
+            ssl_certfile=os.environ["SSL_CERTFILE"],
+        )
+    else:
+        uvicorn.run(app, host=args.host, port=args.port, log_level="info")


### PR DESCRIPTION
## Why are these changes needed?
By default, openai_api_server.py launches a server that does not support SSL. This adds an optional parameter that allows the user to add SSL support once the user sets two environment variables.

I'm slowly getting through adding SSL options to all of the server scripts.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
