### PR TITLE
fix: [model_worker]  #2467

### DIFF
--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -293,7 +293,7 @@ def create_model_worker():
             )
         os.environ["CUDA_VISIBLE_DEVICES"] = args.gpus
 
-    args_host_post = "http://"+str(args.host)+":"+str(args.port)
+    args_host_post = "http://" + str(args.host) + ":" + str(args.port)
     if args.worker_address != args_host_post:
         raise ValueError(
             f"Worker address {args.worker_address} does not match host and port {args_host_post}!"

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -293,6 +293,12 @@ def create_model_worker():
             )
         os.environ["CUDA_VISIBLE_DEVICES"] = args.gpus
 
+    args_host_post = "http://"+str(args.host)+":"+str(args.port)
+    if args.worker_address != args_host_post:
+        raise ValueError(
+            f"Worker address {args.worker_address} does not match host and port {args_host_post}!"
+        )
+
     gptq_config = GptqConfig(
         ckpt=args.gptq_ckpt or args.model_path,
         wbits=args.gptq_wbits,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
If I run the model_worker if host + port is different with worker_address the model_worker won't work properly.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)
Closes #2467

<!-- For example: "Closes #1234" -->

## Changes
So I added value error to check if the host, port is same with the worker_address

below the image, we can see that as default worker_address is set as "http://localhost:21002", this is not same with the worker_address generated by host and port number which is localhost and 10100 in the image below. As I added the ValueError, model_worker raises the error.


<img width="888" alt="image" src="https://github.com/lm-sys/FastChat/assets/39149858/e5e33012-5d27-4a15-ac15-31cd14a7c93b">


## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
