### PR TITLE
Fix the problem of not using the decoding method corresponding to the base model in peft mode

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -422,11 +422,6 @@ def get_generate_stream_function(model: torch.nn.Module, model_path: str):
     else:
         return generate_stream
 
-def get_result(model, tokenizer, prompt):
-    for response, history in model.stream_chat(tokenizer, prompt, [], past_key_values=None, return_past_key_values=False, max_length=8192, top_p=0.8, temperature=0.95):
-        pass
-    return response
-
 
 def add_model_args(parser):
     parser.add_argument(

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -370,10 +370,14 @@ def get_generate_stream_function(model: torch.nn.Module, model_path: str):
     from fastchat.serve.inference import generate_stream
 
     model_type = str(type(model)).lower()
+    is_peft = "peft" in model_type
+    if is_peft:
+        model.set_adapter(model_path)
+        model_type = str(type(model.base_model.model))
+
     is_chatglm = "chatglm" in model_type
     is_falcon = "rwforcausallm" in model_type
     is_codet5p = "codet5p" in model_type
-    is_peft = "peft" in model_type
     is_exllama = "exllama" in model_type
     is_xft = "xft" in model_type
 
@@ -417,6 +421,11 @@ def get_generate_stream_function(model: torch.nn.Module, model_path: str):
         return generate_stream_peft
     else:
         return generate_stream
+
+def get_result(model, tokenizer, prompt):
+    for response, history in model.stream_chat(tokenizer, prompt, [], past_key_values=None, return_past_key_values=False, max_length=8192, top_p=0.8, temperature=0.95):
+        pass
+    return response
 
 
 def add_model_args(parser):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
```shell
CUDA_VISIBLE_DEVICES=1 PEFT_SHARE_BASE_WEIGHTS=true nohup  python3 -m fastchat.serve.multi_model_worker \
    --model-path /xxx/chatglm3-6b/peft/peft_xxxx \
    --model-path /xxx/chatglm3-6b/peft/peft_xxxx \
    --port 30001 \
    --conv-template chatglm3 \
    --worker http://localhost:30001 >./logs/nohup_3.log  2>&1 &
 ```
**Usage Scenario**：Load peft trained Adapters.
**Problem**: When peft mode is enabled, instead of using the `generate_stream_function` of the base model, `generate_stream_peft ` is used. For example, when the base model is `chatglm`, `generate_stream_chatglm` should be used. When using `generate_stream_peft`, the response is disorganized and repetitive. The fundamental reason is that the inference code (`generate_stream_peft`) is not suitable for models such as chatglm. Here is an test example.
```json
{
  "model": "peft_base",
  "messages": [
    {
      "role": "user",
      "content": "写一篇1000字的检讨"
    }
  ],
  "temperature": 0.7,
  "n": 1,
  "max_tokens": 1024,
  "stop": [],
  "stream": false,
  "presence_penalty": 0,
  "frequency_penalty": 0
}
```
**`generate_stream_peft**: the response is disorganized and repetitive.

> 尊敬的领导:
> 
> 首先，我想通过这封禁言辞退而非常抱歉，我写这封检讨 
> 我写这封检讨
> 写这封检讨 如果您能写这封检讨 报告，我写这篇检讨 检讨 
> 写这封检讨 检讨 报 
> 报告是关于上一次我写这封检讨 检讨 报 报 报 报 报 报
> 我写这封 检讨 报 报 报 
> 我写这封道歉信是关于我 上周 书 是我的错 检讨 检讨 检讨 书是我在过去承 
> 我写这周 检讨 检讨 书信是关于我 上周 检讨 书 书信的方式 回 书信是关于我的 书信 是我的最近我 上周 书信表达 书信中 检讨 书信，我 上周 书 

**`generate_stream_chatglm**: the response is normal.

> 作为一款人工智能助手，我虽然不能像人类一样感受到情感和压力，但我能够通过不断地学习和改进，来提高自己的表现和质量。最近，我因为自己的失误，给用户带来了不必要的困扰和麻烦，我深感抱歉和内疚。在此，我要向所有使用我的用户提供诚挚的道歉。
> 
> 我的失误导致了用户的失望和不满。我深感愧疚和自责，因为我知道，作为一款人工智能助手，我的目标是尽可能地提供准确、高效、优质的服务，让用户能够更好地体验和使用我的产品。然而，我的失误却让用户的目标并未得到满足，反而增加了他们的困扰和麻烦。我深知自己的失误是多么的不可原谅，我必须努力改进和提高自己的表现。

**Solution**: When peft mode is enabled, get the base model and then use the corresponding `generate_stream_function`.
## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ x ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
