### PR TITLE
feat: train with template

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -53,7 +53,6 @@ class Conversation:
     sep_style: SeparatorStyle = SeparatorStyle.ADD_COLON_SINGLE
     sep: str = "\n"
     sep2: str = None
-    prefix_token = ""
     # Stop criteria (the default one is EOS token)
     stop_str: Union[str, List[str]] = None
     # Stops generation if meeting any token in this list
@@ -63,7 +62,6 @@ class Conversation:
         """Get the prompt for generation."""
         system_prompt = self.system_template.format(system_message=self.system_message)
         if self.sep_style == SeparatorStyle.ADD_COLON_SINGLE:
-            self.prefix_token = self.roles[1] + ": "
             ret = system_prompt + self.sep
             for role, message in self.messages:
                 if message:
@@ -72,7 +70,6 @@ class Conversation:
                     ret += role + ":"
             return ret
         elif self.sep_style == SeparatorStyle.ADD_COLON_TWO:
-            self.prefix_token = self.roles[1] + ": "
             seps = [self.sep, self.sep2]
             ret = system_prompt + seps[0]
             for i, (role, message) in enumerate(self.messages):
@@ -82,9 +79,6 @@ class Conversation:
                     ret += role + ":"
             return ret
         elif self.sep_style == SeparatorStyle.ADD_COLON_SPACE_SINGLE:
-            self.prefix_token = self.roles[1] + ": "
-            if self.sep2 is None:
-                self.sep2 = self.roles[0] + ": "
             ret = system_prompt + self.sep
             for role, message in self.messages:
                 if message:
@@ -131,7 +125,6 @@ class Conversation:
                     ret += role + ":"
             return ret
         elif self.sep_style == SeparatorStyle.LLAMA2:
-            self.prefix_token = self.roles[1] + " "
             seps = [self.sep, self.sep2]
             if self.system_message:
                 ret = system_prompt
@@ -166,9 +159,6 @@ class Conversation:
                     ret += f"{role}："
             return ret
         elif self.sep_style == SeparatorStyle.CHATML:
-            self.prefix_token = self.roles[1] + "\n"
-            if self.sep2 is None:
-                self.sep2 = self.sep
             ret = "" if system_prompt == "" else system_prompt + self.sep + "\n"
             for role, message in self.messages:
                 if message:
@@ -310,7 +300,6 @@ class Conversation:
             sep_style=self.sep_style,
             sep=self.sep,
             sep2=self.sep2,
-            prefix_token=self.prefix_token,
             stop_str=self.stop_str,
             stop_token_ids=self.stop_token_ids,
         )

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -53,6 +53,7 @@ class Conversation:
     sep_style: SeparatorStyle = SeparatorStyle.ADD_COLON_SINGLE
     sep: str = "\n"
     sep2: str = None
+    prefix_token = ""
     # Stop criteria (the default one is EOS token)
     stop_str: Union[str, List[str]] = None
     # Stops generation if meeting any token in this list
@@ -62,6 +63,7 @@ class Conversation:
         """Get the prompt for generation."""
         system_prompt = self.system_template.format(system_message=self.system_message)
         if self.sep_style == SeparatorStyle.ADD_COLON_SINGLE:
+            self.prefix_token = self.roles[1] + ": "
             ret = system_prompt + self.sep
             for role, message in self.messages:
                 if message:
@@ -70,6 +72,7 @@ class Conversation:
                     ret += role + ":"
             return ret
         elif self.sep_style == SeparatorStyle.ADD_COLON_TWO:
+            self.prefix_token = self.roles[1] + ": "
             seps = [self.sep, self.sep2]
             ret = system_prompt + seps[0]
             for i, (role, message) in enumerate(self.messages):
@@ -79,6 +82,9 @@ class Conversation:
                     ret += role + ":"
             return ret
         elif self.sep_style == SeparatorStyle.ADD_COLON_SPACE_SINGLE:
+            self.prefix_token = self.roles[1] + ": "
+            if self.sep2 is None:
+                self.sep2 = self.roles[0] + ": "
             ret = system_prompt + self.sep
             for role, message in self.messages:
                 if message:
