### PR TITLE
xdan-l1-chat-v0.1 support submit with the scores of 8.09.

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1813,6 +1813,15 @@ class ZephyrAdapter(BaseModelAdapter):
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("zephyr")
 
+class xDANAdapter(BaseModelAdapter):
+    """The model adapter for xDAN-AI (e.g. xDAN-AI/xDAN-L1-Chat-v0.1)"""
+
+    def match(self, model_path: str):
+        return "xdan" in model_path.lower()
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("xdan-v1")
+
 
 class XwinLMAdapter(BaseModelAdapter):
     """The model adapter for Xwin-LM V0.1 and V0.2 series of models(e.g., Xwin-LM/Xwin-LM-70B-V0.1)"""
@@ -1928,6 +1937,7 @@ register_model_adapter(PhindCodeLlamaAdapter)
 register_model_adapter(CodeLlamaAdapter)
 register_model_adapter(Llama2ChangAdapter)
 register_model_adapter(ZephyrAdapter)
+register_model_adapter(xDANdapter)
 register_model_adapter(XwinLMAdapter)
 register_model_adapter(LemurAdapter)
 register_model_adapter(PygmalionAdapter)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- xdan-ai. -->

## Why are these changes needed?

I am submitting a new state-of-the-art (SOTA) model, a 7b SOTA model developed by xDAN-AI, which has demonstrated superior performance over GPT-3.5-turbo in MTBench benchmarks. This model exhibits remarkable reasoning and conversational abilities, indicating a significant advancement in AI language models. This contribution aims to support and showcase the cutting-edge capabilities of this new model in MTBench, furthering the field's understanding of AI-driven language processing and interactions.


## Checks

- [ ☑️] I've run `format.sh` to lint the changes in this PR.
- [ ☑️] I've included any doc changes needed.
- [ ☑️] I've made sure the relevant tests are passing (if applicable).
