### PR TITLE
fix baichuan:apply_prompt_template call args error

### DIFF
--- a/fastchat/train/train_baichuan.py
+++ b/fastchat/train/train_baichuan.py
@@ -159,7 +159,7 @@ def preprocess(sources, tokenizer: transformers.PreTrainedTokenizer, **kwargs) -
     else:  # If the data volume is large, use multithreading for processing
         with Pool() as p:
             conversations, conv = p.apply_async(
-                apply_prompt_template, (sources, tokenizer, systems)
+                apply_prompt_template, (sources, systems)
             ).get()
             input_ids, targets = p.apply_async(
                 tokenize_conversations, (conversations, tokenizer)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
According to [function signature](https://github.com/lm-sys/FastChat/blob/6ff8505ec80fc4b04d668f65d229f4f58bc449e0/fastchat/train/train_baichuan.py#L80),

`
def apply_prompt_template(sources, systems=None):
`

this [function call: train_baichuan.py](https://github.com/lm-sys/FastChat/blob/6ff8505ec80fc4b04d668f65d229f4f58bc449e0/fastchat/train/train_baichuan.py#L162C17-L162C69) gives incorrect args
`
 apply_prompt_template, (sources, tokenizer, systems)
`
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
