### PR TITLE
fix: garbled Chinese in the conv.json

### DIFF
--- a/fastchat/serve/gradio_block_arena_anony.py
+++ b/fastchat/serve/gradio_block_arena_anony.py
@@ -62,7 +62,7 @@ def load_demo_side_by_side_anony(models_, url_params):
 
 
 def vote_last_response(states, vote_type, model_selectors, request: gr.Request):
-    with open(get_conv_log_filename(), "a") as fout:
+    with open(get_conv_log_filename(), "a", encoding='utf-8') as fout:
         data = {
             "tstamp": round(time.time(), 4),
             "type": vote_type,
@@ -70,7 +70,7 @@ def vote_last_response(states, vote_type, model_selectors, request: gr.Request):
             "states": [x.dict() for x in states],
             "ip": get_ip(request),
         }
-        fout.write(json.dumps(data) + "\n")
+        fout.write(json.dumps(data, ensure_ascii=False) + "\n")
 
     if ":" not in model_selectors[0]:
         for i in range(5):

--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -65,7 +65,7 @@ def load_demo_side_by_side_named(models, url_params):
 
 
 def vote_last_response(states, vote_type, model_selectors, request: gr.Request):
-    with open(get_conv_log_filename(), "a") as fout:
+    with open(get_conv_log_filename(), "a", encoding='utf-8') as fout:
         data = {
             "tstamp": round(time.time(), 4),
             "type": vote_type,
@@ -73,7 +73,7 @@ def vote_last_response(states, vote_type, model_selectors, request: gr.Request):
             "states": [x.dict() for x in states],
             "ip": get_ip(request),
         }
-        fout.write(json.dumps(data) + "\n")
+        fout.write(json.dumps(data, ensure_ascii=False) + "\n")
 
 
 def leftvote_last_response(

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -201,7 +201,7 @@ def load_demo(url_params, request: gr.Request):
 
 
 def vote_last_response(state, vote_type, model_selector, request: gr.Request):
-    with open(get_conv_log_filename(), "a") as fout:
+    with open(get_conv_log_filename(), "a", encoding='utf-8') as fout:
         data = {
             "tstamp": round(time.time(), 4),
             "type": vote_type,
@@ -209,7 +209,7 @@ def vote_last_response(state, vote_type, model_selector, request: gr.Request):
             "state": state.dict(),
             "ip": get_ip(request),
         }
-        fout.write(json.dumps(data) + "\n")
+        fout.write(json.dumps(data, ensure_ascii=False) + "\n")
 
 
 def upvote_last_response(state, model_selector, request: gr.Request):
@@ -513,7 +513,7 @@ def bot_response(
             os.makedirs(os.path.dirname(filename), exist_ok=True)
             image.save(filename)
 
-    with open(get_conv_log_filename(), "a") as fout:
+    with open(get_conv_log_filename(), "a", encoding='utf-8') as fout:
         data = {
             "tstamp": round(finish_tstamp, 4),
             "type": "chat",
@@ -529,7 +529,7 @@ def bot_response(
             "ip": get_ip(request),
             "images": images_hash,
         }
-        fout.write(json.dumps(data) + "\n")
+        fout.write(json.dumps(data, ensure_ascii=False) + "\n")
 
 
 block_css = """


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
I need save the battle logs in the `conv.json`, and then I found that garbled Chinese in the file. The reason is `json.dumps` the ascii encoding used by default during serialization, if you want to output the real Chinese, you need to specify ensure_ascii=False: for more in-depth analysis, it should be that the dJSON object is not a simple unicode implementation, but contains a mixed unicode encoding and a string that has been encoded with utf-8.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks
Before fixed:
![image](https://github.com/lm-sys/FastChat/assets/98650340/f2e6cee9-9bde-476a-8c11-8ff7dd270df7)

After:
![image](https://github.com/lm-sys/FastChat/assets/98650340/0fa05777-46cf-40f2-9e18-eb8baba84b1c)

- [v] I've run `format.sh` to lint the changes in this PR.
- [v] I've included any doc changes needed.
- [v] I've made sure the relevant tests are passing (if applicable).
