### PR TITLE
Update inference.py

### DIFF
--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -85,6 +85,9 @@ def generate_stream(
     stop_token_ids = params.get("stop_token_ids", None) or []
     if tokenizer.eos_token_id not in stop_token_ids:
         stop_token_ids.append(tokenizer.eos_token_id)
+    for item in model.generation_config.eos_token_id:
+        if item not in stop_token_ids:
+            stop_token_ids.append(item)
 
     logits_processor = prepare_logits_processor(
         temperature, repetition_penalty, top_p, top_k


### PR DESCRIPTION
Add eos_token_id from the generation config file so that Llama3 can perform inference correctly.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The addition of eos_token_id from the generation config file to the stop_token_ids is crucial for ensuring correct inference termination in frameworks like Llama3. Typically, the eos_token_id used for model inference can be sourced from the tokenizer's config file and is usually identical to the one in the model's generation config. However, for certain models like Llama3, discrepancies between these two can prevent inference from stopping correctly. By explicitly specifying the eos_token_id from the generation config, our framework can handle inference more accurately and support a wider range of models.

## Related issue number (if applicable)

N/A

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
