### PR TITLE
train_flant5: fix typo

### DIFF
--- a/fastchat/train/train_flant5.py
+++ b/fastchat/train/train_flant5.py
@@ -231,7 +231,7 @@ def preprocess(
     """
     # add end signal and concatenate together
     conversations = []
-    header = f"{default_conversation.system}\n\n"
+    header = f"{default_conversation.system_message}\n\n"
     for source in sources:
         conversation = _add_speaker_and_signal(header, source, tokenizer)
         conversations.append(conversation)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/lm-sys/FastChat/blob/main/fastchat/train/train_flant5.py#L234
```python
def preprocess(
    sources: Sequence[str],
    tokenizer: transformers.PreTrainedTokenizer,
) -> Dict:
    """
    Given a list of sources, each is a conversation list. This transform:
    1. Add signal '### ' at the beginning each sentence, with end signal '\n';
    2. Concatenate conversations together;
    3. Tokenize the concatenated conversation;
    4. Make a deepcopy as the target. Mask human words with IGNORE_INDEX.
    """
    # add end signal and concatenate together
    conversations = []
    header = f"{default_conversation.system}\n\n"      !!! this looks like a typo
```
according to [this](https://github.com/lm-sys/FastChat/blob/e0b351a4e7c47b84c6af34b551838c5bb790ee60/fastchat/conversation.py#L232), I fix that typo and it works for me

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
