### PR TITLE
Inference stop_str missing filter fix

### DIFF
--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -39,7 +39,12 @@ from fastchat.modules.awq import AWQConfig
 from fastchat.modules.gptq import GptqConfig
 from fastchat.modules.exllama import ExllamaConfig
 from fastchat.modules.xfastertransformer import XftConfig
-from fastchat.utils import is_partial_stop, is_sentence_complete, get_context_length
+from fastchat.utils import (
+    is_partial_stop,
+    is_sentence_complete,
+    get_context_length,
+    compile_stop_pattern,
+)
 
 
 def prepare_logits_processor(
@@ -113,6 +118,21 @@ def generate_stream(
         )
     else:
         start_ids = torch.as_tensor([input_ids], device=device)
+
+    stop_pattern = None
+    max_stop_len = 0
+    if stop_str:
+        if isinstance(stop_str, str):
+            stop_str = [stop_str]
+        if not isinstance(stop_str, Iterable):
+            raise ValueError("Invalid stop field type.")
+        max_stop_len = max(len(s) for s in stop_str)
+        stop_pattern = compile_stop_pattern(stop_str)
+
+    if echo:
+        rfind_start = len_prompt
+    else:
+        rfind_start = 0
 
     past_key_values = out = None
     token_logprobs = [None]  # The first token has no logprobs.
@@ -206,10 +226,8 @@ def generate_stream(
         if i % stream_interval == 0 or i == max_new_tokens - 1 or stopped:
             if echo:
                 tmp_output_ids = output_ids
-                rfind_start = len_prompt
             else:
                 tmp_output_ids = output_ids[input_echo_len:]
-                rfind_start = 0
 
             output = tokenizer.decode(
                 tmp_output_ids,
@@ -239,6 +257,21 @@ def generate_stream(
                     ret_logprobs["text_offset"].append(curr_pos)
                     curr_pos += len(text)
 
+            partially_stopped = False
+            if stop_pattern:
+                out_len = len(output)
+                rfind_start = max(rfind_start, out_len - 2 * max_stop_len)
+                output_tocheck = output[rfind_start:]
+                match = stop_pattern.search(output_tocheck)
+                if match:
+                    output = output[: rfind_start + match.start()]
+                    stopped = True
+                else:
+                    for stop_sign in stop_str:
+                        if is_partial_stop(output_tocheck, stop_sign):
+                            partially_stopped = True
+                            break
+
             # TODO: For the issue of incomplete sentences interrupting output, apply a patch and others can also modify it to a more elegant way
             if judge_sent_end and stopped and not is_sentence_complete(output):
                 if len(tokens) > 1:
@@ -248,29 +281,6 @@ def generate_stream(
                     output_ids.pop()
                 stopped = False
                 sent_interrupt = True
-
-            partially_stopped = False
-            if stop_str:
-                if isinstance(stop_str, str):
-                    pos = output.rfind(stop_str, rfind_start)
-                    if pos != -1:
-                        output = output[:pos]
-                        stopped = True
-                    else:
-                        partially_stopped = is_partial_stop(output, stop_str)
-                elif isinstance(stop_str, Iterable):
-                    for each_stop in stop_str:
-                        pos = output.rfind(each_stop, rfind_start)
-                        if pos != -1:
-                            output = output[:pos]
-                            stopped = True
-                            break
-                        else:
-                            partially_stopped = is_partial_stop(output, each_stop)
-                            if partially_stopped:
-                                break
-                else:
-                    raise ValueError("Invalid stop field type.")
 
             # Prevent yielding partial stop sequence
             if not partially_stopped:

--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -6,6 +6,7 @@ import json
 import logging
 import logging.handlers
 import os
+import re
 import platform
 import sys
 from typing import AsyncGenerator, Generator
@@ -292,6 +293,14 @@ def is_partial_stop(output: str, stop_str: str):
         if stop_str.startswith(output[-i:]):
             return True
     return False
+
+
+def compile_stop_pattern(stop_list):
+    # Escape special characters, and then compile the pattern.
+    pattern_str = "|".join(re.escape(s) for s in stop_list) if stop_list else None
+    pattern = re.compile(pattern_str) if pattern_str else None
+
+    return pattern
 
 
 def run_cmd(cmd: str):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
1. Fro stop_str = ["\</s\>", "<|im_end|>"], although "<| im_ end |>" has been added to "special_tokens", there some cases like
```
I am a chatbot created by researchers.<
I am a chatbot created by researchers.<|
I am a chatbot created by researchers.<|im_
I am a chatbot created by researchers.<|im_end
I am a chatbot created by researchers.<|im_end|><
I am a chatbot created by researchers.<|im_end|><|im_end|><
```
The original logic will only find the last<| im_end|> through _rfind_, which in turn leads to filtering failure.
2. When no stop is generated and "rfind_start" is not updated, the starting position is always found, which is time-consuming.
3. Determine the search subset based on the maximum "stop_token" length to improve search efficiency.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
