### PR TITLE
Fix web launch bug

### DIFF
--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -970,6 +970,12 @@ if __name__ == "__main__":
         help="Enable content moderation to block unsafe inputs",
     )
     parser.add_argument(
+        "--use_remote_storage",
+        type=bool,
+        default=False,
+        help="Whether to use remote storage when using image",
+    )
+    parser.add_argument(
         "--show-terms-of-use",
         action="store_true",
         help="Shows term of use before loading the demo",
@@ -993,7 +999,7 @@ if __name__ == "__main__":
     logger.info(f"args: {args}")
 
     # Set global variables
-    set_global_vars(args.controller_url, args.moderate)
+    set_global_vars(args.controller_url, args.moderate, args.use_remote_storage)
     models, all_models = get_model_list(
         args.controller_url, args.register_api_endpoint_file, False
     )


### PR DESCRIPTION
Fix argument missing bug.
TypeError: set_global_vars() missing 1 required positional argument: 'use_remote_storage_'

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`python3 -m fastchat.serve.gradio_web_server` launch failed.

info

"""
2024-04-23 07:32:13 | ERROR | stderr | Traceback (most recent call last):
2024-04-23 07:32:13 | ERROR | stderr |   File "<frozen runpy>", line 198, in _run_module_as_main
2024-04-23 07:32:13 | ERROR | stderr |   File "<frozen runpy>", line 88, in _run_code
2024-04-23 07:32:13 | ERROR | stderr |   File "/data/youshuji/FastChat/fastchat/serve/gradio_web_server.py", line 996, in <module>
2024-04-23 07:32:13 | ERROR | stderr |     set_global_vars(args.controller_url, args.moderate)
2024-04-23 07:32:13 | ERROR | stderr | TypeError: set_global_vars() missing 1 required positional argument: 'use_remote_storage_'
"""

## Related issue number (if applicable)

There is no issue yet

## Checks

- [x ] I've run `format.sh` to lint the changes in this PR.
- [x ] I've included any doc changes needed.
- [x ] I've made sure the relevant tests are passing (if applicable).
