### PR TITLE
Support for cosmosage

### DIFF
--- a/docs/model_support.md
+++ b/docs/model_support.md
@@ -50,6 +50,7 @@ After these steps, the new model should be compatible with most FastChat feature
 - [bofenghuang/vigogne-2-7b-chat](https://huggingface.co/bofenghuang/vigogne-2-7b-chat)
 - [camel-ai/CAMEL-13B-Combined-Data](https://huggingface.co/camel-ai/CAMEL-13B-Combined-Data)
 - [codellama/CodeLlama-7b-Instruct-hf](https://huggingface.co/codellama/CodeLlama-7b-Instruct-hf)
+- [Tijmen2/cosmosage_v2](https://huggingface.co/Tijmen2/cosmosage_v2)
 - [databricks/dolly-v2-12b](https://huggingface.co/databricks/dolly-v2-12b)
 - [deepseek-ai/deepseek-llm-67b-chat](https://huggingface.co/deepseek-ai/deepseek-llm-67b-chat)
 - [deepseek-ai/deepseek-coder-33b-instruct](https://huggingface.co/deepseek-ai/deepseek-coder-33b-instruct)

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -34,6 +34,7 @@ class SeparatorStyle(IntEnum):
     DEEPSEEK_CHAT = auto()
     METAMATH = auto()
     YUAN2 = auto()
+    COSMOSAGE_V2 = auto()
 
 
 IMAGE_PLACEHOLDER_STR = "$$<image>$$"
@@ -269,6 +270,16 @@ class Conversation:
                 else:
                     ret += ""
             ret = ret.rstrip("<n>") + seps[0]
+            return ret
+        elif self.sep_style == SeparatorStyle.COSMOSAGE_V2:
+            ret = "<s>"
+            if system_prompt:
+                ret += system_prompt + "▁"
+            for role, message in self.messages:
+                if message:  # If there is a message, format it with the role
+                    ret += f" {role}: {message}▁"
+                else:  # If there's no message, just add the role and the final colon without trailing whitespace
+                    ret += f" {role}:"
             return ret
         else:
             raise ValueError(f"Invalid style: {self.sep_style}")
@@ -1592,6 +1603,17 @@ register_conv_template(
     )
 )
 
+# cosmosage_v2
+# reference: https://huggingface.co/Tijmen2/cosmosage_v2#instruction-format
+register_conv_template(
+    Conversation(
+        name="cosmosage_v2",
+        system_message="You are cosmosage, an AI programmed to provide excellent and detailed answers to the user's question. You are an expert cosmology assistant, able to answer questions on the cosmic microwave background, galaxy formation, large scale structure, theoretical cosmology, inflation, big bang nucleosynthesis, cosmology instrumentation, and other related topics. Please assume the user is fluent in scientific terminology. Elaborate where possible to give a complete answer. If you do not know, say you do not know.",
+        roles=("USER", "ASSISTANT"),
+        sep_style=SeparatorStyle.COSMOSAGE_V2,
+        stop_str="</s>",
+    )
+)
 
 if __name__ == "__main__":
     from fastchat.conversation import get_conv_template

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -2267,6 +2267,15 @@ class GemmaAdapter(BaseModelAdapter):
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("gemma")
 
+class CosmosageV2Adapter(BaseModelAdapter):
+    """The model adapter for cosmosage_v2"""
+
+    def match(self, model_path: str):
+        return "cosmosage_v2" in model_path.lower()
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("cosmosage_v2")
+
 
 # Note: the registration order matters.
 # The one registered earlier has a higher matching priority.
@@ -2358,6 +2367,7 @@ register_model_adapter(SteerLMAdapter)
 register_model_adapter(LlavaAdapter)
 register_model_adapter(YuanAdapter)
 register_model_adapter(GemmaAdapter)
+register_model_adapter(CosmosageV2Adapter)
 
 # After all adapters, try the default base adapter.
 register_model_adapter(BaseModelAdapter)


### PR DESCRIPTION
## Why are these changes needed?

This pull request introduces support for the new `cosmosage_v2` model into our system. The `cosmosage_v2` model is a specialized language model designed for providing expert-level responses in the field of cosmology. The changes include
 - documentation listing this model as supported
 - conversation separator style
 - conversation template
 - model adapter

## Related issue number (if applicable)

N/A

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
