### PR TITLE
Add customizable model config for API providers

### DIFF
--- a/fastchat/serve/api_provider.py
+++ b/fastchat/serve/api_provider.py
@@ -86,14 +86,14 @@ def get_api_provider_stream_iter(
     elif model_api_dict["api_type"] == "cohere":
         messages = conv.to_openai_api_messages()
         stream_iter = cohere_api_stream_iter(
-            client_name=model_api_dict.get("client_name"),
+            client_name=model_api_dict.get("client_name", "FastChat"),
             model_id=model_api_dict["model_name"],
             messages=messages,
             temperature=temperature,
             top_p=top_p,
             max_new_tokens=max_new_tokens,
-            api_base=model_api_dict.get("api_base"),
-            api_key=model_api_dict.get("api_key"),
+            api_base=model_api_dict["api_base"],
+            api_key=model_api_dict["api_key"],
         )
     else:
         raise NotImplementedError()
@@ -490,7 +490,7 @@ def cohere_api_stream_iter(
     client = cohere.Client(
         api_key=api_key,
         base_url=api_base,
-        client_name=client_name or "FastChat",
+        client_name=client_name,
     )
 
     # prepare and log requests

--- a/fastchat/serve/gradio_block_arena_anony.py
+++ b/fastchat/serve/gradio_block_arena_anony.py
@@ -29,6 +29,7 @@ from fastchat.serve.gradio_web_server import (
     acknowledgment_md,
     get_ip,
     get_model_description_md,
+    api_endpoint_info,
 )
 from fastchat.utils import (
     build_logger,
@@ -588,6 +589,7 @@ def bot_response_multi(
                 max_new_tokens,
                 request,
                 apply_rate_limit=False,
+                use_recommended_config=True,
             )
         )
 

--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -238,6 +238,8 @@ def bot_response_multi(
                 top_p,
                 max_new_tokens,
                 request,
+                apply_rate_limit=True,
+                use_recommended_config=False,
             )
         )
 

--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -238,8 +238,6 @@ def bot_response_multi(
                 top_p,
                 max_new_tokens,
                 request,
-                apply_rate_limit=True,
-                use_recommended_config=False,
             )
         )
 

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -364,7 +364,7 @@ def bot_response(
     max_new_tokens,
     request: gr.Request,
     apply_rate_limit=True,
-    use_recommended_config=True,
+    use_recommended_config=False,
 ):
     ip = get_ip(request)
     logger.info(f"bot_response. ip: {ip}")
@@ -732,8 +732,6 @@ def build_single_model_ui(models, add_promotion_links=False):
 
     # Register listeners
     imagebox = gr.State(None)
-    apply_rate_limit = gr.State(True)
-    use_recommended_config = gr.State(False)
 
     btn_list = [upvote_btn, downvote_btn, flag_btn, regenerate_btn, clear_btn]
     upvote_btn.click(
@@ -775,8 +773,6 @@ def build_single_model_ui(models, add_promotion_links=False):
             temperature,
             top_p,
             max_output_tokens,
-            apply_rate_limit,
-            use_recommended_config,
         ],
         [state, chatbot] + btn_list,
     )
@@ -791,8 +787,6 @@ def build_single_model_ui(models, add_promotion_links=False):
             temperature,
             top_p,
             max_output_tokens,
-            apply_rate_limit,
-            use_recommended_config,
         ],
         [state, chatbot] + btn_list,
     )

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -364,6 +364,7 @@ def bot_response(
     max_new_tokens,
     request: gr.Request,
     apply_rate_limit=True,
+    use_recommended_config=True,
 ):
     ip = get_ip(request)
     logger.info(f"bot_response. ip: {ip}")
@@ -437,6 +438,12 @@ def bot_response(
             images,
         )
     else:
+        if use_recommended_config:
+            recommended_config = model_api_dict.get("recommended_config", None)
+            if recommended_config is not None:
+                temperature = recommended_config.get("temperature", temperature)
+                top_p = recommended_config.get("top_p", top_p)
+
         stream_iter = get_api_provider_stream_iter(
             conv,
             model_name,
@@ -725,6 +732,9 @@ def build_single_model_ui(models, add_promotion_links=False):
 
     # Register listeners
     imagebox = gr.State(None)
+    apply_rate_limit = gr.State(True)
+    use_recommended_config = gr.State(False)
+
     btn_list = [upvote_btn, downvote_btn, flag_btn, regenerate_btn, clear_btn]
     upvote_btn.click(
         upvote_last_response,
@@ -760,7 +770,14 @@ def build_single_model_ui(models, add_promotion_links=False):
         [state, chatbot, textbox, imagebox] + btn_list,
     ).then(
         bot_response,
-        [state, temperature, top_p, max_output_tokens],
+        [
+            state,
+            temperature,
+            top_p,
+            max_output_tokens,
+            apply_rate_limit,
+            use_recommended_config,
+        ],
         [state, chatbot] + btn_list,
     )
     send_btn.click(
@@ -769,7 +786,14 @@ def build_single_model_ui(models, add_promotion_links=False):
         [state, chatbot, textbox, imagebox] + btn_list,
     ).then(
         bot_response,
-        [state, temperature, top_p, max_output_tokens],
+        [
+            state,
+            temperature,
+            top_p,
+            max_output_tokens,
+            apply_rate_limit,
+            use_recommended_config,
+        ],
         [state, chatbot] + btn_list,
     )
 

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -732,7 +732,6 @@ def build_single_model_ui(models, add_promotion_links=False):
 
     # Register listeners
     imagebox = gr.State(None)
-
     btn_list = [upvote_btn, downvote_btn, flag_btn, regenerate_btn, clear_btn]
     upvote_btn.click(
         upvote_last_response,
@@ -768,12 +767,7 @@ def build_single_model_ui(models, add_promotion_links=False):
         [state, chatbot, textbox, imagebox] + btn_list,
     ).then(
         bot_response,
-        [
-            state,
-            temperature,
-            top_p,
-            max_output_tokens,
-        ],
+        [state, temperature, top_p, max_output_tokens],
         [state, chatbot] + btn_list,
     )
     send_btn.click(
@@ -782,12 +776,7 @@ def build_single_model_ui(models, add_promotion_links=False):
         [state, chatbot, textbox, imagebox] + btn_list,
     ).then(
         bot_response,
-        [
-            state,
-            temperature,
-            top_p,
-            max_output_tokens,
-        ],
+        [state, temperature, top_p, max_output_tokens],
         [state, chatbot] + btn_list,
     )
 


### PR DESCRIPTION
## Why are these changes needed?
Add the ability to set a default behavior in the anonymous battle mode in terms of temperature and top_p. 

ex:
```
"<model-name>": {
      "model_name": "<model-name>",
      "api_type": "<api-type>",
      "anony_only": false,
      "multimodal": false,
      "api_base": "<api-base>",
      "api_key": "<api-key>",
      "recommended_config" : {
        "temperature": 0.7,
        "top_p": 1.0
      }
    }
```
## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
