### PR TITLE
--state-dict option to overrwide pretrained kwarsg

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -188,6 +188,7 @@ def load_model(
     awq_config: Optional[AWQConfig] = None,
     exllama_config: Optional[ExllamaConfig] = None,
     xft_config: Optional[XftConfig] = None,
+    state_dict: Optional[str] = None,
     revision: str = "main",
     debug: bool = False,
 ):
@@ -330,6 +331,9 @@ def load_model(
         return model, tokenizer
     kwargs["revision"] = revision
 
+    if state_dict is not None: # Pass state_dict if it is provided in the arguments.
+        kwargs["state_dict"] = state_dict
+
     if dtype is not None:  # Overwrite dtype if it is provided in the arguments.
         kwargs["torch_dtype"] = dtype
 
@@ -463,6 +467,12 @@ def add_model_args(parser):
         type=str,
         default="lmsys/vicuna-7b-v1.5",
         help="The path to the weights. This can be a local folder or a Hugging Face repo ID.",
+    )
+    parser.add_argument(
+        "--state-dict",
+        type=str,
+        required=False,
+        help="The path to compatible weights overriding the default weights in the Hugging Face repo.",
     )
     parser.add_argument(
         "--revision",

--- a/fastchat/serve/cli.py
+++ b/fastchat/serve/cli.py
@@ -226,6 +226,7 @@ def main(args):
     try:
         chat_loop(
             args.model_path,
+            args.state_dict,
             args.device,
             args.num_gpus,
             args.max_gpu_memory,

--- a/fastchat/serve/huggingface_api.py
+++ b/fastchat/serve/huggingface_api.py
@@ -17,6 +17,7 @@ def main(args):
     # Load model
     model, tokenizer = load_model(
         args.model_path,
+        state_dict=args.state_dict,
         device=args.device,
         num_gpus=args.num_gpus,
         max_gpu_memory=args.max_gpu_memory,

--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -336,6 +336,7 @@ class ChatIO(abc.ABC):
 
 def chat_loop(
     model_path: str,
+    state_dict: str,
     device: str,
     num_gpus: int,
     max_gpu_memory: str,
@@ -360,6 +361,7 @@ def chat_loop(
     # Model
     model, tokenizer = load_model(
         model_path,
+        state_dict=state_dict,
         device=device,
         num_gpus=num_gpus,
         max_gpu_memory=max_gpu_memory,

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -48,7 +48,8 @@ class ModelWorker(BaseModelWorker):
         device: str,
         num_gpus: int,
         max_gpu_memory: str,
-        revision: str = None,
+        state_dict: Optional[str] = None,
+        revision: Optional[str] = None,
         dtype: Optional[torch.dtype] = None,
         load_8bit: bool = False,
         cpu_offloading: bool = False,
@@ -76,6 +77,7 @@ class ModelWorker(BaseModelWorker):
         logger.info(f"Loading the model {self.model_names} on worker {worker_id} ...")
         self.model, self.tokenizer = load_model(
             model_path,
+            state_dict=state_dict,
             revision=revision,
             device=device,
             num_gpus=num_gpus,
@@ -389,6 +391,7 @@ def create_model_worker():
         args.model_path,
         args.model_names,
         args.limit_worker_concurrency,
+        state_dict=args.state_dict,
         revision=args.revision,
         no_register=args.no_register,
         device=args.device,

--- a/fastchat/serve/multi_model_worker.py
+++ b/fastchat/serve/multi_model_worker.py
@@ -253,6 +253,7 @@ def create_multi_model_worker():
             model_names,
             args.limit_worker_concurrency,
             args.no_register,
+            state_dict=args.state_dict,
             device=args.device,
             num_gpus=args.num_gpus,
             max_gpu_memory=args.max_gpu_memory,


### PR DESCRIPTION
## Why are these changes needed?

This allows serving a fine-tuned model with the updated weights without creating a repo on Huggingface / hacking the Huggingface cache with new weights.

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
