### PR TITLE
add fastchat/serve/example_images to wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,5 +32,8 @@ dev = ["black==23.3.0", "pylint==2.8.2"]
 [tool.setuptools.packages.find]
 exclude = ["assets*", "benchmark*", "docs", "dist*", "playground*", "scripts*", "tests*"]
 
+[tool.setuptools.package-data]
+"*" = ["fastchat/serve/example_images/*"]
+
 [tool.wheel]
 exclude = ["assets*", "benchmark*", "docs", "dist*", "playground*", "scripts*", "tests*"]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

An error occurs when starting gradio_web_server_multi because the wheel package contains images under fastchat/serve/example_images/. Modify pyproject.toml to include this directory in the wheel package.

## Related issue number (if applicable)

Closes #3111

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
