### PR TITLE
fix(llm_judge): Fix display issues in qa_browser

### DIFF
--- a/fastchat/llm_judge/qa_browser.py
+++ b/fastchat/llm_judge/qa_browser.py
@@ -233,7 +233,9 @@ def build_pairwise_browser_tab():
     # Conversation
     chat_mds = []
     for i in range(num_turns):
-        chat_mds.append(gr.Markdown(elem_id=f"user_question_{i+1}"))
+        chat_mds.append(
+            gr.Markdown(elem_id=f"user_question_{i+1}", elem_classes=["qa-block-text"])
+        )
         with gr.Row():
             for j in range(num_sides):
                 with gr.Column(scale=100):
@@ -242,11 +244,15 @@ def build_pairwise_browser_tab():
                 if j == 0:
                     with gr.Column(scale=1, min_width=8):
                         gr.Markdown()
-    reference = gr.Markdown(elem_id=f"reference")
+    reference = gr.Markdown(elem_id=f"reference", elem_classes=["qa-block-text"])
     chat_mds.append(reference)
 
-    model_explanation = gr.Markdown(elem_id="model_explanation")
-    model_explanation2 = gr.Markdown(elem_id="model_explanation")
+    model_explanation = gr.Markdown(
+        elem_id="model_explanation", elem_classes=["qa-block-text"]
+    )
+    model_explanation2 = gr.Markdown(
+        elem_id="model_explanation", elem_classes=["qa-block-text"]
+    )
 
     # Callbacks
     category_selector.change(display_question, [category_selector], [question_selector])
@@ -302,7 +308,9 @@ def build_single_answer_browser_tab():
     # Conversation
     chat_mds = []
     for i in range(num_turns):
-        chat_mds.append(gr.Markdown(elem_id=f"user_question_{i+1}"))
+        chat_mds.append(
+            gr.Markdown(elem_id=f"user_question_{i+1}", elem_classes=["qa-block-text"])
+        )
         with gr.Row():
             for j in range(num_sides):
                 with gr.Column(scale=100):
@@ -312,11 +320,15 @@ def build_single_answer_browser_tab():
                     with gr.Column(scale=1, min_width=8):
                         gr.Markdown()
 
-    reference = gr.Markdown(elem_id=f"reference")
+    reference = gr.Markdown(elem_id=f"reference", elem_classes=["qa-block-text"])
     chat_mds.append(reference)
 
-    model_explanation = gr.Markdown(elem_id="model_explanation")
-    model_explanation2 = gr.Markdown(elem_id="model_explanation")
+    model_explanation = gr.Markdown(
+        elem_id="model_explanation", elem_classes=["qa-block-text"]
+    )
+    model_explanation2 = gr.Markdown(
+        elem_id="model_explanation", elem_classes=["qa-block-text"]
+    )
 
     # Callbacks
     category_selector.change(display_question, [category_selector], [question_selector])
@@ -349,11 +361,14 @@ block_css = """
 #model_explanation {
     background-color: #FBE5D6;
 }
+.qa-block-text.prose * {
+    color: #1F2937 !important;
+}
 """
 
 
 def load_demo():
-    dropdown_update = gr.Dropdown.update(value=list(category_selector_map.keys())[0])
+    dropdown_update = gr.Dropdown(value=list(category_selector_map.keys())[0])
     return dropdown_update, dropdown_update
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The .update method was deprecated in Gradio 4.x which caused the dropdown to show an error.

Added a CSS class to set the text color inside colored blocks to be black as the white text on those pastel colors had too little contrast to be easily read.

**Before**
<img width="1503" alt="Screenshot 2024-03-08 at 16 27 33" src="https://github.com/lm-sys/FastChat/assets/3781777/c341bb25-400a-4d81-8db6-5610457bc4a3">
<img width="1503" alt="Screenshot 2024-03-08 at 16 27 49" src="https://github.com/lm-sys/FastChat/assets/3781777/7b92d467-381f-4ef2-84a3-0863e440d8ba">

**After**
<img width="1503" alt="Screenshot 2024-03-08 at 16 27 07" src="https://github.com/lm-sys/FastChat/assets/3781777/6cdb40a4-38d4-43cf-8f11-ed29dc13b51a">

## Related issue number (if applicable)


## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
