### PR TITLE
Add revision arg to MT Bench answer generation

### DIFF
--- a/fastchat/llm_judge/gen_model_answer.py
+++ b/fastchat/llm_judge/gen_model_answer.py
@@ -31,6 +31,7 @@ def run_eval(
     num_gpus_total,
     max_gpu_memory,
     dtype,
+    revision,
 ):
     questions = load_questions(question_file, question_begin, question_end)
     # random shuffle the questions to balance the loading
@@ -61,6 +62,7 @@ def run_eval(
                 num_gpus_per_model,
                 max_gpu_memory,
                 dtype=dtype,
+                revision=revision,
             )
         )
 
@@ -79,9 +81,11 @@ def get_model_answers(
     num_gpus_per_model,
     max_gpu_memory,
     dtype,
+    revision,
 ):
     model, tokenizer = load_model(
         model_path,
+        revision=revision,
         device="cuda",
         num_gpus=num_gpus_per_model,
         max_gpu_memory=max_gpu_memory,
@@ -259,6 +263,12 @@ if __name__ == "__main__":
         help="Override the default dtype. If not set, it will use float16 on GPU and float32 on CPU.",
         default=None,
     )
+    parser.add_argument(
+        "--revision",
+        type=str,
+        default="main",
+        help="The model revision to load.",
+    )
 
     args = parser.parse_args()
 
@@ -288,6 +298,7 @@ if __name__ == "__main__":
         num_gpus_total=args.num_gpus_total,
         max_gpu_memory=args.max_gpu_memory,
         dtype=str_to_torch_dtype(args.dtype),
+        revision=args.revision,
     )
 
     reorg_answer_file(answer_file)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

It is often useful to be able to run MT Bench on a specific model revision to e.g. test for regressions. This PR adds a `revision` arg to the `gen_model_answers.py` script.

Usage:

```shell
python gen_model_answer.py --model-path {HUB_MODEL_ID} --revision {REVISION} --model-id {MT_BENCH_ID}
```

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
