### PR TITLE
fix error and support Phi-3 models

### DIFF
--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -341,7 +341,7 @@ def get_context_length(config):
     """Get the context length of a model from a huggingface model config."""
     rope_scaling = getattr(config, "rope_scaling", None)
     if rope_scaling:
-        rope_scaling_factor = config.rope_scaling["factor"]
+        rope_scaling_factor = getattr(rope_scaling, "factor", 1)
     else:
         rope_scaling_factor = 1
 


### PR DESCRIPTION
## Why are these changes needed?

Model worker (also vllm_worker) has error to load "microsoft/Phi-3-mini-128k-instruct" etc..

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
