### PR TITLE
fix tokenizer.pad_token attribute error

### DIFF
--- a/fastchat/train/train.py
+++ b/fastchat/train/train.py
@@ -277,7 +277,8 @@ def train():
         padding_side="right",
         use_fast=False,
     )
-    if tokenizer.pad_token and tokenizer.pad_token != tokenizer.unk_token:
+
+    if tokenizer.pad_token != tokenizer.unk_token:
         tokenizer.pad_token = tokenizer.unk_token
 
     # Load data

--- a/fastchat/train/train.py
+++ b/fastchat/train/train.py
@@ -277,7 +277,8 @@ def train():
         padding_side="right",
         use_fast=False,
     )
-    tokenizer.pad_token = tokenizer.unk_token
+    if tokenizer.pad_token and tokenizer.pad_token != tokenizer.unk_token:
+        tokenizer.pad_token = tokenizer.unk_token
 
     # Load data
     data_module = make_supervised_data_module(tokenizer=tokenizer, data_args=data_args)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
pad_token in chatglm2-6b tokenizer is readonly and equal to the unk_token, this pr is to avoid a attribute error for chatglm2-6b.

## Related issue number (if applicable)

Open #2706

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
