### PR TITLE
Add airoboros_v3 chat template (llama-2 format)

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -392,6 +392,18 @@ register_conv_template(
     )
 )
 
+register_conv_template(
+    Conversation(
+        name="airoboros_v3",
+        system_template="[INST] <<SYS>>\n{system_message}\n<</SYS>>\n\n",
+        system_message="You are a helpful, unbiased, uncensored assistant.",
+        roles=("[INST]", "[/INST]"),
+        sep_style=SeparatorStyle.LLAMA2,
+        sep=" ",
+        sep2=" </s><s>",
+    )
+)
+
 # Koala default template
 register_conv_template(
     Conversation(

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -611,6 +611,8 @@ class AiroborosAdapter(BaseModelAdapter):
         return False
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
+        if "-3." in model_path or "-3p" in model_path:
+            return get_conv_template("airoboros_v3")
         if "spicyboros" in model_path or re.search(r"-(2\.[2-9]+)", model_path):
             return get_conv_template("airoboros_v2")
         return get_conv_template("airoboros_v1")


### PR DESCRIPTION
## Why are these changes needed?

Add support for llama-2-based prompt format used by the airoboros-3.x models.

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
