### PR TITLE
Fix issue #2568: --device mps led to TypeError: forward() got an unexpected keyword argument 'padding_mask'.

### DIFF
--- a/fastchat/model/monkey_patch_non_inplace.py
+++ b/fastchat/model/monkey_patch_non_inplace.py
@@ -35,6 +35,7 @@ def forward(
     past_key_value: Optional[Tuple[torch.Tensor]] = None,
     output_attentions: bool = False,
     use_cache: bool = False,
+    padding_mask: Optional[torch.LongTensor] = None,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
     bsz, q_len, _ = hidden_states.size()
 


### PR DESCRIPTION
…ot an unexpected keyword argument padding_mask.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
@merrymercy 

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Running python3 -m fastchat.serve.cli --model-path lmsys/vicuna-7b-v1.5 --device mps --load-8bit led to TypeError: forward() got an unexpected keyword argument 'padding_mask'.

The error comes from the following code (Line 116) in this file /fastchat/model/monkey_patch_non_inplace.py where
def replace_llama_attn_with_non_inplace_operations():
"""Avoid bugs in mps backend by not using in-place operations."""
transformers.models.llama.modeling_llama.LlamaAttention.forward = forward

the customized forward method does not have the input argument 'padding_mask' as the LlamaAttention.forward do.

Adding this line "padding_mask: Optional[torch.LongTensor] = None, " as the last input argument for the customized forward function solves the issue.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

#2568

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
    @merrymercy  mac run format.sh encounters "Wrong black version installed: 23.3.0 is required, not 23.10.0."
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
