### PR TITLE
Add metharme (pygmalion) conversation template

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -981,6 +981,22 @@ register_conv_template(
     )
 )
 
+# Metharme formatting for Pygmalion models
+# source: https://huggingface.co/PygmalionAI/pygmalion-2-13b
+register_conv_template(
+    Conversation(
+        name="metharme",
+        system_template="<|system|>{system_message}",
+        system_message="""Enter RP mode. You shall reply to the user while staying 
+        in character. Your responses must be detailed, creative, immersive, and drive the scenario
+        forward.""",
+        roles=("<|user|>", "<|model|>"),
+        sep_style=SeparatorStyle.NO_COLON_SINGLE,
+        sep="",
+        stop_str="<|user|>",
+    )
+)
+
 
 if __name__ == "__main__":
     print("Vicuna template:")


### PR DESCRIPTION
This PR adds a conversation template for the Metharme formatting, used by [Pygmalion](https://huggingface.co/PygmalionAI) models.

