### PR TITLE
Update conversation.py

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -647,7 +647,8 @@ register_conv_template(
 register_conv_template(
     Conversation(
         name="deepseek-coder",
-        system_template="You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and you only answer questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will refuse to answer.",
+        #system_template="You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and you only answer questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will refuse to answer.",
+        system_message="You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and you only answer questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will refuse to answer.",
         roles=("### Instruction:", "### Response:"),
         sep="\n",
         stop_str="<|EOT|>",


### PR DESCRIPTION
In deepseek-coder conversation's building code block, when forcefully setting the system message with a new string, it does not work.  In fix version, the init argument change from system_template to system_message. 

The following can reproduce the buggy version, it does not work when forcefully set the system message:     
``` 
conv = conv_templates["deepseek-coder"]
conv.set_system_message("---system---")
```

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The PR can fix a bug when forcefully set the system message for deepseek-coder     

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
