### PR TITLE
fix the tokenize process and prompt template of chatglm3

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -172,7 +172,7 @@ class Conversation:
                 ret += system_prompt
             for role, message in self.messages:
                 if message:
-                    ret += role + "\n" + " " + message
+                    ret += role + "\n" + message
                 else:
                     ret += role
             return ret
@@ -487,7 +487,7 @@ register_conv_template(
 register_conv_template(
     Conversation(
         name="chatglm3",
-        system_template="<|system|>\n {system_message}",
+        system_template="<|system|>\n{system_message}",
         roles=("<|user|>", "<|assistant|>"),
         sep_style=SeparatorStyle.CHATGLM3,
         stop_token_ids=[

--- a/fastchat/model/model_chatglm.py
+++ b/fastchat/model/model_chatglm.py
@@ -36,6 +36,27 @@ def process_response(response):
         response = re.sub(r"%s([\u4e00-\u9fff])" % item[0], r"%s\1" % item[1], response)
     return response
 
+def recover_message_list(prompt):
+    role_token_pattern = "|".join([re.escape(r) for r in ["<|system|>", "<|user|>", "<|assistant|>"]])
+    role = None
+    last_end_idx = -1
+    message_list = []
+    for match in re.finditer(role_token_pattern, prompt):
+        if role:
+            messge = {}
+            if role == "<|system|>":
+                messge["role"] = "system"
+            elif role == "<|user|>":
+                messge["role"] = "user"
+            else:
+                messge["role"] = "assistant"
+            messge["content"] = prompt[last_end_idx + 1: match.start()]
+            message_list.append(messge)
+
+        role = prompt[match.start(): match.end()]
+        last_end_idx = match.end()
+
+    return message_list
 
 @torch.inference_mode()
 def generate_stream_chatglm(
@@ -54,7 +75,15 @@ def generate_stream_chatglm(
     max_new_tokens = int(params.get("max_new_tokens", 256))
     echo = params.get("echo", True)
 
-    inputs = tokenizer([prompt], return_tensors="pt").to(model.device)
+    model_type = str(type(model)).lower()
+    if "peft" in model_type:
+        model_type = str(type(model.base_model.model)).lower()
+
+    if "chatglm3" in model_type:
+        message_list = recover_message_list(prompt)
+        inputs = tokenizer.build_chat_input(query=message_list[-1]["content"], history=message_list[:-1], role='user').to(model.device)
+    else:
+        inputs = tokenizer([prompt], return_tensors="pt").to(model.device)
     input_echo_len = len(inputs["input_ids"][0])
 
     gen_kwargs = {

--- a/fastchat/model/model_chatglm.py
+++ b/fastchat/model/model_chatglm.py
@@ -36,8 +36,11 @@ def process_response(response):
         response = re.sub(r"%s([\u4e00-\u9fff])" % item[0], r"%s\1" % item[1], response)
     return response
 
+
 def recover_message_list(prompt):
-    role_token_pattern = "|".join([re.escape(r) for r in ["<|system|>", "<|user|>", "<|assistant|>"]])
+    role_token_pattern = "|".join(
+        [re.escape(r) for r in ["<|system|>", "<|user|>", "<|assistant|>"]]
+    )
     role = None
     last_end_idx = -1
     message_list = []
@@ -50,13 +53,14 @@ def recover_message_list(prompt):
                 messge["role"] = "user"
             else:
                 messge["role"] = "assistant"
-            messge["content"] = prompt[last_end_idx + 1: match.start()]
+            messge["content"] = prompt[last_end_idx + 1 : match.start()]
             message_list.append(messge)
 
-        role = prompt[match.start(): match.end()]
+        role = prompt[match.start() : match.end()]
         last_end_idx = match.end()
 
     return message_list
+
 
 @torch.inference_mode()
 def generate_stream_chatglm(
@@ -81,7 +85,9 @@ def generate_stream_chatglm(
 
     if "chatglm3" in model_type:
         message_list = recover_message_list(prompt)
-        inputs = tokenizer.build_chat_input(query=message_list[-1]["content"], history=message_list[:-1], role='user').to(model.device)
+        inputs = tokenizer.build_chat_input(
+            query=message_list[-1]["content"], history=message_list[:-1], role="user"
+        ).to(model.device)
     else:
         inputs = tokenizer([prompt], return_tensors="pt").to(model.device)
     input_echo_len = len(inputs["input_ids"][0])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

### Tokenize process
chatglm3 introduces some special role tokens such as `<|user|>`, `<|assistant|>` and `<|system|>`, which results the prompt cannot be directly converted to token_ids using `tokenizer()`. The [official code](https://huggingface.co/THUDM/chatglm3-6b/blob/main/tokenization_chatglm.py) uses `tokenizer. build_chat_input()`, and it takes `tokenizer.get_command()` to convert the special role tokens into corresponding token_ids. 
Here is the difference:
The converted token_ids for query "hi" in FastChat(use `tokenizer()` directly) is
```
tokenizer(["<|user|>\nhi<|assistant|>"], return_tensors="pt")
>> [64790, 64792, 906, 31007, 4865, 31007, 30573, 5473, 31002, 31007, 530, 18971, 31007, 30994]
tokenizer.build_chat_input("hi", [])
>> [64790, 64792, 64795, 30910, 13, 14980, 64796]
```
The token_id is different because tokenizer cannot encode  `<|user|>` and `<|assistant|>` directly.
Although it seems still works when use `tokenizer()` for original chatglm3 model, we observed some mistakes when it comes to use finetuned chatglm3 model. Anyway, it’s better to keep consistent with the official code.
The changed code recovers message list from prompt and then use `tokenizer.build_chat_input()` to get token_ids for chatglm3. For chatglm and chatglm2, it still use 'tokenizer()' directly. 

### Prompt template
There is no space when the prompt is constructed in official code.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
