### PR TITLE
fix: change order of SEQUENCE_LENGTH_KEYS

### DIFF
--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -313,9 +313,9 @@ def is_sentence_complete(output: str):
 # NOTE: The ordering here is important.  Some models have two of these and we
 # have a preference for which value gets used.
 SEQUENCE_LENGTH_KEYS = [
+    "max_position_embeddings",
     "max_sequence_length",
     "seq_length",
-    "max_position_embeddings",
     "max_seq_len",
     "model_max_length",
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Because the order of SEQUENCE_LENGTH_KEYS matters, and `max_position_embeddings` becomes widely used in most of the causal llm configs([Llama-2-7b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/blob/main/config.json), [phi-2](https://huggingface.co/microsoft/phi-2/blob/main/config.json), [mistral-8x7b](https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1/blob/main/config.json), etc..), I suggest we put it on top of `SEQUENCE_LENGTH_KEYS`

We encounter some unexpected issues from current order. For instance:
1. [Qwen-14B-Chat's config](https://huggingface.co/Qwen/Qwen-14B-Chat/blob/main/config.json) contains both `"seq_length": 2048` and `"max_position_embeddings": 8192`. Current order loads `seq_length` first, but `max_position_embeddings` is what we actually need.
2. [longchat-7b-16k's config](https://huggingface.co/lmsys/longchat-7b-16k/blob/main/config.json) contains `"max_sequence_length": 16384,  "max_position_embeddings": 2048` and `"rope_scaling": {"factor": 8.0, "type": "linear"}`. Current order loads `max_sequence_length` first and multiply with `rope_scaling` to 16384 * 8, which is not what we expected.
 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
