### PR TITLE
fix content maybe a str

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -450,6 +450,9 @@ async def create_chat_completion(request: ChatCompletionRequest):
         return create_error_response(ErrorCode.INTERNAL_ERROR, str(e))
     usage = UsageInfo()
     for i, content in enumerate(all_tasks):
+        if isinstance(content, str):
+            content = json.loads(content)
+
         if content["error_code"] != 0:
             return create_error_response(content["error_code"], content["text"])
         choices.append(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix type error raised in fastchat/serve/openai_api_server.py.
The following block may return a string when the `response.status` is not 200.

https://github.com/lm-sys/FastChat/blob/6d4ca23782d4deec0361dc4bee3a4fa9459164c4/fastchat/serve/openai_api_server.py#L72-L85

```python
File "FastChat/fastchat/serve/openai_api_server.py", line 453, in create_chat_completion
if content["error_code"] != 0:
TypeError: string indices must be integers
```
## Related issue number (if applicable)

- #2837

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
