### PR TITLE
move BaseModelWorker outside serve.model_worker to make it independent

### DIFF
--- a/fastchat/serve/base_model_worker.py
+++ b/fastchat/serve/base_model_worker.py
@@ -1,0 +1,143 @@
+import time
+import threading
+import requests
+from fastchat.constants import WORKER_HEART_BEAT_INTERVAL
+from fastchat.conversation import Conversation
+from fastchat.utils import pretty_print_semaphore
+from typing import List
+
+
+def heart_beat_worker(obj):
+    while True:
+        time.sleep(WORKER_HEART_BEAT_INTERVAL)
+        obj.send_heart_beat()
+
+
+class BaseModelWorker:
+    def __init__(
+        self,
+        controller_addr: str,
+        worker_addr: str,
+        worker_id: str,
+        model_path: str,
+        model_names: List[str],
+        limit_worker_concurrency: int,
+        conv_template: str = None,
+    ):
+        self.controller_addr = controller_addr
+        self.worker_addr = worker_addr
+        self.worker_id = worker_id
+        if model_path.endswith("/"):
+            model_path = model_path[:-1]
+        self.model_names = model_names or [model_path.split("/")[-1]]
+        self.limit_worker_concurrency = limit_worker_concurrency
+        self.conv = self.get_conv_template(conv_template, model_path)
+        self.tokenizer = None
+        self.context_len = None
+        self.call_ct = 0
+        self.semaphore = None
+
+        self.heart_beat_thread = None
+
+    def get_conv_template(
+        self,
+        conv_template: str = None,
+        model_path: str = None,
+    )-> Conversation:
+        '''
+        can be overrided to costomize the conversation template for different model workers.
+        '''
+        from fastchat.conversation import get_conv_template
+        from fastchat.model.model_adapter import get_conversation_template
+
+        if conv_template:
+            conv = get_conv_template(conv_template)
+        else:
+            conv = get_conversation_template(model_path)
+        conv.sep_style = int(conv.sep_style)
+        return conv
+
+    def init_heart_beat(self):
+        self.register_to_controller()
+        self.heart_beat_thread = threading.Thread(
+            target=heart_beat_worker,
+            args=(self,),
+            daemon=True,
+        )
+        self.heart_beat_thread.start()
+
+    def register_to_controller(self):
+        logger.info("Register to controller")
+
+        url = self.controller_addr + "/register_worker"
+        data = {
+            "worker_name": self.worker_addr,
+            "check_heart_beat": True,
+            "worker_status": self.get_status(),
+        }
+        r = requests.post(url, json=data)
+        assert r.status_code == 200
+
+    def send_heart_beat(self):
+        logger.info(
+            f"Send heart beat. Models: {self.model_names}. "
+            f"Semaphore: {pretty_print_semaphore(self.semaphore)}. "
+            f"call_ct: {self.call_ct}. "
+            f"worker_id: {self.worker_id}. "
+        )
+
+        url = self.controller_addr + "/receive_heart_beat"
+
+        while True:
+            try:
+                ret = requests.post(
+                    url,
+                    json={
+                        "worker_name": self.worker_addr,
+                        "queue_length": self.get_queue_length(),
+                    },
+                    timeout=5,
+                )
+                exist = ret.json()["exist"]
+                break
+            except (requests.exceptions.RequestException, KeyError) as e:
+                logger.error(f"heart beat error: {e}")
+            time.sleep(5)
+
+        if not exist:
+            self.register_to_controller()
+
+    def get_queue_length(self):
+        if (
+            self.semaphore is None
+            or self.semaphore._value is None
+            or self.semaphore._waiters is None
+        ):
+            return 0
+        else:
+            return (
+                self.limit_worker_concurrency
+                - self.semaphore._value
+                + len(self.semaphore._waiters)
+            )
+
+    def get_status(self):
+        return {
+            "model_names": self.model_names,
+            "speed": 1,
+            "queue_length": self.get_queue_length(),
+        }
+
+    def count_token(self, params):
+        prompt = params["prompt"]
+        input_ids = self.tokenizer(prompt).input_ids
+        input_echo_len = len(input_ids)
+
+        ret = {
+            "count": input_echo_len,
+            "error_code": 0,
+        }
+        return ret
+
+    def get_conv_template(self):
+        return {"conv": self.conv}

--- a/fastchat/serve/huggingface_api_worker.py
+++ b/fastchat/serve/huggingface_api_worker.py
@@ -28,7 +28,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from huggingface_hub import InferenceClient
 
 from fastchat.constants import SERVER_ERROR_MSG, ErrorCode
-from fastchat.serve.model_worker import BaseModelWorker
+from fastchat.serve.base_model_worker import BaseModelWorker
 from fastchat.utils import build_logger
 
 worker_id = str(uuid.uuid4())[:8]

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -9,14 +9,11 @@ import gc
 import logging
 import json
 import os
-import threading
-import time
 from typing import List, Optional
 import uuid
 
 from fastapi import FastAPI, Request, BackgroundTasks
 from fastapi.responses import StreamingResponse, JSONResponse
