### PR TITLE
Integrate LightLLM into serve worker

### DIFF
--- a/docs/lightllm_integration.md
+++ b/docs/lightllm_integration.md
@@ -1,0 +1,18 @@
+# LightLLM Integration
+You can use [LightLLM](https://github.com/ModelTC/lightllm) as an optimized worker implementation in FastChat.
+It offers advanced continuous batching and a much higher (~10x) throughput.
+See the supported models [here](https://github.com/ModelTC/lightllm?tab=readme-ov-file#supported-model-list).
+
+## Instructions
+1. Please refer to the [Get started](https://github.com/ModelTC/lightllm?tab=readme-ov-file#get-started) to install LightLLM. Or use [Pre-built image](https://github.com/ModelTC/lightllm?tab=readme-ov-file#container)
+
+2. When you launch a model worker, replace the normal worker (`fastchat.serve.model_worker`) with the LightLLM worker (`fastchat.serve.lightllm_worker`). All other commands such as controller, gradio web server, and OpenAI API server are kept the same. Refer to [--max_total_token_num](https://github.com/ModelTC/lightllm/blob/4a9824b6b248f4561584b8a48ae126a0c8f5b000/docs/ApiServerArgs.md?plain=1#L23) to understand how to calcuate the `--max_total_token_num` argument.
+   ```
+   python3 -m fastchat.serve.lightllm_worker --model-path lmsys/vicuna-7b-v1.5 --tokenizer_mode "auto" --max_total_token_num 154000
+   ```
+
+   If you what to use quantized weight and kv cache for inference, try
+
+   ```
+   python3 -m fastchat.serve.lightllm_worker --model-path lmsys/vicuna-7b-v1.5 --tokenizer_mode "auto" --max_total_token_num 154000 --mode triton_int8weight triton_int8kv
+   ```

--- a/fastchat/serve/base_model_worker.py
+++ b/fastchat/serve/base_model_worker.py
@@ -54,7 +54,8 @@ class BaseModelWorker:
         self.heart_beat_thread = None
 
         if logger is None:
-            logger = build_logger("model_worker", f"model_worker_{self.worker_id}.log")
+            logger = build_logger(
+                "model_worker", f"model_worker_{self.worker_id}.log")
         if worker is None:
             worker = self
 
@@ -129,11 +130,13 @@ class BaseModelWorker:
         if self.semaphore is None:
             return 0
         else:
-            return (
-                self.limit_worker_concurrency
-                - (self.semaphore._value or self.limit_worker_concurrency)
-                + len((self.semaphore._waiters or []))
-            )
+            sempahore_value = self.semaphore._value \
+                if self.semaphore._value is not None \
+                else self.limit_worker_concurrency
+            waiter_count = 0 \
+                if self.semaphore._waiters is None \
+                else len(self.semaphore._waiters)
+            return self.limit_worker_concurrency - sempahore_value + waiter_count
 
     def get_status(self):
         return {

--- a/fastchat/serve/base_model_worker.py
+++ b/fastchat/serve/base_model_worker.py
@@ -54,8 +54,7 @@ class BaseModelWorker:
         self.heart_beat_thread = None
 
         if logger is None:
-            logger = build_logger(
-                "model_worker", f"model_worker_{self.worker_id}.log")
+            logger = build_logger("model_worker", f"model_worker_{self.worker_id}.log")
         if worker is None:
             worker = self
 
@@ -130,12 +129,14 @@ class BaseModelWorker:
         if self.semaphore is None:
             return 0
         else:
-            sempahore_value = self.semaphore._value \
-                if self.semaphore._value is not None \
+            sempahore_value = (
+                self.semaphore._value
+                if self.semaphore._value is not None
                 else self.limit_worker_concurrency
-            waiter_count = 0 \
-                if self.semaphore._waiters is None \
-                else len(self.semaphore._waiters)
+            )
+            waiter_count = (
+                0 if self.semaphore._waiters is None else len(self.semaphore._waiters)
+            )
             return self.limit_worker_concurrency - sempahore_value + waiter_count
 
     def get_status(self):

--- a/fastchat/serve/base_model_worker.py
+++ b/fastchat/serve/base_model_worker.py
@@ -126,17 +126,13 @@ class BaseModelWorker:
             self.register_to_controller()
 
     def get_queue_length(self):
-        if (
-            self.semaphore is None
-            or self.semaphore._value is None
-            or self.semaphore._waiters is None
-        ):
+        if self.semaphore is None:
             return 0
         else:
             return (
                 self.limit_worker_concurrency
-                - self.semaphore._value
-                + len(self.semaphore._waiters)
+                - (self.semaphore._value or self.limit_worker_concurrency)
+                + len((self.semaphore._waiters or []))
             )
 
     def get_status(self):

--- a/fastchat/serve/lightllm_worker.py
+++ b/fastchat/serve/lightllm_worker.py
@@ -11,6 +11,8 @@ import os
 import torch
 import uvicorn
 
+from transformers import AutoConfig
+
 from typing import List
 
 from fastapi import FastAPI, Request, BackgroundTasks

--- a/fastchat/serve/lightllm_worker.py
+++ b/fastchat/serve/lightllm_worker.py
@@ -434,8 +434,7 @@ if __name__ == "__main__":
     if not args.splitfuse_mode:
         assert len(args.prompt_cache_strs) == 0
 
-    with open(os.path.join(args.model_dir, "config.json"), "r") as f:
-        model_config = json.load(f)
+    model_config = AutoConfig.from_pretrained(args.model_dir)
     context_length = get_context_length(model_config)
 
     if args.max_req_input_len is None:

--- a/fastchat/serve/lightllm_worker.py
+++ b/fastchat/serve/lightllm_worker.py
@@ -8,11 +8,13 @@ import argparse
 import asyncio
 import json
 import os
+import torch
+import uvicorn
+
 from typing import List
 
 from fastapi import FastAPI, Request, BackgroundTasks
 from fastapi.responses import StreamingResponse, JSONResponse
-import uvicorn
 
 from fastchat.serve.base_model_worker import BaseModelWorker
 from fastchat.serve.model_worker import (
@@ -20,7 +22,6 @@ from fastchat.serve.model_worker import (
     worker_id,
 )
 
-from typing import AsyncGenerator
 
 from lightllm.server.sampling_params import SamplingParams
 from lightllm.server.multimodal_params import MultimodalParams
@@ -39,6 +40,7 @@ from lightllm.utils.start_utils import start_submodule_processes
 from fastchat.utils import get_context_length, is_partial_stop
 
 app = FastAPI()
+g_id_gen = ReqIDGenerator()
 
 
 class LightLLMWorker(BaseModelWorker):
@@ -66,13 +68,12 @@ class LightLLMWorker(BaseModelWorker):
         )
 
         logger.info(
-            f"Loading the model {self.model_names} on worker {worker_id}, worker type: vLLM worker..."
+            f"Loading the model {self.model_names} on worker {worker_id}, worker type: LightLLM worker..."
         )
         self.tokenizer = tokenizer
         self.context_len = context_len
 
         self.is_first = True
-        self.g_id_gen = ReqIDGenerator()
 
         if not no_register:
             self.init_heart_beat()
@@ -87,14 +88,13 @@ class LightLLMWorker(BaseModelWorker):
         top_k = params.get("top_k", -1.0)
         presence_penalty = float(params.get("presence_penalty", 0.0))
         frequency_penalty = float(params.get("frequency_penalty", 0.0))
+        repetition_penalty = float(params.get("repetition_penalty", 1.0))
         max_new_tokens = params.get("max_new_tokens", 256)
+        echo = params.get("echo", True)
         stop_str = params.get("stop", None)
         stop_token_ids = params.get("stop_token_ids", None) or []
         if self.tokenizer.eos_token_id is not None:
             stop_token_ids.append(self.tokenizer.eos_token_id)
-        # echo = params.get("echo", True)
-        # use_beam_search = params.get("use_beam_search", False)
-        # best_of = params.get("best_of", None)
 
         # Handle stop_str
         stop = set()
@@ -126,63 +126,113 @@ class LightLLMWorker(BaseModelWorker):
             top_k=top_k,
             presence_penalty=presence_penalty,
             frequency_penalty=frequency_penalty,
+            repetition_penalty=repetition_penalty,
             max_new_tokens=max_new_tokens,
             stop_sequences=list(stop),
         )
         sampling_params.verify()
 
-        request_id = self.g_id_gen.generate_id()
         results_generator = httpserver_manager.generate(
             prompt, sampling_params, request_id, MultimodalParams())
 
-        async def abort_request() -> None:
-            await httpserver_manager.abort(request_id)
-
-        background_tasks = BackgroundTasks()
-        # Abort the request if the client disconnects.
-        background_tasks.add_task(abort_request)
-
+        completion_tokens = 0
+        text_outputs = ''
         async for request_output, metadata, finished in results_generator:
-            print(metadata.keys())
-            ret = {
-                "text": request_output,
-                "error_code": 0,
-                # "usage": {
-                #     "prompt_tokens": prompt_tokens,
-                #     "completion_tokens": completion_tokens,
-                #     "total_tokens": prompt_tokens + completion_tokens,
-                # },
-                "usage": None,
-                "cumulative_logprob": metadata.get("logprob", None),
-                # "finish_reason": request_output.outputs[0].finish_reason
-                # if len(request_output.outputs) == 1
-                # else [output.finish_reason for output in request_output.outputs],
-                "finish_reason": finished,
-            }
-            # ret = {
-            #     "token": {
-            #         "id": metadata.get("id", None),
-            #         "text": request_output,
-            #         "logprob": metadata.get("logprob", None),
-            #         "special": False
-            #     },
-            #     "generated_text": None,
-            #     "finished": finished,
-            #     "details": None
-            # }
+            text_outputs += request_output
 
-            yield ("data:" + json.dumps(ret, ensure_ascii=False) + "\0").encode(
-                "utf-8"
-            )
+            partial_stop = any(is_partial_stop(text_outputs, i) for i in stop)
+            # prevent yielding partial stop sequence
+            if partial_stop:
+                continue
+
+            prompt_tokens = metadata['prompt_tokens']
+            ret = {
+                "text": prompt + text_outputs if echo else text_outputs,
+                "error_code": 0,
+                "usage": {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                },
+            }
+            finish_reason = None
+            if finished:
+                yield (json.dumps({**ret, "finish_reason": None}, ensure_ascii=False) + "\0").encode("utf-8")
+                finish_reason = "stop"
+            yield (json.dumps({**ret, "finish_reason": finish_reason}, ensure_ascii=False) + "\0").encode("utf-8")
 
     async def generate(self, params):
-        x = b''
         async for x in self.generate_stream(params):
             pass
         return json.loads(x[:-1].decode())
 
 
+def release_worker_semaphore():
+    worker.semaphore.release()
+
+
+def acquire_worker_semaphore():
+    if worker.semaphore is None:
+        worker.semaphore = asyncio.Semaphore(worker.limit_worker_concurrency)
+    return worker.semaphore.acquire()
+
+
+def create_background_tasks(request_id):
+    async def abort_request() -> None:
+        await httpserver_manager.abort(request_id)
+
+    background_tasks = BackgroundTasks()
+    background_tasks.add_task(release_worker_semaphore)
+    background_tasks.add_task(abort_request)
+    return background_tasks
+
+
+@app.post("/worker_generate_stream")
+async def api_generate_stream(request: Request):
+    params = await request.json()
+    await acquire_worker_semaphore()
+    request_id = g_id_gen.generate_id()
+    params["request_id"] = request_id
+    generator = worker.generate_stream(params)
+    background_tasks = create_background_tasks(request_id)
+    return StreamingResponse(generator, background=background_tasks)
+
+
+@app.post("/worker_generate")
+async def api_generate(request: Request):
+    params = await request.json()
+    await acquire_worker_semaphore()
+    request_id = g_id_gen.generate_id()
+    params["request_id"] = request_id
+    output = await worker.generate(params)
+    release_worker_semaphore()
+    await httpserver_manager.abort(request_id)
+    return JSONResponse(output)
+
+
+@app.post("/worker_get_status")
+async def api_get_status(request: Request):
+    return worker.get_status()
+
+
+@app.post("/count_token")
+async def api_count_token(request: Request):
+    params = await request.json()
+    return worker.count_token(params)
+
+
+@app.post("/worker_get_conv_template")
+async def api_get_conv(request: Request):
+    return worker.get_conv_template()
+
+
+@app.post("/model_details")
+async def api_model_details(request: Request):
+    return {"context_length": worker.context_len}
+
+
 if __name__ == "__main__":
+    torch.multiprocessing.set_start_method('spawn')
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", type=str, default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
@@ -197,6 +247,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--conv-template", type=str, default=None, help="Conversation prompt template."
     )
+    parser.add_argument(
+        "--model-names",
+        type=lambda s: s.split(","),
+        help="Optional display comma separated names",
+    )
+    parser.add_argument("--limit-worker-concurrency", type=int, default=1024)
+    parser.add_argument("--no-register", action="store_true")
 
     parser.add_argument("--tokenizer_mode", type=str, default="slow",
                         help="""tokenizer load mode, can be slow or auto, slow mode load fast but run slow, slow mode is good for debug and test,
@@ -213,12 +270,10 @@ if __name__ == "__main__":
                         help="the max size for forward requests in the same time")
     parser.add_argument("--tp", type=int, default=1,
                         help="model tp parral size, the default is 1")
-    parser.add_argument("--max_req_input_len", type=int, default=2048,
-                        help="the max value for req input tokens num")
-    parser.add_argument("--max_req_total_len", type=int, default=2048 + 1024,
-                        help="the max value for req_input_len + req_output_len")
-    parser.add_argument("--nccl_port", type=int, default=28765,
-                        help="the nccl_port to build a distributed environment for PyTorch")
+    parser.add_argument("--max_req_input_len", type=int, default=None,
+                        help="the max value for req input tokens num. If None, it will be derived from the config.")
+    parser.add_argument("--max_req_total_len", type=int, default=None,
+                        help="the max value for req_input_len + req_output_len. If None, it will be derived from the config.")
     parser.add_argument("--mode", type=str, default=[], nargs='+',
                         help="""Model mode: [triton_int8kv | ppl_int8kv | ppl_fp16 | triton_flashdecoding
                         | triton_gqa_attention | triton_gqa_flashdecoding]
@@ -253,8 +308,6 @@ if __name__ == "__main__":
                         help="splitfuse block size")
     parser.add_argument("--prompt_cache_strs", type=str, default=[], nargs='+',
                         help="""prompt cache strs""")
-    parser.add_argument("--enable_multimodal", action='store_true',
-                        help="Whether or not to allow to load additional multimodal models.")
     parser.add_argument("--cache_capacity", type=int, default=200,
                         help="cache server capacity for multimodal resources")
     parser.add_argument("--cache_reserved_ratio", type=float, default=0.5,
@@ -272,6 +325,15 @@ if __name__ == "__main__":
     # 非splitfuse 模式，不支持 prompt cache 特性
     if not args.splitfuse_mode:
         assert len(args.prompt_cache_strs) == 0
+
+    with open(os.path.join(args.model_dir, "config.json"), "r") as f:
+        model_config = json.load(f)
+    context_length = get_context_length(model_config)
+
+    if args.max_req_input_len is None:
+        args.max_req_input_len = context_length - 1
+    if args.max_req_total_len is None:
+        args.max_req_total_len = context_length
 
     assert args.max_req_input_len < args.max_req_total_len
     assert args.max_req_total_len <= args.max_total_token_num
@@ -294,16 +356,13 @@ if __name__ == "__main__":
             batch_max_tokens = max(batch_max_tokens, args.splitfuse_block_size)
             args.batch_max_tokens = batch_max_tokens
 
-    can_use_ports = alloc_can_use_network_port(
-        num=5 + args.tp, used_nccl_port=args.nccl_port
-    )
-    router_port, detokenization_port, httpserver_port, visual_port, cache_port = can_use_ports[
-        0:5]
-    model_rpc_ports = can_use_ports[5:]
+    can_use_ports = alloc_can_use_network_port(num=6 + args.tp)
 
-    if args.enable_multimodal:
-        start_submodule_processes(start_funcs=[start_cache_manager,],
-                                  start_args=[(cache_port, args.cache_capacity, args.cache_reserved_ratio)])
+    assert can_use_ports is not None, "Can not alloc free enough port"
+    router_port, detokenization_port, httpserver_port, visual_port, cache_port, nccl_port = can_use_ports[
+        0:6]
+    args.nccl_port = nccl_port
+    model_rpc_ports = can_use_ports[6:]
 
     global httpserver_manager
     httpserver_manager = HttpServerManager(
@@ -312,30 +371,23 @@ if __name__ == "__main__":
         cache_port=cache_port,
         visual_port=visual_port,
         httpserver_port=httpserver_port,
-        enable_multimodal=args.enable_multimodal,
+        enable_multimodal=False,
     )
 
     start_submodule_processes(start_funcs=[start_router_process, start_detokenization_process],
                               start_args=[(args, router_port, detokenization_port, model_rpc_ports),
                                           (args, detokenization_port, httpserver_port)])
-    if args.enable_multimodal:
-        start_submodule_processes(start_funcs=[start_visual_process,],
-                                  start_args=[(args, router_port, visual_port, cache_port),])
-
-    with open(os.path.join(args.model_dir, "config.json"), "r") as f:
-        model_config = json.load(f)
-
     worker = LightLLMWorker(
         args.controller_address,
         args.worker_address,
         worker_id,
-        args.model_path,
+        args.model_dir,
         args.model_names,
         args.limit_worker_concurrency,
         args.no_register,
         args.conv_template,
         httpserver_manager.tokenizer,
-        get_context_length(model_config),
+        context_length,
     )
 
     uvicorn.run(app, host=args.host, port=args.port, log_level="info")

--- a/fastchat/serve/lightllm_worker.py
+++ b/fastchat/serve/lightllm_worker.py
@@ -152,6 +152,10 @@ class LightLLMWorker(BaseModelWorker):
                 await httpserver_manager.abort(request_id)
                 finish_reason = "abort"
 
+            logprob = metadata.get("logprob", None)
+            if logprob is not None:
+                cumulative_logprob += logprob
+
             prompt_tokens = metadata["prompt_tokens"]
             ret = {
                 "text": prompt + text_outputs if echo else text_outputs,
@@ -161,6 +165,7 @@ class LightLLMWorker(BaseModelWorker):
                     "completion_tokens": completion_tokens,
                     "total_tokens": prompt_tokens + completion_tokens,
                 },
+                "cumulative_logprob": cumulative_logprob,
             }
 
             if finish_reason is not None:

--- a/fastchat/serve/lightllm_worker.py
+++ b/fastchat/serve/lightllm_worker.py
@@ -358,7 +358,7 @@ if __name__ == "__main__":
 
     can_use_ports = alloc_can_use_network_port(num=6 + args.tp)
 
-    assert can_use_ports is not None, "Can not alloc free enough port"
+    assert can_use_ports is not None, "Can not alloc enough free ports."
     router_port, detokenization_port, httpserver_port, visual_port, cache_port, nccl_port = can_use_ports[
         0:6]
     args.nccl_port = nccl_port

--- a/fastchat/serve/lightllm_worker.py
+++ b/fastchat/serve/lightllm_worker.py
@@ -1,7 +1,7 @@
 """
 A model worker that executes the model based on LightLLM.
 
-See documentations at docs/vllm_integration.md
+See documentations at docs/lightllm_integration.md
 """
 
 import argparse

--- a/fastchat/serve/lightllm_worker.py
+++ b/fastchat/serve/lightllm_worker.py
@@ -177,6 +177,9 @@ class LightLLMWorker(BaseModelWorker):
                 + "\0"
             ).encode("utf-8")
 
+            if finish_reason is not None:  # In case of abort, we need to break the loop
+                break
+
     async def generate(self, params):
         async for x in self.generate_stream(params):
             pass

--- a/fastchat/serve/lightllm_worker.py
+++ b/fastchat/serve/lightllm_worker.py
@@ -133,10 +133,11 @@ class LightLLMWorker(BaseModelWorker):
         sampling_params.verify()
 
         results_generator = httpserver_manager.generate(
-            prompt, sampling_params, request_id, MultimodalParams())
+            prompt, sampling_params, request_id, MultimodalParams()
+        )
 
         completion_tokens = 0
-        text_outputs = ''
+        text_outputs = ""
         async for request_output, metadata, finished in results_generator:
             text_outputs += request_output
 
@@ -145,7 +146,7 @@ class LightLLMWorker(BaseModelWorker):
             if partial_stop:
                 continue
 
-            prompt_tokens = metadata['prompt_tokens']
+            prompt_tokens = metadata["prompt_tokens"]
             ret = {
                 "text": prompt + text_outputs if echo else text_outputs,
                 "error_code": 0,
@@ -157,9 +158,15 @@ class LightLLMWorker(BaseModelWorker):
             }
             finish_reason = None
             if finished:
-                yield (json.dumps({**ret, "finish_reason": None}, ensure_ascii=False) + "\0").encode("utf-8")
+                yield (
+                    json.dumps({**ret, "finish_reason": None}, ensure_ascii=False)
+                    + "\0"
+                ).encode("utf-8")
                 finish_reason = "stop"
-            yield (json.dumps({**ret, "finish_reason": finish_reason}, ensure_ascii=False) + "\0").encode("utf-8")
+            yield (
+                json.dumps({**ret, "finish_reason": finish_reason}, ensure_ascii=False)
+                + "\0"
+            ).encode("utf-8")
 
     async def generate(self, params):
         async for x in self.generate_stream(params):
@@ -232,15 +239,19 @@ async def api_model_details(request: Request):
 
 
 if __name__ == "__main__":
-    torch.multiprocessing.set_start_method('spawn')
+    torch.multiprocessing.set_start_method("spawn")
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", type=str, default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
 
-    parser.add_argument("--model-path", dest='model_dir', type=str, default=None,
-                        help="the model weight dir path, the app will load config, weights and tokenizer from this dir")
-    parser.add_argument("--worker-address", type=str,
-                        default="http://localhost:21002")
+    parser.add_argument(
+        "--model-path",
+        dest="model_dir",
+        type=str,
+        default=None,
+        help="the model weight dir path, the app will load config, weights and tokenizer from this dir",
+    )
+    parser.add_argument("--worker-address", type=str, default="http://localhost:21002")
     parser.add_argument(
         "--controller-address", type=str, default="http://localhost:21001"
     )
@@ -255,27 +266,59 @@ if __name__ == "__main__":
     parser.add_argument("--limit-worker-concurrency", type=int, default=1024)
     parser.add_argument("--no-register", action="store_true")
 
-    parser.add_argument("--tokenizer_mode", type=str, default="slow",
-                        help="""tokenizer load mode, can be slow or auto, slow mode load fast but run slow, slow mode is good for debug and test,
-                        when you want to get best performance, try auto mode""")
-    parser.add_argument("--load_way", type=str, default="HF",
-                        help="the way of loading model weights, the default is HF(Huggingface format), llama also supports DS(Deepspeed)")
-    parser.add_argument("--max_total_token_num", type=int, default=6000,
-                        help="the total token nums the gpu and model can support, equals = max_batch * (input_len + output_len)")
-    parser.add_argument("--batch_max_tokens", type=int, default=None,
-                        help="max tokens num for new cat batch, it control prefill batch size to Preventing OOM")
-    parser.add_argument("--eos_id", type=int, default=2,
-                        help="eos stop token id")
-    parser.add_argument("--running_max_req_size", type=int, default=1000,
-                        help="the max size for forward requests in the same time")
-    parser.add_argument("--tp", type=int, default=1,
-                        help="model tp parral size, the default is 1")
-    parser.add_argument("--max_req_input_len", type=int, default=None,
-                        help="the max value for req input tokens num. If None, it will be derived from the config.")
-    parser.add_argument("--max_req_total_len", type=int, default=None,
-                        help="the max value for req_input_len + req_output_len. If None, it will be derived from the config.")
-    parser.add_argument("--mode", type=str, default=[], nargs='+',
-                        help="""Model mode: [triton_int8kv | ppl_int8kv | ppl_fp16 | triton_flashdecoding
+    parser.add_argument(
+        "--tokenizer_mode",
+        type=str,
+        default="slow",
+        help="""tokenizer load mode, can be slow or auto, slow mode load fast but run slow, slow mode is good for debug and test,
+                        when you want to get best performance, try auto mode""",
+    )
+    parser.add_argument(
+        "--load_way",
+        type=str,
+        default="HF",
+        help="the way of loading model weights, the default is HF(Huggingface format), llama also supports DS(Deepspeed)",
+    )
+    parser.add_argument(
+        "--max_total_token_num",
+        type=int,
+        default=6000,
+        help="the total token nums the gpu and model can support, equals = max_batch * (input_len + output_len)",
+    )
+    parser.add_argument(
+        "--batch_max_tokens",
+        type=int,
+        default=None,
+        help="max tokens num for new cat batch, it control prefill batch size to Preventing OOM",
+    )
+    parser.add_argument("--eos_id", type=int, default=2, help="eos stop token id")
+    parser.add_argument(
+        "--running_max_req_size",
+        type=int,
+        default=1000,
+        help="the max size for forward requests in the same time",
+    )
+    parser.add_argument(
+        "--tp", type=int, default=1, help="model tp parral size, the default is 1"
+    )
+    parser.add_argument(
+        "--max_req_input_len",
+        type=int,
+        default=None,
+        help="the max value for req input tokens num. If None, it will be derived from the config.",
+    )
+    parser.add_argument(
+        "--max_req_total_len",
+        type=int,
+        default=None,
+        help="the max value for req_input_len + req_output_len. If None, it will be derived from the config.",
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default=[],
+        nargs="+",
+        help="""Model mode: [triton_int8kv | ppl_int8kv | ppl_fp16 | triton_flashdecoding
                         | triton_gqa_attention | triton_gqa_flashdecoding]
                         [triton_int8weight | triton_int4weight | lmdeploy_int4weight | ppl_int4weight],
                         triton_flashdecoding mode is for long context, current support llama llama2 qwen;
@@ -284,41 +327,89 @@ if __name__ == "__main__":
                         ppl_int8kv mode use int8 to store kv cache, and use ppl fast kernel;
                         ppl_fp16 mode use ppl fast fp16 decode attention kernel;
                         triton_int8weight and triton_int4weight and lmdeploy_int4weight or ppl_int4weight mode use int8 and int4 to store weights;
-                        you need to read source code to make sure the supported detail mode for all models""")
-    parser.add_argument("--trust_remote_code", action='store_true',
-                        help="Whether or not to allow for custom models defined on the Hub in their own modeling files.")
-    parser.add_argument("--disable_log_stats", action='store_true',
-                        help="disable logging throughput stats.")
-    parser.add_argument("--log_stats_interval", type=int, default=10,
-                        help="log stats interval in second.")
+                        you need to read source code to make sure the supported detail mode for all models""",
+    )
+    parser.add_argument(
+        "--trust_remote_code",
+        action="store_true",
+        help="Whether or not to allow for custom models defined on the Hub in their own modeling files.",
+    )
+    parser.add_argument(
+        "--disable_log_stats",
+        action="store_true",
+        help="disable logging throughput stats.",
+    )
+    parser.add_argument(
+        "--log_stats_interval",
+        type=int,
+        default=10,
+        help="log stats interval in second.",
+    )
 
-    parser.add_argument("--router_token_ratio", type=float, default=0.0,
-                        help="token ratio to control router dispatch")
-    parser.add_argument("--router_max_new_token_len", type=int, default=1024,
-                        help="the request max new token len for router")
+    parser.add_argument(
+        "--router_token_ratio",
+        type=float,
+        default=0.0,
+        help="token ratio to control router dispatch",
+    )
+    parser.add_argument(
+        "--router_max_new_token_len",
+        type=int,
+        default=1024,
+        help="the request max new token len for router",
+    )
 
-    parser.add_argument("--no_skipping_special_tokens", action="store_true",
-                        help="whether to skip special tokens when decoding")
-    parser.add_argument("--no_spaces_between_special_tokens", action="store_true",
-                        help="whether to add spaces between special tokens when decoding")
+    parser.add_argument(
+        "--no_skipping_special_tokens",
+        action="store_true",
+        help="whether to skip special tokens when decoding",
+    )
+    parser.add_argument(
+        "--no_spaces_between_special_tokens",
+        action="store_true",
+        help="whether to add spaces between special tokens when decoding",
+    )
 
-    parser.add_argument("--splitfuse_mode", action='store_true',
-                        help="use splitfuse mode")
-    parser.add_argument("--splitfuse_block_size", type=int, default=256,
-                        help="splitfuse block size")
-    parser.add_argument("--prompt_cache_strs", type=str, default=[], nargs='+',
-                        help="""prompt cache strs""")
-    parser.add_argument("--cache_capacity", type=int, default=200,
-                        help="cache server capacity for multimodal resources")
-    parser.add_argument("--cache_reserved_ratio", type=float, default=0.5,
-                        help="cache server reserved capacity ratio after clear")
-    parser.add_argument("--return_all_prompt_logprobs", action="store_true",
-                        help="return all prompt tokens logprobs")
-    parser.add_argument("--long_truncation_mode", type=str, choices=[None, 'head', 'center'], default=None,
-                        help="""use to select the handle way when input token len > max_req_input_len.
+    parser.add_argument(
+        "--splitfuse_mode", action="store_true", help="use splitfuse mode"
+    )
+    parser.add_argument(
+        "--splitfuse_block_size", type=int, default=256, help="splitfuse block size"
+    )
+    parser.add_argument(
+        "--prompt_cache_strs",
+        type=str,
+        default=[],
+        nargs="+",
+        help="""prompt cache strs""",
+    )
+    parser.add_argument(
+        "--cache_capacity",
+        type=int,
+        default=200,
+        help="cache server capacity for multimodal resources",
+    )
+    parser.add_argument(
+        "--cache_reserved_ratio",
+        type=float,
+        default=0.5,
+        help="cache server reserved capacity ratio after clear",
+    )
+    parser.add_argument(
+        "--return_all_prompt_logprobs",
+        action="store_true",
+        help="return all prompt tokens logprobs",
+    )
+    parser.add_argument(
+        "--long_truncation_mode",
+        type=str,
+        choices=[None, "head", "center"],
+        default=None,
+        help="""use to select the handle way when input token len > max_req_input_len.
                         None : raise Exception
                         head : remove some head tokens to make input token len <= max_req_input_len
-                        center : remove some tokens in center loc to make input token len <= max_req_input_len""")
+                        center : remove some tokens in center loc to make input token len <= max_req_input_len""",
+    )
 
     args = parser.parse_args()
 
@@ -359,8 +450,14 @@ if __name__ == "__main__":
     can_use_ports = alloc_can_use_network_port(num=6 + args.tp)
 
     assert can_use_ports is not None, "Can not alloc enough free ports."
-    router_port, detokenization_port, httpserver_port, visual_port, cache_port, nccl_port = can_use_ports[
-        0:6]
+    (
+        router_port,
+        detokenization_port,
+        httpserver_port,
+        visual_port,
+        cache_port,
+        nccl_port,
+    ) = can_use_ports[0:6]
     args.nccl_port = nccl_port
     model_rpc_ports = can_use_ports[6:]
 
@@ -374,9 +471,13 @@ if __name__ == "__main__":
         enable_multimodal=False,
     )
 
