### PR TITLE
Replace dict merge with unpacking for compatibility of 3.8 in vLLM worker

### DIFF
--- a/fastchat/serve/vllm_worker.py
+++ b/fastchat/serve/vllm_worker.py
@@ -147,7 +147,7 @@ class VLLMWorker(BaseModelWorker):
             # Emit twice here to ensure a 'finish_reason' with empty content in the OpenAI API response.
             # This aligns with the behavior of model_worker.
             if request_output.finished:
-                yield (json.dumps(ret | {"finish_reason": None}) + "\0").encode()
+                yield (json.dumps({**ret, **{"finish_reason": None}}) + "\0").encode()
             yield (json.dumps(ret) + "\0").encode()
 
     async def generate(self, params):


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This pull request replaces dict merge with unpacking for compatibility with Python 3.8 in vLLM worker.

Since [PEP-584](https://peps.python.org/pep-0584/) for union operator to dict was implemented in Python 3.9 and the minimum requirement of the project is specified as Python 3.8, it is reasonable to maintain compatibility with 3.8.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
