### PR TITLE
fix specify local path issue use model from www.modelscope.cn

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,13 @@ python3 -m fastchat.serve.gradio_web_server_multi
 ```
 - The default model worker based on huggingface/transformers has great compatibility but can be slow. If you want high-throughput batched serving, you can try [vLLM integration](docs/vllm_integration.md).
 - If you want to host it on your own UI or third party UI, see [Third Party UI](docs/third_party_ui.md).
- 
+
+## Use models from modelscope
+For Chinese users, you can use models from www.modelscope.cn via specify the following environment variables.
+```bash
+export FASTCHAT_USE_MODELSCOPE=True
+```
+
 ## API
 ### OpenAI-Compatible RESTful APIs & SDK
 FastChat provides OpenAI-compatible APIs for its supported models, so you can use FastChat as a local drop-in replacement for OpenAI APIs.

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -336,8 +336,8 @@ def load_model(
         # lazy import so that modelscope is not required for normal use.
         try:
             from modelscope.hub.snapshot_download import snapshot_download
-
-            model_path = snapshot_download(model_id=model_path, revision=revision)
+            if not os.path.exists(model_path):                
+                model_path = snapshot_download(model_id=model_path, revision=revision)
         except ImportError as e:
             warnings.warn(
                 "Use model from www.modelscope.cn need pip install modelscope"

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -336,7 +336,8 @@ def load_model(
         # lazy import so that modelscope is not required for normal use.
         try:
             from modelscope.hub.snapshot_download import snapshot_download
-            if not os.path.exists(model_path):                
+
+            if not os.path.exists(model_path):
                 model_path = snapshot_download(model_id=model_path, revision=revision)
         except ImportError as e:
             warnings.warn(


### PR DESCRIPTION
## Why are these changes needed?
Fix issue when --model-path is not model id but a path from www.modelscope.cn.
Add doc how to use models from www.modelscope.cn

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
