### PR TITLE
Convert read-only endpoints from POST to GET (#2625)

### DIFF
--- a/fastchat/serve/base_model_worker.py
+++ b/fastchat/serve/base_model_worker.py
@@ -217,7 +217,7 @@ async def api_get_embeddings(request: Request):
     return JSONResponse(content=embedding)
 
 
-@app.post("/worker_get_status")
+@app.get("/worker_get_status")
 async def api_get_status(request: Request):
     return worker.get_status()
 
@@ -228,11 +228,11 @@ async def api_count_token(request: Request):
     return worker.count_token(params)
 
 
-@app.post("/worker_get_conv_template")
+@app.get("/worker_get_conv_template")
 async def api_get_conv(request: Request):
     return worker.get_conv_template()
 
 
-@app.post("/model_details")
+@app.get("/model_details")
 async def api_model_details(request: Request):
     return {"context_length": worker.context_len}

--- a/fastchat/serve/base_model_worker.py
+++ b/fastchat/serve/base_model_worker.py
@@ -218,7 +218,7 @@ async def api_get_embeddings(request: Request):
 
 
 @app.get("/worker_get_status")
-async def api_get_status(request: Request):
+async def api_get_status():
     return worker.get_status()
 
 
@@ -229,10 +229,10 @@ async def api_count_token(request: Request):
 
 
 @app.get("/worker_get_conv_template")
-async def api_get_conv(request: Request):
+async def api_get_conv():
     return worker.get_conv_template()
 
 
 @app.get("/model_details")
-async def api_model_details(request: Request):
+async def api_model_details():
     return {"context_length": worker.context_len}

--- a/fastchat/serve/controller.py
+++ b/fastchat/serve/controller.py
@@ -97,7 +97,7 @@ class Controller:
 
     def get_worker_status(self, worker_name: str):
         try:
-            r = requests.post(worker_name + "/worker_get_status", timeout=5)
+            r = requests.get(worker_name + "/worker_get_status", timeout=5)
         except requests.exceptions.RequestException as e:
             logger.error(f"Get status fails: {worker_name}, {e}")
             return None
@@ -272,13 +272,13 @@ async def refresh_all_workers():
     models = controller.refresh_all_workers()
 
 
-@app.post("/list_models")
+@app.get("/list_models")
 async def list_models():
     models = controller.list_models()
     return {"models": models}
 
 
-@app.post("/get_worker_address")
+@app.get("/get_worker_address")
 async def get_worker_address(request: Request):
     data = await request.json()
     addr = controller.get_worker_address(data["model"])
@@ -299,7 +299,7 @@ async def worker_api_generate_stream(request: Request):
     return StreamingResponse(generator)
 
 
-@app.post("/worker_get_status")
+@app.get("/worker_get_status")
 async def worker_api_get_status(request: Request):
     return controller.worker_api_get_status()
 

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -125,7 +125,7 @@ def get_model_list(
     if controller_url:
         ret = requests.post(controller_url + "/refresh_all_workers")
         assert ret.status_code == 200
-        ret = requests.post(controller_url + "/list_models")
+        ret = requests.get(controller_url + "/list_models")
         models = ret.json()["models"]
     else:
         models = []
@@ -358,7 +358,7 @@ def bot_response(state, temperature, top_p, max_new_tokens, request: gr.Request)
         )
     else:
         # Query worker address
-        ret = requests.post(
+        ret = requests.get(
             controller_url + "/get_worker_address", json={"model": model_name}
         )
         worker_addr = ret.json()["address"]

--- a/fastchat/serve/huggingface_api_worker.py
+++ b/fastchat/serve/huggingface_api_worker.py
@@ -238,7 +238,7 @@ async def api_get_embeddings(request: Request):
     return JSONResponse(content=embedding)
 
 
-@app.post("/worker_get_status")
+@app.get("/worker_get_status")
 async def api_get_status(request: Request):
     return {
         "model_names": [m for w in workers for m in w.model_names],
@@ -261,7 +261,7 @@ async def api_get_conv(request: Request):
     return worker.get_conv_template()
 
 
-@app.post("/model_details")
+@app.get("/model_details")
 async def api_model_details(request: Request):
     params = await request.json()
     worker = worker_map[params["model"]]

--- a/fastchat/serve/multi_model_worker.py
+++ b/fastchat/serve/multi_model_worker.py
@@ -123,7 +123,7 @@ async def api_get_embeddings(request: Request):
     return JSONResponse(content=embedding, background=background_tasks)
 
 
-@app.post("/worker_get_status")
+@app.get("/worker_get_status")
 async def api_get_status(request: Request):
     return {
         "model_names": [m for w in workers for m in w.model_names],
@@ -146,7 +146,7 @@ async def api_get_conv(request: Request):
     return worker.get_conv_template()
 
 
-@app.post("/model_details")
+@app.get("/model_details")
 async def api_model_details(request: Request):
     params = await request.json()
     worker = worker_map[params["model"]]

--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -78,7 +78,6 @@ async def fetch_remote_get(url, params=None, name=None):
                     "error_code": ErrorCode.INTERNAL_ERROR,
                 }
                 return json.dumps(ret)
-            
             output = await response.text()
 
     if name is not None:
@@ -87,7 +86,6 @@ async def fetch_remote_get(url, params=None, name=None):
             return res[name]
         else:
             raise KeyError(f"{name} not found in the response.")
-    
     return output
 
 

--- a/fastchat/serve/test_message.py
+++ b/fastchat/serve/test_message.py
@@ -15,12 +15,12 @@ def main():
     else:
         controller_addr = args.controller_address
         ret = requests.post(controller_addr + "/refresh_all_workers")
-        ret = requests.post(controller_addr + "/list_models")
+        ret = requests.get(controller_addr + "/list_models")
         models = ret.json()["models"]
         models.sort()
         print(f"Models: {models}")
 
-        ret = requests.post(
+        ret = requests.get(
             controller_addr + "/get_worker_address", json={"model": model_name}
         )
         worker_addr = ret.json()["address"]

--- a/fastchat/serve/test_throughput.py
+++ b/fastchat/serve/test_throughput.py
@@ -15,12 +15,12 @@ def main():
     else:
         controller_addr = args.controller_address
         ret = requests.post(controller_addr + "/refresh_all_workers")
-        ret = requests.post(controller_addr + "/list_models")
+        ret = requests.get(controller_addr + "/list_models")
         models = ret.json()["models"]
         models.sort()
         print(f"Models: {models}")
 
-        ret = requests.post(
+        ret = requests.get(
             controller_addr + "/get_worker_address", json={"model": args.model_name}
         )
         worker_addr = ret.json()["address"]
@@ -48,7 +48,7 @@ def main():
 
     def send_request(results, i):
         if args.test_dispatch:
-            ret = requests.post(
+            ret = requests.get(
                 controller_addr + "/get_worker_address", json={"model": args.model_name}
             )
             thread_worker_addr = ret.json()["address"]

--- a/fastchat/serve/vllm_worker.py
+++ b/fastchat/serve/vllm_worker.py
@@ -190,7 +190,7 @@ async def api_generate(request: Request):
     return JSONResponse(output)
 
 
-@app.post("/worker_get_status")
+@app.get("/worker_get_status")
 async def api_get_status(request: Request):
     return worker.get_status()
 
@@ -206,7 +206,7 @@ async def api_get_conv(request: Request):
     return worker.get_conv_template()
 
 
-@app.post("/model_details")
+@app.get("/model_details")
 async def api_model_details(request: Request):
     return {"context_length": worker.context_len}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Refactored server endpoints from POST to GET where no server state is modified, following RESTful best practices as discussed in issue #2625. This update includes endpoints worker_get_status, worker_get_conv_template, model_details, list_models, and get_worker_address, optimizing them for data retrieval.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)
Closes #2625

<!-- For example: "Closes #1234" -->

## Changes
Endpoints worker_get_status and worker_get_conv_template now use GET to match their data fetching functionality.
model_details and list_models endpoints are switched to GET as they retrieve model details without state change.
get_worker_address updated to GET to reflect its data lookup nature.
Introduced fetch_remote_get function without iter_chunks() for streamlined GET requests, as the endpoint data does not require chunked streaming.

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
