### PR TITLE
NPU needs to be initialized when starting a new process

### DIFF
--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -31,7 +31,6 @@ from fastchat.utils import (
     str_to_torch_dtype,
 )
 
-
 worker_id = str(uuid.uuid4())[:8]
 logger = build_logger("model_worker", f"model_worker_{worker_id}.log")
 
@@ -101,6 +100,9 @@ class ModelWorker(BaseModelWorker):
             self.init_heart_beat()
 
     def generate_stream_gate(self, params):
+        if self.device == "npu":
+            import torch_npu
+            torch_npu.npu.set_device("npu:0")
         self.call_ct += 1
 
         try:
@@ -216,8 +218,8 @@ class ModelWorker(BaseModelWorker):
                 all_embeddings = []
                 all_token_num = 0
                 for i in range(0, input_ids.size(1), self.context_len):
-                    chunk_input_ids = input_ids[:, i : i + self.context_len]
-                    chunk_attention_mask = attention_mask[:, i : i + self.context_len]
+                    chunk_input_ids = input_ids[:, i: i + self.context_len]
+                    chunk_attention_mask = attention_mask[:, i: i + self.context_len]
 
                     chunk_embeddings, token_num = self.__process_embed_chunk(
                         chunk_input_ids, chunk_attention_mask, **model_type_dict

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -102,6 +102,7 @@ class ModelWorker(BaseModelWorker):
     def generate_stream_gate(self, params):
         if self.device == "npu":
             import torch_npu
+
             torch_npu.npu.set_device("npu:0")
         self.call_ct += 1
 
@@ -218,8 +219,8 @@ class ModelWorker(BaseModelWorker):
                 all_embeddings = []
                 all_token_num = 0
                 for i in range(0, input_ids.size(1), self.context_len):
-                    chunk_input_ids = input_ids[:, i: i + self.context_len]
-                    chunk_attention_mask = attention_mask[:, i: i + self.context_len]
+                    chunk_input_ids = input_ids[:, i : i + self.context_len]
+                    chunk_attention_mask = attention_mask[:, i : i + self.context_len]
 
                     chunk_embeddings, token_num = self.__process_embed_chunk(
                         chunk_input_ids, chunk_attention_mask, **model_type_dict


### PR DESCRIPTION
## Why are these changes needed?
When I test tests/launch_openai_api_test_server.py with NPU, it raise:
```shell
**NETWORK ERROR DUE TO HIGH TRAFFIC. PLEASE REGENERATE OR REFRESH THIS PAGE.*

(allocate:torch_npu/csrc/core/npu/NPUCachingAllocator.cpp:2050 NPU error, error code is 107002
[Error]: The context is empty.
        Check whether acl.rt.set_context or acl.rt.set_device is called.
EE1001: The argument is invalid.Reason: rtGetDevMsg execute failed, reason=[context pointer null]
        Solution: 1.Check the input parameter range of the function. 2.Check the function invocation relationship.
        TraceBack (most recent call last):\n        ctx is NULL![FUNC:GetDevErrMsg][FILE:api_impl.cc][LINE:4620]
        The argument is invalid.Reason: rtGetDevMsg execute failed, reason=[context pointer null]
```
The NPU needs to be initialized when starting a new process.

## Related issue number (if applicable)
issue #2842 

Correct results are returned after fix：
![image](https://github.com/lm-sys/FastChat/assets/4471203/9113b96d-63b5-49d6-a8eb-4a4e632d73c7)

