### PR TITLE
chore: let conv.message be str if no image provided in request

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -320,7 +320,10 @@ async def get_gen_params(
                     ]
 
                     text = "\n".join(text_list)
-                    conv.append_message(conv.roles[0], (text, image_list))
+                    if len(image_list) == 0:
+                        conv.append_message(conv.roles[0], text)
+                    else:
+                        conv.append_message(conv.roles[0], (text, image_list))
                 else:
                     conv.append_message(conv.roles[0], message["content"])
             elif msg_role == "assistant":


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When using langchaingo w/ fastchat, it generates requests with formats like `"messages":["text":"given text", "type": "text"]` as default, which will be recognized and processed as a request with image since JSON sees it as a list(dict), therefore causing errors at `prompt = conv.get_prompt()` since most model adapters for normal LLMs could not accept `conv.messages` as `list[tuple]`. 

By adopting this fix, requests will plain texts would be correctly recognized and appended to `conv` as str.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
