### PR TITLE
add root_path argument to gradio web server.

### DIFF
--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -835,6 +835,11 @@ if __name__ == "__main__":
         type=str,
         help='Set the gradio authentication file path. The file should contain one or more user:password pairs in this format: "u1:p1,u2:p2,u3:p3"',
     )
+    parser.add_argument(
+        "--gradio-root-path",
+        type=str,
+        help="Sets the gradio root path, eg /abc/def. Useful when running behind a reverse-proxy or at a custom URL path prefix"
+    )
     args = parser.parse_args()
     logger.info(f"args: {args}")
 
@@ -863,4 +868,5 @@ if __name__ == "__main__":
         share=args.share,
         max_threads=200,
         auth=auth,
+        root_path=args.gradio_root_path
     )

--- a/fastchat/serve/gradio_web_server_multi.py
+++ b/fastchat/serve/gradio_web_server_multi.py
@@ -228,6 +228,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--leaderboard-table-file", type=str, help="Load leaderboard results and plots"
     )
+    parser.add_argument(
+        "--gradio-root-path",
+        type=str,
+        help="Sets the gradio root path, eg /abc/def. Useful when running behind a reverse-proxy or at a custom URL path prefix"
+    )
     args = parser.parse_args()
     logger.info(f"args: {args}")
 
@@ -267,4 +272,5 @@ if __name__ == "__main__":
         share=args.share,
         max_threads=200,
         auth=auth,
+        root_path=args.gradio_root_path
     )


### PR DESCRIPTION
Allows gradio server to run on a different root path. Fixes lm-sys/FastChat#2489

## Why are these changes needed?

FastChat gradio server currently cannot run under a different root URL than /

## Related issue number (if applicable)

Closes #2489 

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
