### PR TITLE
feat: support template's stop_str as list

### DIFF
--- a/fastchat/llm_judge/gen_model_answer.py
+++ b/fastchat/llm_judge/gen_model_answer.py
@@ -142,15 +142,15 @@ def get_model_answers(
                         spaces_between_special_tokens=False,
                     )
                     if conv.stop_str and isinstance(conv.stop_str, list):
-                        stop_str_indice = sorted(
+                        stop_str_indices = sorted(
                             [
                                 output.find(stop_str)
                                 for stop_str in conv.stop_str
                                 if output.find(stop_str) > 0
                             ]
                         )
-                        if len(stop_str_indice) > 0:
-                            output = output[: stop_str_indice[0]]
+                        if len(stop_str_indices) > 0:
+                            output = output[: stop_str_indices[0]]
                     elif conv.stop_str and output.find(conv.stop_str) > 0:
                         output = output[: output.find(conv.stop_str)]
 

--- a/fastchat/llm_judge/gen_model_answer.py
+++ b/fastchat/llm_judge/gen_model_answer.py
@@ -141,8 +141,19 @@ def get_model_answers(
                         output_ids,
                         spaces_between_special_tokens=False,
                     )
-                    if conv.stop_str and output.find(conv.stop_str) > 0:
+                    if conv.stop_str and isinstance(conv.stop_str, list):
+                        stop_str_indice = sorted(
+                            [
+                                output.find(stop_str)
+                                for stop_str in conv.stop_str
+                                if output.find(stop_str) > 0
+                            ]
+                        )
+                        if len(stop_str_indice) > 0:
+                            output = output[: stop_str_indice[0]]
+                    elif conv.stop_str and output.find(conv.stop_str) > 0:
                         output = output[: output.find(conv.stop_str)]
+
                     for special_token in tokenizer.special_tokens_map.values():
                         if isinstance(special_token, list):
                             for special_tok in special_token:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
User may pass a list of stop string due to the signature of the conversation template's `stop_str: Union[str, List[str]] = None` 

We need to support it in the generation script.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
