### PR TITLE
vllm_worker add multi-lora support

### DIFF
--- a/docs/vllm_integration.md
+++ b/docs/vllm_integration.md
@@ -23,3 +23,8 @@ See the supported models [here](https://vllm.readthedocs.io/en/latest/models/sup
    '''
    python3 -m fastchat.serve.vllm_worker --model-path TheBloke/vicuna-7B-v1.5-AWQ --quantization awq
    '''
+
+   If you use a LoRA model, try
+   '''
+   python3 -m fastchat.serve.vllm_worker --model-path meta-llama/Llama-2-7b-chat-hf --enable-lora --lora-modules lora1=lora1_path lora2=lora2_path --max-lora-rank 64 --lora-dtype float16
+   '''

--- a/fastchat/serve/vllm_worker.py
+++ b/fastchat/serve/vllm_worker.py
@@ -25,6 +25,19 @@ from fastchat.serve.model_worker import (
 from fastchat.utils import get_context_length, is_partial_stop
 
 
+# Add imports for vLLM LoRAs, prevent panic with older vllm versions which not support LoRAs
+# LoRA request only supports vLLM versions >= v0.3.2
+try:
+    from vllm.entrypoints.openai.serving_engine import LoRA
+    from vllm.lora.request import LoRARequest
+    VLLM_LORA_SUPPORTED = True
+except:
+    VLLM_LORA_SUPPORTED = False
+
+    # Fake LoRA class to compatible with old vLLM versions
+    class LoRA:
+        pass
+
 app = FastAPI()
 
 
@@ -40,7 +53,14 @@ class VLLMWorker(BaseModelWorker):
         no_register: bool,
         llm_engine: AsyncLLMEngine,
         conv_template: str,
+        lora_modules: List[LoRA] = [],
     ):
+        # Register LoRA model names
+        if VLLM_LORA_SUPPORTED:
+            model_names = [] if model_names is None else model_names
+            lora_model_names = [lora.name for lora in lora_modules]
+            model_names += lora_model_names
+
         super().__init__(
             controller_addr,
             worker_addr,
@@ -61,8 +81,23 @@ class VLLMWorker(BaseModelWorker):
             self.tokenizer = llm_engine.engine.tokenizer.tokenizer
         self.context_len = get_context_length(llm_engine.engine.model_config.hf_config)
 
+        # Add LoRA requests, lora request will be forwarded to vLLM engine for generating with specific LoRA weights
+        self.lora_requests = [
+            LoRARequest(
+                lora_name=lora.name,
+                lora_int_id=i,
+                lora_local_path=lora.local_path,
+            ) for i, lora in enumerate(lora_modules, start=1)
+        ] if VLLM_LORA_SUPPORTED else []
+
         if not no_register:
             self.init_heart_beat()
+
+    def get_model_lora_request(self, model_name):
+        for lora_req in self.lora_requests:
+            if lora_req.lora_name == model_name:
+                return lora_req
+        return None
 
     async def generate_stream(self, params):
         self.call_ct += 1
@@ -116,7 +151,12 @@ class VLLMWorker(BaseModelWorker):
             frequency_penalty=frequency_penalty,
             best_of=best_of,
         )
-        results_generator = engine.generate(context, sampling_params, request_id)
+        if VLLM_LORA_SUPPORTED:
+            lora_request = self.get_model_lora_request(params.get('model'))
+            results_generator = engine.generate(context, sampling_params, request_id,
+                                                lora_request=lora_request)
+        else:
+            results_generator = engine.generate(context, sampling_params, request_id)
 
         async for request_output in results_generator:
             prompt = request_output.prompt
@@ -241,6 +281,21 @@ async def api_model_details(request: Request):
     return {"context_length": worker.context_len}
 
 
+# Add LoRAParserAction for supporting vLLM Multi-LoRA
+class LoRAParserAction(argparse.Action):
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if VLLM_LORA_SUPPORTED is False:
+            logger.warning("To use the vLLM LoRAs feature, please upgrade vLLM to version v0.3.2 or higher.")
+            return
+
+        lora_list = []
+        for item in values:
+            name, path = item.split('=')
+            lora_list.append(LoRA(name, path))
+        setattr(namespace, self.dest, lora_list)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", type=str, default="localhost")
@@ -279,6 +334,10 @@ if __name__ == "__main__":
         "memory (OOM) errors.",
     )
 
+    # Support parse LoRA modules
+    parser.add_argument("--lora-modules", type=str, default=None, nargs='+', action=LoRAParserAction,
+                        help="LoRA module configurations in the format name=path. Multiple modules can be specified.")
+
     parser = AsyncEngineArgs.add_cli_args(parser)
     args = parser.parse_args()
     if args.model_path:
@@ -298,5 +357,6 @@ if __name__ == "__main__":
         args.no_register,
         engine,
         args.conv_template,
+        args.lora_modules,
     )
     uvicorn.run(app, host=args.host, port=args.port, log_level="info")

--- a/fastchat/serve/vllm_worker.py
+++ b/fastchat/serve/vllm_worker.py
@@ -7,6 +7,7 @@ See documentations at docs/vllm_integration.md
 import argparse
 import asyncio
 import json
+from os import path
 from typing import List
 
 from fastapi import FastAPI, Request, BackgroundTasks
@@ -57,7 +58,8 @@ class VLLMWorker(BaseModelWorker):
     ):
         # Register LoRA model names
         if VLLM_LORA_SUPPORTED:
-            model_names = [] if model_names is None else model_names
+            # If model_names defined, use basename of model path by default
+            model_names = [path.basename(path.normpath(model_path))] if model_names is None else model_names
             lora_model_names = [lora.name for lora in lora_modules]
             model_names += lora_model_names
 


### PR DESCRIPTION
## Why are these changes needed?

Add multi-lora support for vllm_worker, this feature has been supported in vllm v0.3.2. This PR enables this capability in vllm_worker.

1. Add a new argument `lora-modules` to support define multi-lora modules.
2. Auto register lora names as model_names, so that the lora modules can be called in /v1/models and related APIs.
3. Convert the requests with model name as lora name to vllm LoRARequest for vllm to call the LoRA model for inference.

## Related issue number (if applicable)

#3107 

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
