### PR TITLE
Improve Support for Mistral-Instruct

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -28,6 +28,7 @@ class SeparatorStyle(IntEnum):
     PHOENIX = auto()
     ROBIN = auto()
     FALCON_CHAT = auto()
+    MISTRAL_INSTRUCT = auto()
 
 
 @dataclasses.dataclass
@@ -211,6 +212,14 @@ class Conversation:
                 else:
                     ret += role + ":"
 
+            return ret
+        elif self.sep_style == SeparatorStyle.MISTRAL_INSTRUCT:
+            ret = self.sep
+            for role, message in self.messages:
+                if role == "user":
+                    ret += "[INST] " + message + " [/INST]"
+                elif role == "assistant" and message:
+                    ret += message + self.sep2 + " "
             return ret
         else:
             raise ValueError(f"Invalid style: {self.sep_style}")
@@ -840,16 +849,21 @@ register_conv_template(
     )
 )
 
-# Mistral template
+# Mistral instruct template
 # source: https://docs.mistral.ai/llm/mistral-instruct-v0.1#chat-template
+# https://docs.mistral.ai/usage/guardrailing/
+# https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1/blob/main/tokenizer_config.json
 register_conv_template(
     Conversation(
-        name="mistral",
-        system_template="",
-        roles=("[INST] ", " [/INST]"),
-        sep_style=SeparatorStyle.LLAMA2,
-        sep="",
-        sep2=" </s>",
+        name="mistral-instruct",
+        system_message="Always assist with care, respect, and truth. "
+        "Respond with utmost utility yet securely. "
+        "Avoid harmful, unethical, prejudiced, or negative content. "
+        "Ensure replies promote fairness and positivity.",
+        roles=("user", "assistant"),
+        sep_style=SeparatorStyle.MISTRAL_INSTRUCT,
+        sep="<s>",
+        sep2="</s>",
     )
 )
 

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -215,9 +215,12 @@ class Conversation:
             return ret
         elif self.sep_style == SeparatorStyle.MISTRAL_INSTRUCT:
             ret = self.sep
-            for role, message in self.messages:
+            for i, (role, message) in enumerate(self.messages):
                 if role == "user":
-                    ret += "[INST] " + message + " [/INST]"
+                    if self.system_message and i == 0:
+                        ret += "[INST] " + system_prompt + " " + message + " [/INST]"
+                    else:
+                        ret += "[INST] " + message + " [/INST]"
                 elif role == "assistant" and message:
                     ret += message + self.sep2 + " "
             return ret

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1283,11 +1283,11 @@ class StarChatAdapter(BaseModelAdapter):
         return get_conv_template("starchat")
 
 
-class MistralAdapter(BaseModelAdapter):
-    """The model adapter for Mistral AI models"""
+class MistralInstructAdapter(BaseModelAdapter):
+    """The model adapter for Mistral Instruct AI models"""
 
     def match(self, model_path: str):
-        return "mistral" in model_path.lower()
+        return "mistral" in model_path.lower() and "instruct" in model_path.lower()
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
         model, tokenizer = super().load_model(model_path, from_pretrained_kwargs)
@@ -1296,7 +1296,7 @@ class MistralAdapter(BaseModelAdapter):
         return model, tokenizer
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
-        return get_conv_template("mistral")
+        return get_conv_template("mistral-instruct")
 
 
 class Llama2Adapter(BaseModelAdapter):
@@ -1716,7 +1716,7 @@ register_model_adapter(PythiaAdapter)
 register_model_adapter(InternLMChatAdapter)
 register_model_adapter(StarChatAdapter)
 register_model_adapter(Llama2Adapter)
-register_model_adapter(MistralAdapter)
+register_model_adapter(MistralInstructAdapter)
 register_model_adapter(CuteGPTAdapter)
 register_model_adapter(OpenOrcaAdapter)
 register_model_adapter(WizardCoderAdapter)

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -308,7 +308,7 @@ register_model_info(
 )
 register_model_info(
     ["mistral-7b-instruct"],
-    "Mistral",
+    "Mistral-Instruct",
     "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1",
     "a large language model by Mistral AI team",
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The previous support for Mistral missed the `<s>` tokens mentioned in the linked [source](https://docs.mistral.ai/llm/mistral-instruct-v0.1), it would also crash the rich CLI (with `rich.errors.MarkupError: closing tag '[/INST]'`...). This PR tries to explicitly follow same the template to the one found in `chat_template` in it's [tokenizer_config.json](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1/blob/main/tokenizer_config.json).

For example, this is from the official [huggingface repo](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1#instruction-format):
```py
"<s>[INST] What is your favourite condiment? [/INST]"
"Well, I'm quite partial to a good squeeze of fresh lemon juice. It adds just the right amount of zesty flavour to whatever I'm cooking up in the kitchen!</s> "
"[INST] Do you have mayonnaise recipes? [/INST]"
```

This is what this PR generates:
```
<s>[INST] What is your favourite condiment? [/INST]My favourite condiment isprobably garlic. Garlic has such a versatile and pungent flavour that it can elevate the taste of so many dishes, from savoury to sweet. It's also a staple ingredient in many cuisines around the world, so I'm always discovering new ways to use it inmy cooking!</s> [INST] Do you have mayonnaise recipes? [/INST]
```

This is what the original code generates:
```
[INST] What is your favourite condiment?  [/INST] My favorite condiment is sriracha sauce. It adds a perfect spicy kick to a variety of dishes and is versatile enough to use in both savory and sweet dishes. </s>[INST]  Do you have mayonnaise recipes? [/INST]
```

Additionally, I don't believe that this template is compatible with the non-finetuned Mistral (it had strange results whenever I tried). I think it only works with Mistral-Instruct, so I've made some changes to do with that.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->
Closes #2520 

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
