### PR TITLE
Add support for Smaug-2.

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1727,6 +1727,16 @@ class QwenChatAdapter(BaseModelAdapter):
         return get_conv_template("qwen-7b-chat")
 
 
+class SmaugChatAdapter(BaseModelAdapter):
+    """The model adapter for abacusai/Smaug-2-72B."""
+
+    def match(self, model_path: str):
+        return "smaug" in model_path.lower()
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        return get_conv_template("qwen-7b-chat")
+
+
 class BGEAdapter(BaseModelAdapter):
     """The model adapter for BGE (e.g., BAAI/bge-large-en-v1.5)"""
 

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -536,6 +536,13 @@ register_model_info(
 )
 
 register_model_info(
+    ["smaug-2-72b"],
+    "Smaug-2-72B",
+    "https://huggingface.co/abacusai/Smaug-2-72B",
+    "An open model trained by Abacus.AI.",
+)
+
+register_model_info(
     ["Llama2-Chinese-13b-Chat", "LLama2-Chinese-13B"],
     "Llama2-Chinese",
     "https://huggingface.co/FlagAlpha/Llama2-Chinese-13b-Chat",


### PR DESCRIPTION
Hello! We would like to submit our new model, [Smaug-2-72B](https://huggingface.co/abacusai/Smaug-2-72B) to the Chatbot Arena.

Smaug-2-72B has the highest MT-Bench scores of any open-source LLM, scoring approximately 0.2 higher than Qwen1.5-72B-Chat which it is based on (and nearly 0.3 higher on the first turn). In further internal testing on a wider range of prompts than MT-Bench, we find that Smaug-2-72B maintains a lead over Qwen1.5-72B-Chat and in some cases is nearly at GPT4 level.

This PR has what we surmise are the main changes necessary to support Smaug-2-72B, but please let us know if there is anything else you would need from us. Also - we can serve the model ourselves, if necessary.
