### PR TITLE
Update MLX integration to use new generate_step function signature

### DIFF
--- a/docs/mlx_integration.md
+++ b/docs/mlx_integration.md
@@ -13,11 +13,11 @@ Note that for Apple Silicon Macs with less memory, smaller models (or quantized 
 1. Install MLX.
 
    ```
-   pip install mlx-lm
+   pip install "mlx-lm>=0.0.6"
    ```
 
-2. When you launch a model worker, replace the normal worker (`fastchat.serve.model_worker`) with the MLX worker (`fastchat.serve.mlx_worker`).
+2. When you launch a model worker, replace the normal worker (`fastchat.serve.model_worker`) with the MLX worker (`fastchat.serve.mlx_worker`). Remember to launch a model worker after you have launched the controller ([instructions](../README.md))
 
    ```
-   python3 -m fastchat.serve.mlx_worker --model-path microsoft/phi-2
+   python3 -m fastchat.serve.mlx_worker --model-path lmsys/vicuna-7b-v1.5
    ```

--- a/docs/mlx_integration.md
+++ b/docs/mlx_integration.md
@@ -19,5 +19,5 @@ Note that for Apple Silicon Macs with less memory, smaller models (or quantized 
 2. When you launch a model worker, replace the normal worker (`fastchat.serve.model_worker`) with the MLX worker (`fastchat.serve.mlx_worker`). Remember to launch a model worker after you have launched the controller ([instructions](../README.md))
 
    ```
-   python3 -m fastchat.serve.mlx_worker --model-path lmsys/vicuna-7b-v1.5
+   python3 -m fastchat.serve.mlx_worker --model-path TinyLlama/TinyLlama-1.1B-Chat-v1.0
    ```

--- a/fastchat/serve/mlx_worker.py
+++ b/fastchat/serve/mlx_worker.py
@@ -124,7 +124,7 @@ class MLXWorker(BaseModelWorker):
         )
 
         for i in range(max_new_tokens):
-            token = await run_in_threadpool(next, iterator)
+            (token, _) = await run_in_threadpool(next, iterator)
             if token == self.mlx_tokenizer.eos_token_id:
                 finish_reason = "stop"
                 break


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Apple's MLX library was updated so that the generate_step function now returns a tuple, not just a single token. This update updates the MLX model worker to support the updated format.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
