### PR TITLE
added support for CodeGeex(2)

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -448,6 +448,17 @@ register_conv_template(
     )
 )
 
+# CodeGeex(2) Template
+register_conv_template(
+    Conversation(
+        name="codegeex",
+        roles=("", ""),
+        sep_style=SeparatorStyle.NO_COLON_SINGLE,
+        sep="\n\n",
+        stop_token_ids=[0, 2],
+    )
+)
+
 # Dolly V2 default template
 register_conv_template(
     Conversation(

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -769,6 +769,26 @@ class ChatGLMAdapter(BaseModelAdapter):
         return get_conv_template("chatglm")
 
 
+class CodeGeexAdapter(BaseModelAdapter):
+    """The model adapter for THUDM/codegeex-6b, THUDM/codegeex2-6b"""
+
+    def match(self, model_path: str):
+        return "codegeex" in model_path.lower()
+
+    def load_model(self, model_path: str, from_pretrained_kwargs: dict):
+        revision = from_pretrained_kwargs.get("revision", "main")
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_path, trust_remote_code=True, revision=revision
+        )
+        model = AutoModel.from_pretrained(
+            model_path, trust_remote_code=True, **from_pretrained_kwargs
+        )
+        return model, tokenizer
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("codegeex")
+
+
 class DollyV2Adapter(BaseModelAdapter):
     """The model adapter for databricks/dolly-v2-12b"""
 
@@ -1789,6 +1809,7 @@ register_model_adapter(GoogleT5Adapter)
 register_model_adapter(KoalaAdapter)
 register_model_adapter(AlpacaAdapter)
 register_model_adapter(ChatGLMAdapter)
+register_model_adapter(CodeGeexAdapter)
 register_model_adapter(DollyV2Adapter)
 register_model_adapter(OasstPythiaAdapter)
 register_model_adapter(OasstLLaMAAdapter)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

CodeGeex needs very careful prompting to fully function. I first tried to use the regular ChatGLM2 preset (What CodeGeex2 is based on), but it completely obliterated the output. 

Demo of what happens before this PR: https://asciinema.org/a/619610
Same command with this PR: https://asciinema.org/a/619611

[I noticed that something similar](https://github.com/lm-sys/FastChat/blob/5d453e4265050c9e5869e05cbaa5d6aca6276ef8/fastchat/model/model_chatglm.py#L91) was going on with ChatGLM in general. I spent hours figuring out why `stream_generate` didn't return a stop token, and it seems that, it does, but it needs a very specific format - at least in the case of CodeGeex. It's worth looking into.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
 - I tried, but I get this error: `ImportError: cannot import name 'formatargspec' from 'inspect'`
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