-    start_submodule_processes(start_funcs=[start_router_process, start_detokenization_process],
-                              start_args=[(args, router_port, detokenization_port, model_rpc_ports),
-                                          (args, detokenization_port, httpserver_port)])
+    start_submodule_processes(
+        start_funcs=[start_router_process, start_detokenization_process],
+        start_args=[
+            (args, router_port, detokenization_port, model_rpc_ports),
+            (args, detokenization_port, httpserver_port),
+        ],
+    )
     worker = LightLLMWorker(
         args.controller_address,
         args.worker_address,

--- a/fastchat/serve/lightllm_worker.py
+++ b/fastchat/serve/lightllm_worker.py
@@ -134,6 +134,8 @@ class LightLLMWorker(BaseModelWorker):
 
         completion_tokens = 0
         text_outputs = ""
+        cumulative_logprob = 0.0
+
         async for request_output, metadata, finish_status in results_generator:
             text_outputs += request_output
             completion_tokens += 1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Adapt from https://github.com/ModelTC/lightllm/blob/30304096f6f1ec050e2fac34b1795c9ee086ba63/lightllm/server/api_server.py

An alternative to vllm integration, in my own reproduce of https://github.com/ModelTC/lightllm/tree/30304096f6f1ec050e2fac34b1795c9ee086ba63#performance . In single A800 80g, LightLLM is about 20% faster than vllm (10.88 qps vs 8.95 qps). And I modify the benchmark script, directly benchmark the fastchat worker on two A800 80g, LightLLM is still faster than vllm (13.99 qps vs 12.42 qps).

However, the performance above is measure by `api_server.py` barely. After using the openai_api_server.py from fastchat. I  observe some performance drop. Maybe due to the configuration.

~~It has some limitations, such as the lightllm does not provide the finish_reason. Awaiting https://github.com/ModelTC/lightllm/pull/285~~ Done

Moreover, in the original implement of vllm integration, if we use `/worker_generate` and abort the connection, the vllm will not abort the engine, and it will continue try to generate the full content. In this pr, it shall be aware the disconnection of client and abort generation.

But if we use `openai_api_server.py`, even the client close the connection, due to that `openai_api_server.py` will not be notified about it, it will not close the connection between  `openai_api_server.py` and model worker.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
