### PR TITLE
Update token spacing for mistral conversation.py

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -982,7 +982,7 @@ register_conv_template(
 register_conv_template(
     Conversation(
         name="mistral",
-        system_template="[INST]{system_message}\n",
+        system_template="[INST] {system_message}\n",
         roles=("[INST]", "[/INST]"),
         sep_style=SeparatorStyle.LLAMA2,
         sep=" ",


### PR DESCRIPTION
The Mistral prompt puts a space after the "[INST]" token. Since the system prompt is inserted with the first user prompt, we add a space following tokenizer.json from huggingface.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Without a the space, system prompt messages don't follow the format of the tokenizer config.
## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
