### PR TITLE
fix: tokenization mismatch when training with different templates

### DIFF
--- a/fastchat/train/train_with_template.py
+++ b/fastchat/train/train_with_template.py
@@ -132,9 +132,9 @@ def get_prompt_separator(conv):
 
     elif conv.sep_style == SeparatorStyle.CHATML:
         if conv.sep2 is None:
-            user_turn_separator = conv.sep
+            user_turn_separator = conv.sep + "\n"
         else:
-            user_turn_separator = conv.sep2
+            user_turn_separator = conv.sep2 + "\n"
 
         assistant_turn_separator = conv.roles[1] + "\n"
 
@@ -155,7 +155,9 @@ def mask_targets(conversations, targets, tokenizer, conv):
         user_turn_separator, assistant_turn_separator = get_prompt_separator(conv)
         turns = conversation.split(user_turn_separator)
         for i, turn in enumerate(turns):
-            if turn == "":
+            if (
+                i < len(turns) - 1 and turn == ""
+            ):  # Last turn is the user_turn_separator
                 break
 
             if i != 0:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
If input ends with the separator, current logic ignore the last separator , which cause the mismatch. The pr fix it.

Testing with below sample:
```
[
    [
      {
        "from": "human",
        "value": "What is up?"
      },
      {
        "from": "gpt",
        "value": "Hello! How can I help you today?"
      },
      {
        "from": "human",
        "value": "Who are you?"
      },
      {
        "from": "gpt",
        "value": "You can call me Vicuna, and I was trained by Large Model Systems Organization (LMSYS) researchers as a language model."
      },
      {
        "from": "human",
        "value": "Goodbye"
      },
      {
        "from": "gpt",
        "value": "Goodbye! If you have any more questions in the future, don't hesitate to ask."
      }
    ]
]
```

Use `template_id = "tinyllama"`as below:
```
59666 	 -100 <
59705 	 -100 |
3903 	 -100 user
46826 	 -100 |>
144 	 -100 

5697 	 -100 What
620 	 -100 is
828 	 -100 up
100 	 -100 ?
1359 	 -100 </
59575 	 -100 s
59644 	 -100 >
144 	 -100 

59666 	 -100 <
59705 	 -100 |
765 	 -100 ass
13611 	 -100 istant
46826 	 -100 |>
144 	 -100 

25102 	 25102 Hello
99 	 99 !
1742 	 1742 How
748 	 748 can
616 	 616 I
1314 	 1314 help
641 	 641 you
2272 	 2272 today
100 	 100 ?
1359 	 -100 </
59575 	 -100 s
59644 	 -100 >
144 	 -100 

59666 	 -100 <
59705 	 -100 |
3903 	 -100 user
46826 	 -100 |>
144 	 -100 

20061 	 -100 Who
678 	 -100 are
641 	 -100 you
100 	 -100 ?
1359 	 -100 </
59575 	 -100 s
59644 	 -100 >
144 	 -100 

59666 	 -100 <
59705 	 -100 |
765 	 -100 ass
13611 	 -100 istant
46826 	 -100 |>
144 	 -100 

3961 	 3961 You
748 	 748 can
1388 	 1388 call
795 	 795 me
38746 	 38746 Vic
14092 	 14092 una
97 	 97 ,
597 	 597 and
616 	 616 I
717 	 717 was
7325 	 7325 trained
737 	 737 by
21356 	 21356 Large
9627 	 9627 Model
15470 	 15470 Systems
22204 	 22204 Organization
662 	 662 (
59620 	 59620 L
5102 	 5102 MS
25595 	 25595 YS
59604 	 59604 )
9412 	 9412 researchers
659 	 659 as
562 	 562 a
3968 	 3968 language
1396 	 1396 model
98 	 98 .
1359 	 -100 </
59575 	 -100 s
59644 	 -100 >
144 	 -100 

59666 	 -100 <
59705 	 -100 |
3903 	 -100 user
46826 	 -100 |>
144 	 -100 

18635 	 -100 Good
21410 	 -100 bye
1359 	 -100 </
59575 	 -100 s
59644 	 -100 >
144 	 -100 

59666 	 -100 <
59705 	 -100 |
765 	 -100 ass
13611 	 -100 istant
46826 	 -100 |>
144 	 -100 

18635 	 18635 Good
21410 	 21410 bye
99 	 99 !
1393 	 1393 If
641 	 641 you
726 	 726 have
916 	 916 any
863 	 863 more
3275 	 3275 questions
594 	 594 in
567 	 567 the
2653 	 2653 future
97 	 97 ,
1182 	 1182 don
59610 	 59610 '
59570 	 59570 t
27181 	 27181 hesitate
592 	 592 to
1866 	 1866 ask
98 	 98 .
1359 	 -100 </
59575 	 -100 s
59644 	 -100 >
144 	 -100 

0 	 -100 <unk>
0 	 -100 <unk>
0 	 -100 <unk>

```
## Related issue number (if applicable)
This pr fix https://github.com/lm-sys/FastChat/issues/2871  https://github.com/lm-sys/FastChat/issues/2992

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
