### PR TITLE
Solve the compatibility problem of SeparatorStyle.CHATML type messes …

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -189,12 +189,16 @@ class Conversation:
             ret = "" if system_prompt == "" else system_prompt + self.sep + "\n"
             for role, message in self.messages:
                 if message:
-                    if type(message) is tuple:
-                        message, images = message
-                        message = IMAGE_PLACEHOLDER_STR * len(images) + message
-                    ret += role + "\n" + message + self.sep + "\n"
+                    if isinstance(message, tuple):
+                        message, images = message if len(message) > 1 else (message[0], [])
+                        images = images if images is not None else []
+                        message = (IMAGE_PLACEHOLDER_STR * len(images) if images else "") + (
+                            message if message is not None else "")
+                    else:
+                        message = message if message is not None else ""
+                    ret += f"{role}\n{message}{self.sep}\n"
                 else:
-                    ret += role + "\n"
+                    ret += f"{role}\n"
             return ret
         elif self.sep_style == SeparatorStyle.CHATGLM3:
             ret = ""


### PR DESCRIPTION
…field

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Solve the compatibility problem of SeparatorStyle.CHATML type messes field

```
/usr/local/lib/python3.10/dist-packages/fastchat/conversation.py", line 197, in get_prompt ERROR | stderr | ret += role + ":" + message + seps[i % 2] + "\n" ERROR | stderr | TypeError: can only concatenate str (not "NoneType") to str
```

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
