### PR TITLE
support openai embedding for topic clustering

### DIFF
--- a/fastchat/serve/monitor/summarize_cluster.py
+++ b/fastchat/serve/monitor/summarize_cluster.py
@@ -6,6 +6,8 @@ python3 summarize_cluster.py --in results_c20_kmeans_cluster.pkl --model azure-g
 import argparse
 import pickle
 
+import pandas as pd
+
 from fastchat.llm_judge.common import (
     chat_compeletion_openai,
     chat_compeletion_openai_azure,
@@ -74,3 +76,10 @@ if __name__ == "__main__":
     print()
     print(f"topics: {topics}")
     print(f"percentages: {percentages}")
+
+    # save the informations
+    df = pd.DataFrame()
+    df["topic"] = topics
+    df["percentage"] = percentages
+
+    df.to_json(f"cluster_summary_{len(df)}.jsonl", lines=True, orient="records")

--- a/fastchat/serve/monitor/topic_clustering.py
+++ b/fastchat/serve/monitor/topic_clustering.py
@@ -244,15 +244,16 @@ if __name__ == "__main__":
     texts = read_texts(
         args.input_file, args.min_length, args.max_length, args.english_only
     )
+    print(f"#text: {len(texts)}")
+
     if args.embeddings_file is None:
-        print(f"#text: {len(texts)}")
         embeddings = get_embeddings(texts, args.model, args.batch_size)
-        print(f"embeddings shape: {embeddings.shape}")
         if args.save_embeddings:
-            # allow saving embedding to save time
+            # allow saving embedding to save time and money
             torch.save(embeddings, "embeddings.pt")
     else:
         embeddings = torch.load(args.embeddings_file)
+    print(f"embeddings shape: {embeddings.shape}")
 
     if args.cluster_alg == "kmeans":
         centers, labels = run_k_means(embeddings, num_clusters)

--- a/fastchat/serve/monitor/topic_clustering.py
+++ b/fastchat/serve/monitor/topic_clustering.py
@@ -241,10 +241,10 @@ if __name__ == "__main__":
     show_top_k = args.show_top_k
     show_cut_off = args.show_cut_off
 
+    texts = read_texts(
+        args.input_file, args.min_length, args.max_length, args.english_only
+    )
     if args.embeddings_file is None:
-        texts = read_texts(
-            args.input_file, args.min_length, args.max_length, args.english_only
-        )
         print(f"#text: {len(texts)}")
         embeddings = get_embeddings(texts, args.model, args.batch_size)
         print(f"embeddings shape: {embeddings.shape}")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
To support OpenAI embedding (text-embedding-ada-002)
`topic_clustering.py` requires openai version 1.0.0, however, `summarize_cluster.py` still uses openai version < 1.0.0
Added `--save-embedding` and `--embedding-file` features to allow user to save the embedding tensor and reduce cost. 
Right now need to run `pip install openai --upgrade` before use. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
