### PR TITLE
Import `accelerate` locally to avoid it as a strong dependency

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -12,7 +12,6 @@ if sys.version_info >= (3, 9):
 else:
     from functools import lru_cache as cache
 
-import accelerate
 import psutil
 import torch
 from transformers import (
@@ -179,6 +178,7 @@ def load_model(
     revision: str = "main",
     debug: bool = False,
 ):
+    import accelerate
     """Load a model from Hugging Face."""
     # get model adapter
     adapter = get_model_adapter(model_path)

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -178,8 +178,9 @@ def load_model(
     revision: str = "main",
     debug: bool = False,
 ):
-    import accelerate
     """Load a model from Hugging Face."""
+    import accelerate
+    
     # get model adapter
     adapter = get_model_adapter(model_path)
 


### PR DESCRIPTION
## Why are these changes needed?

We use fastchat on the client side to format chat messages into prompts using the convenient templates shipped in the package. Unfortunately because `load_model` is also in the same module and it requires `accelerate` it requires us to install accelerate and torch which can be heavy dependencies Because fastchat has already marked accelerate as an optional dependency, it makes sense to only import it when loading models.

This is only a quick solution, a better solution would be to properly refactor template formatting away from model loading.

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
