### PR TITLE
Fix bug that model doesn't automatically switch peft adapter

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -371,10 +371,6 @@ def get_generate_stream_function(model: torch.nn.Module, model_path: str):
 
     model_type = str(type(model)).lower()
     is_peft = "peft" in model_type
-    if is_peft:
-        model.set_adapter(model_path)
-        model_type = str(type(model.base_model.model))
-
     is_chatglm = "chatglm" in model_type
     is_falcon = "rwforcausallm" in model_type
     is_codet5p = "codet5p" in model_type
@@ -407,7 +403,24 @@ def get_generate_stream_function(model: torch.nn.Module, model_path: str):
             judge_sent_end: bool = False,
         ):
             model.set_adapter(model_path)
-            for x in generate_stream(
+            base_model_type = str(type(model.base_model.model))
+            is_chatglm = "chatglm" in base_model_type
+            is_falcon = "rwforcausallm" in base_model_type
+            is_codet5p = "codet5p" in base_model_type
+            is_exllama = "exllama" in base_model_type
+            is_xft = "xft" in base_model_type
+            generate_stream_function = generate_stream
+            if is_chatglm:
+                generate_stream_function = generate_stream_chatglm
+            elif is_falcon:
+                generate_stream_function = generate_stream_falcon
+            elif is_codet5p:
+                generate_stream_function = generate_stream_codet5p
+            elif is_exllama:
+                generate_stream_function = generate_stream_exllama
+            elif is_xft:
+                generate_stream_function = generate_stream_xft
+            for x in generate_stream_function(
                 model,
                 tokenizer,
                 params,

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -422,11 +422,6 @@ def get_generate_stream_function(model: torch.nn.Module, model_path: str):
     else:
         return generate_stream
 
-def get_result(model, tokenizer, prompt):
-    for response, history in model.stream_chat(tokenizer, prompt, [], past_key_values=None, return_past_key_values=False, max_length=8192, top_p=0.8, temperature=0.95):
-        pass
-    return response
-
 
 def add_model_args(parser):
     parser.add_argument(

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -370,10 +370,14 @@ def get_generate_stream_function(model: torch.nn.Module, model_path: str):
     from fastchat.serve.inference import generate_stream
 
     model_type = str(type(model)).lower()
+    is_peft = "peft" in model_type
+    if is_peft:
+        model.set_adapter(model_path)
+        model_type = str(type(model.base_model.model))
+
     is_chatglm = "chatglm" in model_type
     is_falcon = "rwforcausallm" in model_type
     is_codet5p = "codet5p" in model_type
-    is_peft = "peft" in model_type
     is_exllama = "exllama" in model_type
     is_xft = "xft" in model_type
 
@@ -417,6 +421,11 @@ def get_generate_stream_function(model: torch.nn.Module, model_path: str):
         return generate_stream_peft
     else:
         return generate_stream
+
+def get_result(model, tokenizer, prompt):
+    for response, history in model.stream_chat(tokenizer, prompt, [], past_key_values=None, return_past_key_values=False, max_length=8192, top_p=0.8, temperature=0.95):
+        pass
+    return response
 
 
 def add_model_args(parser):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Although [#2865](https://github.com/lm-sys/FastChat/pull/2865) has fixed the problem of not using the decoding method corresponding to the base model in peft mode, it introduces additional bug (model doesn't automatically switch peft adapter).
When we call `generate_stream_function` such as `generate_stream_chatglm`, the process does not execute code `model.set_adapter(model_path)` to switch peft models . That's because `generate_stream_function` doesn't have the line of code `model.set_adapter(model_path)`.

My solution is to execute the ``generate_stream_function`` corresponding to the base model in `generate_stream_peft`.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ x ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
