### PR TITLE
Handle NaN values in "num_battles" column

### DIFF
--- a/fastchat/serve/monitor/elo_analysis.py
+++ b/fastchat/serve/monitor/elo_analysis.py
@@ -285,8 +285,7 @@ def report_elo_analysis_results(battles_json, rating_system="bt", num_bootstrap=
             "variance": bootstrap_df.var(),
             "rating_q975": bootstrap_df.quantile(0.975),
             "rating_q025": bootstrap_df.quantile(0.025),
-            "num_battles": battles["model_a"].value_counts()
-            + battles["model_b"].value_counts(),
+            "num_battles": battles["model_a"].value_counts().add(battles["model_b"].value_counts(), fill_value=0),
         }
     )
 

--- a/fastchat/serve/monitor/elo_analysis.py
+++ b/fastchat/serve/monitor/elo_analysis.py
@@ -285,7 +285,9 @@ def report_elo_analysis_results(battles_json, rating_system="bt", num_bootstrap=
             "variance": bootstrap_df.var(),
             "rating_q975": bootstrap_df.quantile(0.975),
             "rating_q025": bootstrap_df.quantile(0.025),
-            "num_battles": battles["model_a"].value_counts().add(battles["model_b"].value_counts(), fill_value=0),
+            "num_battles": battles["model_a"]
+            .value_counts()
+            .add(battles["model_b"].value_counts(), fill_value=0),
         }
     )
 


### PR DESCRIPTION
## Why are these changes needed?

This pull request addresses an issue with NaN values in the "num_battles" column, preventing a ValueError when attempting to convert NaN to an integer. 

The "num_battles" column can contain NaN values when a model participating in the arena(battles) has been placed to only one party, `model_a` or `model_b`. For example:

```
battles = [    
   {'model_a': 'llama2', 'model_b': 'gpt-4-turbo-preview', ...},   
   {'model_a': 'llama2', 'model_b': 'gpt-4-turbo-preview', ...},
]
```

This situation raises an ValueError in [get_arena_table](https://github.com/lm-sys/FastChat/blob/97065ff7caa3ae4ca28c661b7424f7ae4cca539b/fastchat/serve/monitor/monitor.py#L254) because battles["model_a"].value_counts() + battles["model_b"].value_counts() results in NaN values as shown below:

```

gpt-4-turbo-preview   NaN
llama2                NaN
dtype: float64
```

However, for the arena table to be created, the count should be as follows:

```
gpt-4-turbo-preview    2.0
llama2                 2.0
dtype: float64
```

The code has been modified to address this issue by checking for NaN values in the "num_battles" column and replacing them with 0 using fillna(0, inplace=True).

## Related issue number (if applicable)

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
