### PR TITLE
Change separator in phind conversation template from colon to newline

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -1548,7 +1548,7 @@ register_conv_template(
         roles=("### User Message", "### Assistant"),
         messages=(),
         offset=0,
-        sep_style=SeparatorStyle.ADD_COLON_SINGLE,
+        sep_style=SeparatorStyle.ADD_NEW_LINE_SINGLE,
         sep="\n\n",
     )
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

From the [documentation](https://huggingface.co/Phind/Phind-CodeLlama-34B-v2) on HuggingFace, it can be seen that the Phind-CodeLlama models use newline separators in their conversation templates. As it is currently implemented, colon separators are used.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
