### PR TITLE
feat: support system messages for DeepSeek-V2

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -269,7 +269,7 @@ class Conversation:
             return ret
         elif self.sep_style == SeparatorStyle.DEEPSEEK_CHAT:
             seps = [self.sep, self.sep2]
-            ret = system_prompt
+            ret = system_prompt + self.sep if self.system_message else system_prompt
             for i, (role, message) in enumerate(self.messages):
                 if message:
                     ret += role + ": " + message + seps[i % 2]
@@ -1906,11 +1906,11 @@ register_conv_template(
 )
 
 # Deepseek-chat template
-# reference: https://huggingface.co/deepseek-ai/deepseek-llm-67b-chat/blob/main/tokenizer_config.json
+# reference: https://huggingface.co/deepseek-ai/DeepSeek-V2-Chat/blob/main/tokenizer_config.json
 register_conv_template(
     Conversation(
         name="deepseek-chat",
-        system_message="<｜begin▁of▁sentence｜>",  # must add a bos token before first message
+        system_message="<｜begin▁of▁sentence｜>{system_message}",  # must add a bos token before first message
         roles=("User", "Assistant"),
         sep_style=SeparatorStyle.DEEPSEEK_CHAT,
         sep="\n\n",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
According to the https://huggingface.co/deepseek-ai/DeepSeek-V2-Chat, optional system message is supported(which is not in https://huggingface.co/deepseek-ai/deepseek-llm-67b-chat)

```
<｜begin▁of▁sentence｜>User: {user_message_1}

Assistant: {assistant_message_1}<｜end▁of▁sentence｜>User: {user_message_2}

Assistant:
```

```
<｜begin▁of▁sentence｜>{system_message}

User: {user_message_1}

Assistant: {assistant_message_1}<｜end▁of▁sentence｜>User: {user_message_2}

Assistant:
``` 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
