### PR TITLE
Add SOLAR-10.7b Instruct Model

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -1341,6 +1341,19 @@ register_conv_template(
     )
 )
 
+# Solar-10.7B Chat Template
+# Reference: https://huggingface.co/upstage/SOLAR-10.7B-Instruct-v1.0/blob/main/tokenizer_config.json
+register_conv_template(
+    Conversation(
+        name="solar",
+        system_message="",
+        roles=("### User", "### Assistant"),
+        sep_style=SeparatorStyle.ADD_NEW_LINE_SINGLE,
+        sep="\n\n",
+        stop_str="</s>",
+    )
+)
+
 if __name__ == "__main__":
     from fastchat.conversation import get_conv_template
 

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1989,6 +1989,16 @@ class MetaMathAdapter(BaseModelAdapter):
         return get_conv_template("metamath")
 
 
+class SolarAdapter(BaseModelAdapter):
+    """The model adapter for upstage/SOLAR-10.7B-Instruct-v1.0"""
+
+    def match(self, model_path: str):
+        return "solar-" in model_path.lower() and "instruct" in model_path.lower()
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("solar")
+
+
 # Note: the registration order matters.
 # The one registered earlier has a higher matching priority.
 register_model_adapter(PeftModelAdapter)
@@ -2065,6 +2075,7 @@ register_model_adapter(YiAdapter)
 register_model_adapter(DeepseekCoderAdapter)
 register_model_adapter(DeepseekChatAdapter)
 register_model_adapter(MetaMathAdapter)
+register_model_adapter(SolarAdapter)
 
 # After all adapters, try the default base adapter.
 register_model_adapter(BaseModelAdapter)

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -441,3 +441,10 @@ register_model_info(
     "https://huggingface.co/meta-math",
     "MetaMath is a finetune of Llama2 on [MetaMathQA](https://huggingface.co/datasets/meta-math/MetaMathQA) that specializes in mathematical reasoning.",
 )
+
+register_model_info(
+    ["upstage/SOLAR-10.7B-Instruct-v1.0"],
+    "SOLAR-10.7B-Instruct",
+    "https://huggingface.co/upstage/SOLAR-10.7B-Instruct-v1.0",
+    "A Llama2 fine-tune developed by upstage.ai that incorporates depth up-scaling.",
+)


### PR DESCRIPTION
## Why are these changes needed?
Adds the latest model from upstage.ai: https://huggingface.co/upstage/SOLAR-10.7B-Instruct-v1.0 that performs very well on eval leaderboards.

Example output:
<img width="1645" alt="image" src="https://github.com/lm-sys/FastChat/assets/49086305/b784727a-9040-4554-a9a7-6fc2d9f9cc40">

