### PR TITLE
fix: inconsistent tokenization by llama tokenizer

### DIFF
--- a/fastchat/train/train_with_template.py
+++ b/fastchat/train/train_with_template.py
@@ -163,7 +163,7 @@ def mask_targets(conversations, targets, tokenizer, conv):
             if i != 0:
                 turn = user_turn_separator + turn
 
-            turn_len = len(tokenizer(turn).input_ids)
+            turn_len = len(tokenizer(turn, add_special_tokens=False).input_ids)
 
             if assistant_turn_separator in turn:
                 parts = turn.rsplit(assistant_turn_separator)

--- a/fastchat/train/train_with_template.py
+++ b/fastchat/train/train_with_template.py
@@ -373,6 +373,7 @@ def train():
     )
     # NOTE: if the token_id exceed the vocab_size will cause failing in training process! we need add special config and resize the embedding size!
     tokenizer.pad_token = tokenizer.unk_token
+    tokenizer.pad_token_id = tokenizer.unk_token_id
     print(f"tokens len: {len(tokenizer)}")
     model.resize_token_embeddings(len(tokenizer))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fix the mismatched tokenization by  llama tokenizer:

### Testing
inputs:
```json
[
    {
      "from": "system",
      "value": "You are an AI."
    },
    {
      "from": "human",
      "value": "What is up?"
    },
    {
      "from": "gpt",
      "value": "Hello! How can I help you today?"
    },
    {
      "from": "human",
      "value": "Who are you?"
    },
    {
      "from": "gpt",
      "value": "You can call me Vicuna, and I was trained by Large Model Systems Organization (LMSYS) researchers as a language model."
    },
    {
      "from": "human",
      "value": "Goodbye"
    },
    {
      "from": "gpt",
      "value": "Goodbye! If you have any more questions in the future, don't hesitate to ask."
    }
]
```

1. Llama 2 testing passed:
```
1 	 -100 	 <s>
529 	 -100 	 <
29989 	 -100 	 |
5205 	 -100 	 system
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

3492 	 -100 	 You
526 	 -100 	 are
385 	 -100 	 an
319 	 -100 	 A
29902 	 -100 	 I
29889 	 -100 	 .
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

29966 	 -100 	 <
29989 	 -100 	 |
1792 	 -100 	 user
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

5618 	 -100 	 What
338 	 -100 	 is
701 	 -100 	 up
29973 	 -100 	 ?
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

29966 	 -100 	 <
29989 	 -100 	 |
465 	 -100 	 ass
22137 	 -100 	 istant
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

10994 	 10994 	 Hello
29991 	 29991 	 !
1128 	 1128 	 How
508 	 508 	 can
306 	 306 	 I
1371 	 1371 	 help
366 	 366 	 you
9826 	 9826 	 today
29973 	 29973 	 ?
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

29966 	 -100 	 <
29989 	 -100 	 |
1792 	 -100 	 user
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

22110 	 -100 	 Who
526 	 -100 	 are
366 	 -100 	 you
29973 	 -100 	 ?
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

29966 	 -100 	 <
29989 	 -100 	 |
465 	 -100 	 ass
22137 	 -100 	 istant
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

3492 	 3492 	 You
508 	 508 	 can
1246 	 1246 	 call
592 	 592 	 me
13423 	 13423 	 Vic
4347 	 4347 	 una
29892 	 29892 	 ,
322 	 322 	 and
306 	 306 	 I
471 	 471 	 was
16370 	 16370 	 trained
491 	 491 	 by
8218 	 8218 	 Lar
479 	 479 	 ge
8125 	 8125 	 Model
23985 	 23985 	 Systems
9205 	 9205 	 Organ
2133 	 2133 	 ization
313 	 313 	 (
29931 	 29931 	 L
4345 	 4345 	 MS
21554 	 21554 	 YS
29897 	 29897 	 )
5925 	 5925 	 research
414 	 414 	 ers
408 	 408 	 as
263 	 263 	 a
4086 	 4086 	 language
1904 	 1904 	 model
29889 	 29889 	 .
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

29966 	 -100 	 <
29989 	 -100 	 |
1792 	 -100 	 user
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

18420 	 -100 	 Good
26966 	 -100 	 bye
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

29966 	 -100 	 <
29989 	 -100 	 |
465 	 -100 	 ass
22137 	 -100 	 istant
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

18420 	 18420 	 Good
26966 	 26966 	 bye
29991 	 29991 	 !
960 	 960 	 If
366 	 366 	 you
505 	 505 	 have
738 	 738 	 any
901 	 901 	 more
5155 	 5155 	 questions
297 	 297 	 in
278 	 278 	 the
5434 	 5434 	 future
29892 	 29892 	 ,
1016 	 1016 	 don
29915 	 29915 	 '
29873 	 29873 	 t
19066 	 19066 	 hes
10388 	 10388 	 itate
304 	 304 	 to
2244 	 2244 	 ask
29889 	 29889 	 .
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

0 	 -100 	 <unk>
```