-import requests
 
 try:
     from transformers import (
@@ -37,19 +34,17 @@ import torch.nn.functional as F
 from transformers import set_seed
 import uvicorn
 
-from fastchat.constants import WORKER_HEART_BEAT_INTERVAL, ErrorCode, SERVER_ERROR_MSG
-from fastchat.conversation import get_conv_template
+from fastchat.constants import ErrorCode, SERVER_ERROR_MSG
 from fastchat.model.model_adapter import (
     load_model,
     add_model_args,
-    get_conversation_template,
     get_generate_stream_function,
 )
+from fastchat.serve.base_model_worker import BaseModelWorker
 from fastchat.modules.gptq import GptqConfig
 from fastchat.modules.awq import AWQConfig
 from fastchat.utils import (
     build_logger,
-    pretty_print_semaphore,
     get_context_length,
     str_to_torch_dtype,
 )
@@ -59,128 +54,6 @@ worker_id = str(uuid.uuid4())[:8]
 logger = build_logger("model_worker", f"model_worker_{worker_id}.log")
 
 app = FastAPI()
-
-
-def heart_beat_worker(obj):
-    while True:
-        time.sleep(WORKER_HEART_BEAT_INTERVAL)
-        obj.send_heart_beat()
-
-
-class BaseModelWorker:
-    def __init__(
-        self,
-        controller_addr: str,
-        worker_addr: str,
-        worker_id: str,
-        model_path: str,
-        model_names: List[str],
-        limit_worker_concurrency: int,
-        conv_template: str = None,
-    ):
-        self.controller_addr = controller_addr
-        self.worker_addr = worker_addr
-        self.worker_id = worker_id
-        if model_path.endswith("/"):
-            model_path = model_path[:-1]
-        self.model_names = model_names or [model_path.split("/")[-1]]
-        self.limit_worker_concurrency = limit_worker_concurrency
-        if conv_template:
-            self.conv = get_conv_template(conv_template)
-        else:
-            self.conv = get_conversation_template(model_path)
-        self.conv.sep_style = int(self.conv.sep_style)
-        self.tokenizer = None
-        self.context_len = None
-        self.call_ct = 0
-        self.semaphore = None
-
-        self.heart_beat_thread = None
-
-    def init_heart_beat(self):
-        self.register_to_controller()
-        self.heart_beat_thread = threading.Thread(
-            target=heart_beat_worker,
-            args=(self,),
-            daemon=True,
-        )
-        self.heart_beat_thread.start()
-
-    def register_to_controller(self):
-        logger.info("Register to controller")
-
-        url = self.controller_addr + "/register_worker"
-        data = {
-            "worker_name": self.worker_addr,
-            "check_heart_beat": True,
-            "worker_status": self.get_status(),
-        }
-        r = requests.post(url, json=data)
-        assert r.status_code == 200
-
-    def send_heart_beat(self):
-        logger.info(
-            f"Send heart beat. Models: {self.model_names}. "
-            f"Semaphore: {pretty_print_semaphore(self.semaphore)}. "
-            f"call_ct: {self.call_ct}. "
-            f"worker_id: {self.worker_id}. "
-        )
-
-        url = self.controller_addr + "/receive_heart_beat"
-
-        while True:
-            try:
-                ret = requests.post(
-                    url,
-                    json={
-                        "worker_name": self.worker_addr,
-                        "queue_length": self.get_queue_length(),
-                    },
-                    timeout=5,
-                )
-                exist = ret.json()["exist"]
-                break
-            except (requests.exceptions.RequestException, KeyError) as e:
-                logger.error(f"heart beat error: {e}")
-            time.sleep(5)
-
-        if not exist:
-            self.register_to_controller()
-
-    def get_queue_length(self):
-        if (
-            self.semaphore is None
-            or self.semaphore._value is None
-            or self.semaphore._waiters is None
-        ):
-            return 0
-        else:
-            return (
-                self.limit_worker_concurrency
-                - self.semaphore._value
-                + len(self.semaphore._waiters)
-            )
-
-    def get_status(self):
-        return {
-            "model_names": self.model_names,
-            "speed": 1,
-            "queue_length": self.get_queue_length(),
-        }
-
-    def count_token(self, params):
-        prompt = params["prompt"]
-        input_ids = self.tokenizer(prompt).input_ids
-        input_echo_len = len(input_ids)
-
-        ret = {
-            "count": input_echo_len,
-            "error_code": 0,
-        }
-        return ret
-
-    def get_conv_template(self):
-        return {"conv": self.conv}
 
 
 class ModelWorker(BaseModelWorker):

--- a/fastchat/serve/vllm_worker.py
+++ b/fastchat/serve/vllm_worker.py
@@ -18,8 +18,8 @@ from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.sampling_params import SamplingParams
 from vllm.utils import random_uuid
 
+from fastchat.serve.base_model_worker import BaseModelWorker
 from fastchat.serve.model_worker import (
-    BaseModelWorker,
     logger,
     worker_id,
 )


### PR DESCRIPTION
move BaseModelWorker outside serve.model_worker to make it independent of torch and etc. 
So user can create custom model worker besides local models, such as wrap an online API to model worker without torch and transformers.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
