### PR TITLE
Remove duplicate API endpoint

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -375,7 +375,6 @@ async def show_available_models():
     return ModelList(data=model_cards)
 
 
-@app.post("/v1chat/completions", dependencies=[Depends(check_api_key)])
 @app.post("/v1/chat/completions", dependencies=[Depends(check_api_key)])
 async def create_chat_completion(request: ChatCompletionRequest):
     """Creates a completion for the chat message"""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When you open the api endpoint documentation (server:8000/docs), you get an invalid `v1chat` endpoint

<!-- Please give a short summary of the change and the problem this solves. -->
This one clears it up.

## Related issue number (if applicable)

Closes #2948

## Checks

- [V] I've run `format.sh` to lint the changes in this PR.
- [V] I've included any doc changes needed.
- [V] I've made sure the relevant tests are passing (if applicable).