2. Passed testing `TinyLlama-1.1B-Chat-v1.0/` tokenizer with `TinyLlama` template. And we need to set the `tokenizer.pad_token` to `tokenizer.unk_token` to avoid getting the wrong `total_len`.
```
1 	 -100 	 <s>
529 	 -100 	 <
29989 	 -100 	 |
5205 	 -100 	 system
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

3492 	 -100 	 You
526 	 -100 	 are
385 	 -100 	 an
319 	 -100 	 A
29902 	 -100 	 I
29889 	 -100 	 .
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

29966 	 -100 	 <
29989 	 -100 	 |
1792 	 -100 	 user
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

5618 	 -100 	 What
338 	 -100 	 is
701 	 -100 	 up
29973 	 -100 	 ?
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

29966 	 -100 	 <
29989 	 -100 	 |
465 	 -100 	 ass
22137 	 -100 	 istant
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

10994 	 10994 	 Hello
29991 	 29991 	 !
1128 	 1128 	 How
508 	 508 	 can
306 	 306 	 I
1371 	 1371 	 help
366 	 366 	 you
9826 	 9826 	 today
29973 	 29973 	 ?
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

29966 	 -100 	 <
29989 	 -100 	 |
1792 	 -100 	 user
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

22110 	 -100 	 Who
526 	 -100 	 are
366 	 -100 	 you
29973 	 -100 	 ?
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

29966 	 -100 	 <
29989 	 -100 	 |
465 	 -100 	 ass
22137 	 -100 	 istant
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

3492 	 3492 	 You
508 	 508 	 can
1246 	 1246 	 call
592 	 592 	 me
13423 	 13423 	 Vic
4347 	 4347 	 una
29892 	 29892 	 ,
322 	 322 	 and
306 	 306 	 I
471 	 471 	 was
16370 	 16370 	 trained
491 	 491 	 by
8218 	 8218 	 Lar
479 	 479 	 ge
8125 	 8125 	 Model
23985 	 23985 	 Systems
9205 	 9205 	 Organ
2133 	 2133 	 ization
313 	 313 	 (
29931 	 29931 	 L
4345 	 4345 	 MS
21554 	 21554 	 YS
29897 	 29897 	 )
5925 	 5925 	 research
414 	 414 	 ers
408 	 408 	 as
263 	 263 	 a
4086 	 4086 	 language
1904 	 1904 	 model
29889 	 29889 	 .
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

29966 	 -100 	 <
29989 	 -100 	 |
1792 	 -100 	 user
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

18420 	 -100 	 Good
26966 	 -100 	 bye
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

29966 	 -100 	 <
29989 	 -100 	 |
465 	 -100 	 ass
22137 	 -100 	 istant
29989 	 -100 	 |
29958 	 -100 	 >
13 	 -100 	 

18420 	 18420 	 Good
26966 	 26966 	 bye
29991 	 29991 	 !
960 	 960 	 If
366 	 366 	 you
505 	 505 	 have
738 	 738 	 any
901 	 901 	 more
5155 	 5155 	 questions
297 	 297 	 in
278 	 278 	 the
5434 	 5434 	 future
29892 	 29892 	 ,
1016 	 1016 	 don
29915 	 29915 	 '
29873 	 29873 	 t
19066 	 19066 	 hes
10388 	 10388 	 itate
304 	 304 	 to
2244 	 2244 	 ask
29889 	 29889 	 .
2 	 -100 	 </s>
29871 	 -100 	 
13 	 -100 	 

0 	 -100 	 <unk>
```



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)
This pr fix https://github.com/lm-sys/FastChat/issues/2871 https://github.com/lm-sys/FastChat/issues/2992
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
