### PR TITLE
Update conversation.py to fix “When the type of context in the incoming messages is text, an error”

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -164,8 +164,11 @@ class Conversation:
         elif self.sep_style == SeparatorStyle.CHATML:
             ret = "" if system_prompt == "" else system_prompt + self.sep + "\n"
             for role, message in self.messages:
-                if message:
-                    ret += role + "\n" + message + self.sep + "\n"
+                if type(message) is tuple:
+                    message, images = message
+                    ret += role + ": " + message + self.sep + "\n"
+                elif type(message, list):
+                    ret += role + "\n" + "\n".join(message) + self.sep + "\n"
                 else:
                     ret += role + "\n"
             return ret


### PR DESCRIPTION
## Why are these changes needed?

fix “When the type of context in the incoming messages is text, an error” 

## Related issue number (if applicable)

Closes #3017 

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
