### PR TITLE
Fix Alpaca Format

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -551,8 +551,8 @@ register_conv_template(
     Conversation(
         name="alpaca",
         system_message="Below is an instruction that describes a task. Write a response that appropriately completes the request.",
-        roles=("### Instruction", "### Response"),
-        sep_style=SeparatorStyle.ADD_COLON_TWO,
+        roles=("### Instruction:", "### Response:"),
+        sep_style=SeparatorStyle.ADD_NEW_LINE_SINGLE,
         sep="\n\n",
         sep2="</s>",
     )


### PR DESCRIPTION
Right now the `alpaca` conversation type does not follow the Alpaca format introduced by Stanford, and mainly it differs from what most people I've seen consider the "Alpaca format" to be.

Currently it formats as such:
```
<s>Below is an instruction that describes a task. Write a response that appropriately completes the request.

### Instruction: An example instruction.

### Response: An example output.</s>
```

While the proper format is as such:
```
<s>Below is an instruction that describes a task. Write a response that appropriately completes the request.

### Instruction:
An example instruction.

### Response:
An example output.</s>
```

Initially this PR seemed to be correct, but after a second look I'm seeing that samples are ending with `\n\n</s>` instead of just `</s>`