### PR TITLE
Third Party UI Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ This is the user interface that users will interact with.
 By following these steps, you will be able to serve your models using the web UI. You can open your browser and chat with a model now.
 If the models do not show up, try to reboot the gradio web server.
 
-#### (Optional): Advanced Features
+#### (Optional): Advanced Features, Scalability
 - You can register multiple model workers to a single controller, which can be used for serving a single model with higher throughput or serving multiple models at the same time. When doing so, please allocate different GPUs and ports for different model workers.
 ```
 # worker 0
@@ -239,6 +239,13 @@ CUDA_VISIBLE_DEVICES=1 python3 -m fastchat.serve.model_worker --model-path lmsys
 python3 -m fastchat.serve.gradio_web_server_multi
 ```
 - The default model worker based on huggingface/transformers has great compatibility but can be slow. If you want high-throughput batched serving, you can try [vLLM integration](docs/vllm_integration.md).
+
+#### (Optional): Advanced Features, Third Party UI
+- if you want to host it on your own UI or third party UI. Launch the OpenAI compatible server, host with a hosting service like ngrok, and enter the credentials approriatly.
+    - https://github.com/WongSaang/chatgpt-ui
+    - https://github.com/mckaywrigley/chatbot-ui
+- Note some third party provider only offer the stand `gpt-3.5-turbo, gpt-4, etc`, so you will have to add your own custom model inside the code. [Here is an example of a modification of creating a UI with any custom model name](https://github.com/ztjhz/BetterChatGPT/pull/461)
+
 
 ## API
 ### OpenAI-Compatible RESTful APIs & SDK


### PR DESCRIPTION
Problem statment: There are alot of powerfull LLMs backend with a bad UI and alot of nice front end LLMw with bad/unscalable backend. 

This PR explains how to use this scalable repository with any thirdparty openai API compatible UI

this will make libraries like [llama-gpt]https://github.com/getumbrel/llama-gpt
 obsolete as the focus of this project is nice UI, but has a unscallable backend

Here is how to test it
1. host Fast Chat.
2. Host the server via ngrok
3. Enter in your credentials into a webUI. [I recommend this example as it is all put together](https://github.com/ztjhz/BetterChatGPT/pull/461)
![image](https://github.com/ztjhz/BetterChatGPT/assets/47466848/55c3628c-fc62-4e2e-aa6a-3f1117b12fca)
4. Choose a model supported by your API
![image](https://github.com/ztjhz/BetterChatGPT/assets/47466848/5af9b957-6194-4d39-8710-e3313436bbe0)
5. Start chating with a nice UI on a local private server!!
![image](https://github.com/lm-sys/FastChat/assets/47466848/0a0a0998-df2e-4a27-bb86-26ffdcc8758b)

