### PR TITLE
Fix port in worker-address in vllm_worker for #2467

### DIFF
--- a/fastchat/serve/vllm_worker.py
+++ b/fastchat/serve/vllm_worker.py
@@ -245,7 +245,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", type=str, default="localhost")
     parser.add_argument("--port", type=int, default=21002)
-    parser.add_argument("--worker-address", type=str, default="http://localhost:21002")
+    parser.add_argument("--worker-address", type=str, default=None)
     parser.add_argument(
         "--controller-address", type=str, default="http://localhost:21001"
     )
@@ -281,6 +281,8 @@ if __name__ == "__main__":
 
     parser = AsyncEngineArgs.add_cli_args(parser)
     args = parser.parse_args()
+    if args.worker_address is None:
+        args.worker_address = f"http://localhost:{args.port}"
     if args.model_path:
         args.model = args.model_path
     if args.num_gpus > 1:


### PR DESCRIPTION
When just change ```--port``` , it has no error but it does not work well when run sevural models in one machine.

And this does not change the behavior when explicitly specify the ```-worker-address```.

## Why are these changes needed?

When running more than one model with one controller in one machine, changing ```--port```  is a natural behavior.
This a more frequent case should be supported.

## Related issue number

Open #2467" 

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
