### PR TITLE
Add basic support of mamba-chat

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -1455,6 +1455,21 @@ register_conv_template(
     )
 )
 
+# Mamba-chat template
+# reference: https://huggingface.co/havenhq/mamba-chat
+# same as zephyr
+register_conv_template(
+    Conversation(
+        name="mamba",
+        system_template="<|system|>\n{system_message}",
+        roles=("<|user|>", "<|assistant|>"),
+        sep_style=SeparatorStyle.CHATML,
+        sep="</s>",
+        stop_token_ids=[2],
+        stop_str="</s>",
+    )
+)
+
 # CatPPT template
 # reference: https://huggingface.co/rishiraj/CatPPT
 register_conv_template(

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -2001,6 +2001,25 @@ class MambaChatAdapter(BaseModelAdapter):
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("mamba")
 
+    def load_model(self, model_path: str, from_pretrained_kwargs: dict):
+        # requires installation of mamba_ssm, according to https://github.com/state-spaces/mamba
+        from mamba_ssm.models.mixer_seq_simple import MambaLMHeadMode
+        
+        revision = from_pretrained_kwargs.get("revision", "main")
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_path,
+            use_fast=self.use_fast_tokenizer,
+            trust_remote_code=True,
+            revision=revision,
+        )
+        model = MambaLMHeadModel.from_pretrained(
+            model_path, 
+            device="cuda" if torch.cuda.is_available() else "cpu", 
+            **from_pretrained_kwargs,  
+        )
+
+        return model, tokenizer
+
 class NotusAdapter(BaseModelAdapter):
     """The model adapter for Notus (e.g. argilla/notus-7b-v1)"""
 

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1992,6 +1992,14 @@ class ZephyrAdapter(BaseModelAdapter):
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("zephyr")
 
+class MambaChatAdapter(BaseModelAdapter):
+    """The model adapter for mamba-chat """
+
+    def match(self, model_path: str):
+        return "mamba" in model_path.lower()
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("mamba")
 
 class NotusAdapter(BaseModelAdapter):
     """The model adapter for Notus (e.g. argilla/notus-7b-v1)"""
@@ -2347,6 +2355,7 @@ register_model_adapter(SolarAdapter)
 register_model_adapter(SteerLMAdapter)
 register_model_adapter(LlavaAdapter)
 register_model_adapter(YuanAdapter)
+register_model_adapter(MambaChatAdapter)
 
 # After all adapters, try the default base adapter.
 register_model_adapter(BaseModelAdapter)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Mamba has become a popular non-transformer based model, yet it has not been supported in FastChat. I really love both FastChat and mamba, and hope that FastChat could support it!
<!-- Please give a short summary of the change and the problem this solves. -->
I add the prompt template and a basic model adapter referring to [havenhq/mamba-chat](https://github.com/havenhq/mamba-chat/tree/main). However, it seems that the current generation code not fully compatible with mamba (just some minor changes could solve). As I'm still new to FastChat and not yet familiar with all its features, I didn't add code in `gen_model_answers.py`. The requirements of mamba is also missing but could be found in [mamba's official repo](https://github.com/state-spaces/mamba). If you are interested in adding mamba into FastChat, I'd appreciate that you accept this pr and add the missing parts shown above!

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
