### PR TITLE
fetch_remote needs to catch exception

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -71,18 +71,23 @@ fetch_timeout = aiohttp.ClientTimeout(total=3 * 3600)
 
 async def fetch_remote(url, pload=None, name=None):
     async with aiohttp.ClientSession(timeout=fetch_timeout) as session:
-        async with session.post(url, json=pload) as response:
-            chunks = []
-            if response.status != 200:
-                ret = {
-                    "text": f"{response.reason}",
-                    "error_code": ErrorCode.INTERNAL_ERROR,
-                }
-                return json.dumps(ret)
+        try:
+            async with session.post(url, json=pload) as response:
+                chunks = []
+                if response.status != 200:
+                    ret = {
+                        "text": f"{response.reason}",
+                        "error_code": ErrorCode.INTERNAL_ERROR,
+                    }
+                    return json.dumps(ret)
 
-            async for chunk, _ in response.content.iter_chunks():
-                chunks.append(chunk)
-        output = b"".join(chunks)
+                async for chunk, _ in response.content.iter_chunks():
+                    chunks.append(chunk)
+        except Exception as e:
+            ret = {"text": f"{e}", "error_code": ErrorCode.INTERNAL_ERROR}
+            return json.dumps(ret)
+        else:
+            output = b"".join(chunks)
 
     if name is not None:
         res = json.loads(output)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Many methods call the `fetch_remote` method in `openai_api_server.py`, but they don't handle exceptions that `fetch_remote`might throw.

For example:

```python
async def check_model(request) -> Optional[JSONResponse]:
    controller_address = app_settings.controller_address
    ret = None

    models = await fetch_remote(controller_address + "/list_models", None, "models")
    if request.model not in models:
        ret = create_error_response(
            ErrorCode.INVALID_MODEL,
            f"Only {'&&'.join(models)} allowed now, your model {request.model}",
        )
    return ret
```

`check_model` calls `fetch_remote` but the former does not handle the exception.

Here is a specified exception.

```python
 | ERROR | stderr |     return await dependant.call(**values)
 | ERROR | stderr |   File "~/codebases/FastChat/fastchat/serve/openai_api_server.py", line 382, in create_chat_completion
 | ERROR | stderr |     error_check_ret = await check_model(request)
 | ERROR | stderr |   File "~/codebases/FastChat/fastchat/serve/openai_api_server.py", line 145, in check_model
 | ERROR | stderr |     models = await fetch_remote(controller_address + "/list_models", None, "models")
 | ERROR | stderr |   File "~/codebases/FastChat/fastchat/serve/openai_api_server.py", line 74, in fetch_remote
 | ERROR | stderr |     async with session.post(url, json=pload) as response:
 | ERROR | stderr |   File "~/miniconda3/envs/fastchat/lib/python3.10/site-packages/aiohttp/client.py", line 1187, in __aenter__
 | ERROR | stderr |     self._resp = await self._coro
 | ERROR | stderr |   File "~/miniconda3/envs/fastchat/lib/python3.10/site-packages/aiohttp/client.py", line 601, in _request
 | ERROR | stderr |     await resp.start(conn)
 | ERROR | stderr |   File "~/miniconda3/envs/fastchat/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 965, in start
 | ERROR | stderr |     message, payload = await protocol.read()  # type: ignore[union-attr]
 | ERROR | stderr |   File "~/miniconda3/envs/fastchat/lib/python3.10/site-packages/aiohttp/streams.py", line 622, in read
 | ERROR | stderr |     await self._waiter
 | ERROR | stderr | aiohttp.client_exceptions.ClientOSError: [Errno 104] Connection reset by peer
```

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
