### PR TITLE
Add deepseek chat

### DIFF
--- a/docs/model_support.md
+++ b/docs/model_support.md
@@ -54,6 +54,8 @@
 - [OpenLemur/lemur-70b-chat-v1](https://huggingface.co/OpenLemur/lemur-70b-chat-v1)
 - [allenai/tulu-2-dpo-7b](https://huggingface.co/allenai/tulu-2-dpo-7b)
 - [Microsoft/Orca-2-7b](https://huggingface.co/microsoft/Orca-2-7b)
+- [deepseek-ai/deepseek-llm-67b-chat](https://huggingface.co/deepseek-ai/deepseek-llm-67b-chat)
+- [deepseek-ai/deepseek-coder-33b-instruct](https://huggingface.co/deepseek-ai/deepseek-coder-33b-instruct)
 - Any [EleutherAI](https://huggingface.co/EleutherAI) pythia model such as [pythia-6.9b](https://huggingface.co/EleutherAI/pythia-6.9b)
 - Any [Peft](https://github.com/huggingface/peft) adapter trained on top of a
   model above.  To activate, must have `peft` in the model path.  Note: If

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -1280,7 +1280,7 @@ register_conv_template(
 register_conv_template(
     Conversation(
         name="deepseek-chat",
-        system_message="<｜begin▁of▁sentence｜>", # must add a bos token before first message
+        system_message="<｜begin▁of▁sentence｜>",  # must add a bos token before first message
         roles=("User", "Assistant"),
         sep_style=SeparatorStyle.DEEPSEEK_CHAT,
         sep="\n\n",

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -29,6 +29,7 @@ class SeparatorStyle(IntEnum):
     ROBIN = auto()
     FALCON_CHAT = auto()
     CHATGLM3 = auto()
+    DEEPSEEK_CHAT = auto()
 
 
 @dataclasses.dataclass
@@ -223,6 +224,15 @@ class Conversation:
                 else:
                     ret += role + ":"
 
+            return ret
+        elif self.sep_style == SeparatorStyle.DEEPSEEK_CHAT:
+            seps = [self.sep, self.sep2]
+            ret = system_prompt
+            for i, (role, message) in enumerate(self.messages):
+                if message:
+                    ret += role + ": " + message + seps[i % 2]
+                else:
+                    ret += role + ":"
             return ret
         else:
             raise ValueError(f"Invalid style: {self.sep_style}")
@@ -530,7 +540,7 @@ register_conv_template(
 # Deepseek code default template
 register_conv_template(
     Conversation(
-        name="deepseek",
+        name="deepseek-coder",
         system_template="You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and you only answer questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will refuse to answer.",
         roles=("### Instruction:", "### Response:"),
         sep="\n",
@@ -1262,6 +1272,20 @@ register_conv_template(
         sep_style=SeparatorStyle.CHATML,
         sep="<|im_end|>",
         stop_str="<|im_end|>",
+    )
+)
+
+# Deepseek-chat template
+# reference: https://huggingface.co/deepseek-ai/deepseek-llm-67b-chat/blob/main/tokenizer_config.json
+register_conv_template(
+    Conversation(
+        name="deepseek-chat",
+        system_message="<｜begin▁of▁sentence｜>", # must add a bos token before first message
+        roles=("User", "Assistant"),
+        sep_style=SeparatorStyle.DEEPSEEK_CHAT,
+        sep="\n\n",
+        sep2="<｜end▁of▁sentence｜>",
+        stop_str="<｜end▁of▁sentence｜>",
     )
 )
 

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1933,6 +1933,7 @@ class YiAdapter(BaseModelAdapter):
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("Yi-34b-chat")
 
+
 class DeepseekCoderAdapter(BaseModelAdapter):
     """The model adapter for deepseek-ai's coder models"""
 
@@ -1941,6 +1942,7 @@ class DeepseekCoderAdapter(BaseModelAdapter):
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("deepseek-coder")
+
 
 class DeepseekChatAdapter(BaseModelAdapter):
     """The model adapter for deepseek-ai's chat models"""

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1933,6 +1933,26 @@ class YiAdapter(BaseModelAdapter):
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("Yi-34b-chat")
 
+class DeepseekCoderAdapter(BaseModelAdapter):
+    """The model adapter for deepseek-ai's coder models"""
+
+    def match(self, model_path: str):
+        return "deepseek-coder" in model_path.lower()
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("deepseek-coder")
+
+class DeepseekChatAdapter(BaseModelAdapter):
+    """The model adapter for deepseek-ai's chat models"""
+
+    # Note: that this model will require tokenizer version >= 0.13.3 because the tokenizer class is LlamaTokenizerFast
+
+    def match(self, model_path: str):
+        return "deepseek-llm" in model_path.lower() and "chat" in model_path.lower()
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("deepseek-chat")
+
 
 # Note: the registration order matters.
 # The one registered earlier has a higher matching priority.
@@ -2005,6 +2025,8 @@ register_model_adapter(LemurAdapter)
 register_model_adapter(PygmalionAdapter)
 register_model_adapter(MicrosoftOrcaAdapter)
 register_model_adapter(YiAdapter)
+register_model_adapter(DeepseekCoderAdapter)
+register_model_adapter(DeepseekChatAdapter)
 
 # After all adapters, try the default base adapter.
 register_model_adapter(BaseModelAdapter)


### PR DESCRIPTION
## Why are these changes needed?
Adds the deepseek chat model. Note, we create a new conversation style because Deepseek has a unique characteristic of prepending a `<|begin_of_sentence|>` token before the user input, which is not something that other models do. Furthermore, Deepseek does not recommend to use a system prompt with the current iteration of the model.

Also, this model probably requires using a newer version of tokenizers/transformers since the `tokenizer_class` in the config is `LlamaTokenizerFast`

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