@@ -125,6 +131,7 @@ class Conversation:
                     ret += role + ":"
             return ret
         elif self.sep_style == SeparatorStyle.LLAMA2:
+            self.prefix_token = self.roles[1] + " "
             seps = [self.sep, self.sep2]
             if self.system_message:
                 ret = system_prompt
@@ -159,6 +166,9 @@ class Conversation:
                     ret += f"{role}："
             return ret
         elif self.sep_style == SeparatorStyle.CHATML:
+            self.prefix_token = self.roles[1] + "\n"
+            if self.sep2 is None:
+                self.sep2 = self.sep
             ret = "" if system_prompt == "" else system_prompt + self.sep + "\n"
             for role, message in self.messages:
                 if message:
@@ -300,6 +310,7 @@ class Conversation:
             sep_style=self.sep_style,
             sep=self.sep,
             sep2=self.sep2,
+            prefix_token=self.prefix_token,
             stop_str=self.stop_str,
             stop_token_ids=self.stop_token_ids,
         )

--- a/fastchat/train/train_with_template.py
+++ b/fastchat/train/train_with_template.py
@@ -1,0 +1,333 @@
+# This code is based on tatsu-lab/stanford_alpaca. Below is the original copyright:
+#
+#    Copyright 2023 Rohan Taori, Ishaan Gulrajani, Tianyi Zhang, Yann Dubois, Xuechen Li
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from dataclasses import dataclass, field
+import json
+import math
+import jsonlines
+import pathlib
+from multiprocessing import Pool
+from typing import Dict, Optional, Sequence
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+import transformers
+from transformers import Trainer
+from transformers.trainer_pt_utils import LabelSmoother
+
+from fastchat.conversation import SeparatorStyle
+from fastchat.model.model_adapter import get_conversation_template
+
+IGNORE_TOKEN_ID = LabelSmoother.ignore_index
+
+
+@dataclass
+class ModelArguments:
+    model_name_or_path: Optional[str] = field(default="facebook/opt-125m")
+
+
+@dataclass
+class DataArguments:
+    data_path: str = field(
+        default=None, metadata={"help": "Path to the training data."}
+    )
+    lazy_preprocess: bool = False
+
+
+@dataclass
+class TrainingArguments(transformers.TrainingArguments):
+    cache_dir: Optional[str] = field(default=None)
+    optim: str = field(default="adamw_torch")
+    model_max_length: int = field(
+        default=512,
+        metadata={
+            "help": "Maximum sequence length. Sequences will be right padded (and possibly truncated)."
+        },
+    )
+
+
+local_rank = None
+
+
+def rank0_print(*args):
+    if local_rank == 0:
+        print(*args)
+
+
+def safe_save_model_for_hf_trainer(trainer: transformers.Trainer, output_dir: str):
+    """Collects the state dict and dump to disk."""
+    state_dict = trainer.model.state_dict()
+    if trainer.args.should_save:
+        cpu_state_dict = {key: value.cpu() for key, value in state_dict.items()}
+        del state_dict
+        trainer._save(output_dir, state_dict=cpu_state_dict)  # noqa
+
+
+def apply_prompt_template(sources, systems=None):
+    conv = get_conversation_template("vicuna")
+    roles = {"human": conv.roles[0], "gpt": conv.roles[1]}
+    conversations = []
+    for i, source in enumerate(sources):
+        if roles[source[0]["from"]] != conv.roles[0]:
+            source = source[1:]
+
+        conv.messages = []
+        for j, sentence in enumerate(source):
+            role = roles[sentence["from"]]
+            assert role == conv.roles[j % 2], f"{i}"
+            conv.append_message(role, sentence["value"])
+        if systems and systems[i]:
+            conv.set_system_message(systems[i])
+        prompt = conv.get_prompt()
+        conversations.append(prompt)
+    return conversations, conv
+
+
+def tokenize_conversations(conversations, tokenizer):
+    input_ids = tokenizer(
+        conversations,
+        return_tensors="pt",
+        padding="max_length",
+        max_length=tokenizer.model_max_length,
+        truncation=True,
+    ).input_ids
+    targets = input_ids.clone()
+    return input_ids, targets
+
+
+def mask_targets(conversations, targets, tokenizer, conv):
+    sep = conv.sep + conv.roles[1] + ": "
+    for conversation, target in zip(conversations, targets):
+        total_len = int(target.ne(tokenizer.pad_token_id).sum())
+
+        turns = conversation.split(conv.sep2)
+        cur_len = 0
+        target[:cur_len] = IGNORE_TOKEN_ID
+        for i, turn in enumerate(turns):
+            if turn == "":
+                break
+            turn_len = len(tokenizer(turn + conv.sep2).input_ids)
+
+            parts = turn.split(sep)
+            if len(parts) != 2:
+                break
+            parts[0] += sep
+            instruction_len = len(tokenizer(parts[0]).input_ids) - 1
+
+            target[cur_len : cur_len + instruction_len] = IGNORE_TOKEN_ID
+            cur_len += turn_len
+
+        target[cur_len:] = IGNORE_TOKEN_ID
+
+        if False:  # Inspect and check the correctness of masking
+            z = target.clone()
+            z = torch.where(z == IGNORE_TOKEN_ID, tokenizer.unk_token_id, z)
+            rank0_print(tokenizer.decode(z))
+
+        if cur_len < tokenizer.model_max_length:
+            if cur_len != total_len:
+                target[:] = IGNORE_TOKEN_ID
+                rank0_print(
+                    f"WARNING: tokenization mismatch: {cur_len} vs. {total_len}."
+                    f" (ignored)"
+                )
+    return targets
+
+
+def preprocess(sources, tokenizer: transformers.PreTrainedTokenizer, **kwargs) -> Dict:
+    systems = None if not kwargs else kwargs.get("systems", None)
+
+    # If the data volume is small, process it directly in the main thread
+    if len(sources) <= 1000:
+        conversations, conv = apply_prompt_template(sources, systems)
+        input_ids, targets = tokenize_conversations(conversations, tokenizer)
+        targets = mask_targets(conversations, targets, tokenizer, conv)
+    else:  # If the data volume is large, use multithreading for processing
+        with Pool() as p:
+            conversations, conv = p.apply_async(
+                apply_prompt_template, (sources, systems)
+            ).get()
+            input_ids, targets = p.apply_async(
+                tokenize_conversations, (conversations, tokenizer)
+            ).get()
+            targets = p.apply_async(
+                mask_targets, (conversations, targets, tokenizer, conv)
+            ).get()
+            p.close()
+            p.join()
+
+    return dict(
+        input_ids=input_ids,
+        labels=targets,
+        attention_mask=input_ids.ne(tokenizer.pad_token_id),
+    )
+
+
+class SupervisedDataset(Dataset):
+    """Dataset for supervised fine-tuning."""
+
+    def __init__(self, raw_data, tokenizer: transformers.PreTrainedTokenizer):
+        super(SupervisedDataset, self).__init__()
+
+        rank0_print("Formatting inputs...")
+        systems = [example.get("system", "") for example in raw_data]
+        sources = [example["conversations"] for example in raw_data]
+
+        data_dict = preprocess(sources, tokenizer, systems=systems)
+
+        self.input_ids = data_dict["input_ids"]
+        self.labels = data_dict["labels"]
+        self.attention_mask = data_dict["attention_mask"]
+
+    def __len__(self):
+        return len(self.input_ids)
+
+    def __getitem__(self, i) -> Dict[str, torch.Tensor]:
+        return dict(
+            input_ids=self.input_ids[i],
+            labels=self.labels[i],
+            attention_mask=self.attention_mask[i],
+        )
+
+
+class LazySupervisedDataset(Dataset):
+    """Dataset for supervised fine-tuning."""
+
+    def __init__(self, raw_data, tokenizer: transformers.PreTrainedTokenizer):
+        super(LazySupervisedDataset, self).__init__()
+        self.tokenizer = tokenizer
+
+        rank0_print("Formatting inputs...Skip in lazy mode")
+        self.raw_data = raw_data
+        self.cached_data_dict = {}
+
+    def __len__(self):
+        return len(self.raw_data)
+
+    def __getitem__(self, i) -> Dict[str, torch.Tensor]:
+        if i in self.cached_data_dict:
+            return self.cached_data_dict[i]
+
+        ret = preprocess(
+            [self.raw_data[i]["conversations"]],
+            self.tokenizer,
+            systems=[self.raw_data[i].get("system", "")],
+        )
+        ret = dict(
+            input_ids=ret["input_ids"][0],
+            labels=ret["labels"][0],
+            attention_mask=ret["attention_mask"][0],
+        )
+        self.cached_data_dict[i] = ret
+
+        return ret
+
+
+def make_supervised_data_module(
+    tokenizer: transformers.PreTrainedTokenizer, data_args, train_ratio=0.98
+) -> Dict:
+    """Make dataset and collator for supervised fine-tuning."""
+    train_ratio = min(train_ratio, 1.0)
+    dataset_cls = (
+        LazySupervisedDataset if data_args.lazy_preprocess else SupervisedDataset
+    )
+    rank0_print("Loading data...")
+    data_path = data_args.data_path
+    if data_path.endswith(".json"):
+        raw_data = json.load(open(data_path, "r"))
+    elif data_path.endswith(".jsonl"):
+        with jsonlines.open(data_path, mode="r") as reader:
+            raw_data = [item for item in reader]
+
+    # Split train/test
+    np.random.seed(0)
+    perm = np.random.permutation(len(raw_data))
+    split = int(len(perm) * train_ratio)
+    train_indices = perm[:split]
+    if train_ratio < 1:
+        eval_indices = perm[split:]
+    else:
+        # if train_ratio==1, we use 5% of data as eval data, make sure trainer will not throw error when eval data is empty
+        eval_indices = perm[-int(len(perm) * 0.05) :]
+    train_raw_data = [raw_data[i] for i in train_indices]
+    eval_raw_data = [raw_data[i] for i in eval_indices]
+    rank0_print(f"#train {len(train_raw_data)}, #eval {len(eval_raw_data)}")
+
+    train_dataset = dataset_cls(train_raw_data, tokenizer=tokenizer)
+    eval_dataset = dataset_cls(eval_raw_data, tokenizer=tokenizer)
+    return dict(train_dataset=train_dataset, eval_dataset=eval_dataset)
+
+
+def train():
+    global local_rank
+
+    parser = transformers.HfArgumentParser(
+        (ModelArguments, DataArguments, TrainingArguments)
+    )
+    model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+    local_rank = training_args.local_rank
+    config = transformers.AutoConfig.from_pretrained(
+        model_args.model_name_or_path,
+        trust_remote_code=True,
+        cache_dir=training_args.cache_dir,
+    )
+    # Set RoPE scaling factor
+    orig_ctx_len = getattr(config, "max_position_embeddings", None)
+    if orig_ctx_len and training_args.model_max_length > orig_ctx_len:
+        scaling_factor = float(math.ceil(training_args.model_max_length / orig_ctx_len))
+        config.rope_scaling = {"type": "linear", "factor": scaling_factor}
+    config.use_cache = False
+    model = transformers.AutoModelForCausalLM.from_pretrained(
+        model_args.model_name_or_path,
+        config=config,
+        trust_remote_code=True,
+        cache_dir=training_args.cache_dir,
+    )
+    # Tie the weights
+    model.tie_weights()
+
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        model_args.model_name_or_path,
+        config=config,
+        trust_remote_code=True,
+        cache_dir=training_args.cache_dir,
+        model_max_length=training_args.model_max_length,
+        padding_side="right",
+        use_fast=False,
+    )
+    # NOTE: if the token_id exceed the vocab_size will cause failing in training process! we need add special config and resize the embedding size!
+    tokenizer.pad_token = tokenizer.unk_token
+    print(f"tokens len: {len(tokenizer)}")
+    model.resize_token_embeddings(len(tokenizer))
+
+    data_module = make_supervised_data_module(
+        tokenizer=tokenizer, train_ratio=0.98, data_args=data_args
+    )
+    trainer = Trainer(
+        model=model, tokenizer=tokenizer, args=training_args, **data_module
+    )
+
+    if list(pathlib.Path(training_args.output_dir).glob("checkpoint-*")):
+        trainer.train(resume_from_checkpoint=True)
+    else:
+        trainer.train()
+    trainer.save_state()
+    safe_save_model_for_hf_trainer(trainer=trainer, output_dir=training_args.output_dir)
+
+
+if __name__ == "__main__":
+    train()

