### PR TITLE
Fix ChatGLM3 format error

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -188,9 +188,9 @@ class Conversation:
                 ret += system_prompt
             for role, message in self.messages:
                 if message:
-                    ret += role + "\n" + message
+                    ret += role + "\n" + message + "\n"
                 else:
-                    ret += role
+                    ret += role + "\n"
             return ret
         elif self.sep_style == SeparatorStyle.CHATINTERN:
             # source: https://huggingface.co/internlm/internlm-chat-7b-8k/blob/bd546fa984b4b0b86958f56bf37f94aa75ab8831/modeling_internlm.py#L771


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The previous format for ChatGLM3 is not correct, which will yield wrong output:
![image](https://github.com/lm-sys/FastChat/assets/110874468/ec8a3a39-e4eb-4e6d-8156-45c474f69018)

After changing:
![image](https://github.com/lm-sys/FastChat/assets/110874468/a199166d-6560-44d1-bd8e-a0073195c5ed)


## Related issue number (if applicable)

None

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
