### PR TITLE
Add Huggingface's apply chat template functionality

### DIFF
--- a/docs/model_support.md
+++ b/docs/model_support.md
@@ -85,6 +85,9 @@ You can add `--debug` to see the actual prompt sent to the model.
 
 FastChat uses the `Conversation` class to handle prompt templates and `BaseModelAdapter` class to handle model loading.
 
+First, check if the model has a chat template in its tokenizer's config. It will look something like [this](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2/blob/main/tokenizer_config.json#L42).
+
+If the model does not have a chat template in its tokenizer's config, follow these steps to add a new model:
 1. Implement a conversation template for the new model at [fastchat/conversation.py](https://github.com/lm-sys/FastChat/blob/main/fastchat/conversation.py). You can follow existing examples and use `register_conv_template` to add a new one. Please also add a link to the official reference code if possible.
 2. Implement a model adapter for the new model at [fastchat/model/model_adapter.py](https://github.com/lm-sys/FastChat/blob/main/fastchat/model/model_adapter.py). You can follow existing examples and use `register_model_adapter` to add a new one.
 3. (Optional) add the model name to the "Supported models" [section](#supported-models) above and add more information in [fastchat/model/model_registry.py](https://github.com/lm-sys/FastChat/blob/main/fastchat/model/model_registry.py).

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -107,7 +107,7 @@ class BaseModelAdapter:
         )
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
-        return get_conv_template("one_shot")
+        return get_conv_template(model_path)
 
 
 # A global registry for all model adapters

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -502,7 +502,10 @@ def chat_loop(
 
         conv.append_message(conv.roles[0], inp)
         conv.append_message(conv.roles[1], None)
-        prompt = conv.get_prompt()
+        # if tokenizer.chat_template is None:
+        #     prompt = conv.get_prompt()
+        # else:
+        prompt = tokenizer.apply_chat_template(conv.to_openai_api_messages(), tokenize=False, add_generation_prompt=True)
 
         if is_codet5p:  # codet5p is a code completion model.
             prompt = inp

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -502,10 +502,7 @@ def chat_loop(
 
         conv.append_message(conv.roles[0], inp)
         conv.append_message(conv.roles[1], None)
-        # if tokenizer.chat_template is None:
-        #     prompt = conv.get_prompt()
-        # else:
-        prompt = tokenizer.apply_chat_template(conv.to_openai_api_messages(), tokenize=False, add_generation_prompt=True)
+        prompt = conv.get_prompt()
 
         if is_codet5p:  # codet5p is a code completion model.
             prompt = inp


### PR DESCRIPTION
## Why are these changes needed?
**Main Idea:** Instead of having to add conversation templates into `conversation.py`, many models now support a chat template in the `tokenizer_config.json` file on Huggingface. Given this, we try to use the tokenizer to apply the chat template instead of having to add our own conversation format. Now, users will no longer have to register the model into the adapters nor create a conversation for the model since the tokenizer automatically knows.

**How do we do this?** For any new model that does not match the string matching scheme of current adapters, they will hit the `BaseModelAdapter`. The `BaseModelAdapter` will try to get the conversation template by calling `get_default_conversation_template(model_path)`. We will try to load in the tokenizer with this model path passed in (e.g. 
`tokenizer = AutoTokenizer.from_pretrained("Upstage/SOLAR-10.7B-Instruct-v1.0"`). If this model has a chat template, we then save this tokenizer and use this tokenizer to apply chat templates. If not, we just return the one_shot template.

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