--- a/fastchat/train/train_with_template.py
+++ b/fastchat/train/train_with_template.py
@@ -77,8 +77,8 @@ def safe_save_model_for_hf_trainer(trainer: transformers.Trainer, output_dir: st
         trainer._save(output_dir, state_dict=cpu_state_dict)  # noqa
 
 
-def apply_prompt_template(sources, systems=None):
-    conv = get_conversation_template("vicuna")
+def apply_prompt_template(sources, template_id, systems=None):
+    conv = get_conversation_template(template_id)
     roles = {"human": conv.roles[0], "gpt": conv.roles[1]}
     conversations = []
     for i, source in enumerate(sources):
@@ -110,23 +110,35 @@ def tokenize_conversations(conversations, tokenizer):
 
 
 def mask_targets(conversations, targets, tokenizer, conv):
-    sep = conv.sep + conv.roles[1] + ": "
     for conversation, target in zip(conversations, targets):
         total_len = int(target.ne(tokenizer.pad_token_id).sum())
+        if tokenizer.eos_token is None:
+            cur_len = 0
+        elif tokenizer.eos_token is not None and target[0] != tokenizer.bos_token_id:
+            cur_len = 0
+        elif tokenizer.eos_token is not None and target[0] == tokenizer.bos_token_id:
+            cur_len = 1
 
-        turns = conversation.split(conv.sep2)
-        cur_len = 0
         target[:cur_len] = IGNORE_TOKEN_ID
+        turns = conversation.split(conv.sep2)
         for i, turn in enumerate(turns):
             if turn == "":
                 break
-            turn_len = len(tokenizer(turn + conv.sep2).input_ids)
 
-            parts = turn.split(sep)
-            if len(parts) != 2:
-                break
-            parts[0] += sep
-            instruction_len = len(tokenizer(parts[0]).input_ids) - 1
+            if i != 0:
+                turn = conv.sep2 + turn
+
+            turn_len = len(tokenizer(turn).input_ids)
+
+            if conv.prefix_token in turn:
+                parts = turn.rsplit(conv.prefix_token)
+                parts[0] += conv.prefix_token
+            else:
+                parts = [turn]
+
+            instruction_len = len(
+                tokenizer(parts[0], add_special_tokens=False).input_ids
+            )
 
             target[cur_len : cur_len + instruction_len] = IGNORE_TOKEN_ID
             cur_len += turn_len
@@ -148,18 +160,20 @@ def mask_targets(conversations, targets, tokenizer, conv):
     return targets
 
 
-def preprocess(sources, tokenizer: transformers.PreTrainedTokenizer, **kwargs) -> Dict:
+def preprocess(
+    sources, tokenizer: transformers.PreTrainedTokenizer, template_id, **kwargs
+) -> Dict:
     systems = None if not kwargs else kwargs.get("systems", None)
 
     # If the data volume is small, process it directly in the main thread
     if len(sources) <= 1000:
-        conversations, conv = apply_prompt_template(sources, systems)
+        conversations, conv = apply_prompt_template(sources, template_id, systems)
         input_ids, targets = tokenize_conversations(conversations, tokenizer)
         targets = mask_targets(conversations, targets, tokenizer, conv)
     else:  # If the data volume is large, use multithreading for processing
         with Pool() as p:
             conversations, conv = p.apply_async(
-                apply_prompt_template, (sources, systems)
+                apply_prompt_template, (sources, template_id, systems)
             ).get()
             input_ids, targets = p.apply_async(
                 tokenize_conversations, (conversations, tokenizer)
@@ -180,14 +194,16 @@ def preprocess(sources, tokenizer: transformers.PreTrainedTokenizer, **kwargs) -
 class SupervisedDataset(Dataset):
     """Dataset for supervised fine-tuning."""
 
-    def __init__(self, raw_data, tokenizer: transformers.PreTrainedTokenizer):
+    def __init__(
+        self, raw_data, tokenizer: transformers.PreTrainedTokenizer, template_id
+    ):
         super(SupervisedDataset, self).__init__()
 
         rank0_print("Formatting inputs...")
         systems = [example.get("system", "") for example in raw_data]
         sources = [example["conversations"] for example in raw_data]
 
-        data_dict = preprocess(sources, tokenizer, systems=systems)
+        data_dict = preprocess(sources, tokenizer, template_id, systems=systems)
 
         self.input_ids = data_dict["input_ids"]
         self.labels = data_dict["labels"]
@@ -207,9 +223,12 @@ class SupervisedDataset(Dataset):
 class LazySupervisedDataset(Dataset):
     """Dataset for supervised fine-tuning."""
 
-    def __init__(self, raw_data, tokenizer: transformers.PreTrainedTokenizer):
+    def __init__(
+        self, raw_data, tokenizer: transformers.PreTrainedTokenizer, template_id
+    ):
         super(LazySupervisedDataset, self).__init__()
         self.tokenizer = tokenizer
+        self.template_id = template_id
 
         rank0_print("Formatting inputs...Skip in lazy mode")
         self.raw_data = raw_data
@@ -225,6 +244,7 @@ class LazySupervisedDataset(Dataset):
         ret = preprocess(
             [self.raw_data[i]["conversations"]],
             self.tokenizer,
+            self.template_id,
             systems=[self.raw_data[i].get("system", "")],
         )
         ret = dict(
@@ -238,7 +258,10 @@ class LazySupervisedDataset(Dataset):
 
 
 def make_supervised_data_module(
-    tokenizer: transformers.PreTrainedTokenizer, data_args, train_ratio=0.98
+    tokenizer: transformers.PreTrainedTokenizer,
+    data_args,
+    template_id,
+    train_ratio=0.98,
 ) -> Dict:
     """Make dataset and collator for supervised fine-tuning."""
     train_ratio = min(train_ratio, 1.0)
@@ -267,8 +290,12 @@ def make_supervised_data_module(
     eval_raw_data = [raw_data[i] for i in eval_indices]
     rank0_print(f"#train {len(train_raw_data)}, #eval {len(eval_raw_data)}")
 
-    train_dataset = dataset_cls(train_raw_data, tokenizer=tokenizer)
-    eval_dataset = dataset_cls(eval_raw_data, tokenizer=tokenizer)
+    train_dataset = dataset_cls(
+        train_raw_data, tokenizer=tokenizer, template_id=template_id
+    )
+    eval_dataset = dataset_cls(
+        eval_raw_data, tokenizer=tokenizer, template_id=template_id
+    )
     return dict(train_dataset=train_dataset, eval_dataset=eval_dataset)
 
 
@@ -314,8 +341,12 @@ def train():
     print(f"tokens len: {len(tokenizer)}")
     model.resize_token_embeddings(len(tokenizer))
 
+    template_id = model_args.model_name_or_path
     data_module = make_supervised_data_module(
-        tokenizer=tokenizer, train_ratio=0.98, data_args=data_args
+        tokenizer=tokenizer,
+        template_id=template_id,
+        train_ratio=0.98,
+        data_args=data_args,
     )
     trainer = Trainer(
         model=model, tokenizer=tokenizer, args=training_args, **data_module


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When training chat models, the default `train.py` use the `Vicuna` template , but there are more and more new models releasing with different templates. 

I am trying to adapt the current `conversation` structure with minimal changes to support most of the most popular models' chats template in training.

There is a more deeper wip solutions in transformers repo https://github.com/huggingface/transformers/pull/28473 but not sure how long it will take.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
