### PR TITLE
support more LaTeX delimiters

### DIFF
--- a/fastchat/serve/gradio_block_arena_anony.py
+++ b/fastchat/serve/gradio_block_arena_anony.py
@@ -538,10 +538,10 @@ Find out who is the 🥇LLM Champion!
                         height=550,
                         show_copy_button=True,
                         latex_delimiters=[
-                            {"left": '$$', "right": '$$', "display": True},
-                            {"left": '$', "right": '$', "display": False},
-                            {"left": '\\(', "right": '\\)', "display": False},
-                            {"left": '\\[', "right": '\\]', "display": True}
+                            {"left": "$$", "right": "$$", "display": True},
+                            {"left": "$", "right": "$", "display": False},
+                            {"left": "\\(", "right": "\\)", "display": False},
+                            {"left": "\\[", "right": "\\]", "display": True},
                         ],
                     )
 

--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -344,10 +344,10 @@ def build_side_by_side_ui_named(models):
                         height=550,
                         show_copy_button=True,
                         latex_delimiters=[
-                            {"left": '$$', "right": '$$', "display": True},
-                            {"left": '$', "right": '$', "display": False},
-                            {"left": '\\(', "right": '\\)', "display": False},
-                            {"left": '\\[', "right": '\\]', "display": True}
+                            {"left": "$$", "right": "$$", "display": True},
+                            {"left": "$", "right": "$", "display": False},
+                            {"left": "\\(", "right": "\\)", "display": False},
+                            {"left": "\\[", "right": "\\]", "display": True},
                         ],
                     )
 

--- a/fastchat/serve/gradio_block_arena_vision.py
+++ b/fastchat/serve/gradio_block_arena_vision.py
@@ -227,12 +227,14 @@ Note: You can only chat with **one image per conversation**. You can upload imag
             )
         with gr.Column(scale=8):
             chatbot = gr.Chatbot(
-                elem_id="chatbot", label="Scroll down and start chatting", height=550,
+                elem_id="chatbot",
+                label="Scroll down and start chatting",
+                height=550,
                 latex_delimiters=[
-                    {"left": '$$', "right": '$$', "display": True},
-                    {"left": '$', "right": '$', "display": False},
-                    {"left": '\\(', "right": '\\)', "display": False},
-                    {"left": '\\[', "right": '\\]', "display": True}
+                    {"left": "$$", "right": "$$", "display": True},
+                    {"left": "$", "right": "$", "display": False},
+                    {"left": "\\(", "right": "\\)", "display": False},
+                    {"left": "\\[", "right": "\\]", "display": True},
                 ],
             )
 

--- a/fastchat/serve/gradio_block_arena_vision_anony.py
+++ b/fastchat/serve/gradio_block_arena_vision_anony.py
@@ -398,10 +398,10 @@ Note: You can only chat with **one image per conversation**. You can upload imag
                                 height=550,
                                 show_copy_button=True,
                                 latex_delimiters=[
-                                    {"left": '$$', "right": '$$', "display": True},
-                                    {"left": '$', "right": '$', "display": False},
-                                    {"left": '\\(', "right": '\\)', "display": False},
-                                    {"left": '\\[', "right": '\\]', "display": True}
+                                    {"left": "$$", "right": "$$", "display": True},
+                                    {"left": "$", "right": "$", "display": False},
+                                    {"left": "\\(", "right": "\\)", "display": False},
+                                    {"left": "\\[", "right": "\\]", "display": True},
                                 ],
                             )
 

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -283,10 +283,10 @@ Note: You can only chat with **one image per conversation**. You can upload imag
                                 height=550,
                                 show_copy_button=True,
                                 latex_delimiters=[
-                                    {"left": '$$', "right": '$$', "display": True},
-                                    {"left": '$', "right": '$', "display": False},
-                                    {"left": '\\(', "right": '\\)', "display": False},
-                                    {"left": '\\[', "right": '\\]', "display": True}
+                                    {"left": "$$", "right": "$$", "display": True},
+                                    {"left": "$", "right": "$", "display": False},
+                                    {"left": "\\(", "right": "\\)", "display": False},
+                                    {"left": "\\[", "right": "\\]", "display": True},
                                 ],
                             )
 

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -514,7 +514,9 @@ def bot_response(
         data = {"text": ""}
         for i, data in enumerate(stream_iter):
             if data["error_code"] == 0:
-                output = wrap_output(data["text"], strip=True, add_html_code=True, escape_backslash=True)
+                output = wrap_output(
+                    data["text"], strip=True, add_html_code=True, escape_backslash=True
+                )
                 # conv.update_last_message(output + "▌")
                 yield (state, state.to_gradio_chatbot()) + (disable_btn,) * 5
             else:
@@ -528,7 +530,9 @@ def bot_response(
                     enable_btn,
                 )
                 return
-        output = wrap_output(data["text"], strip=True, add_html_code=False, escape_backslash=True)
+        output = wrap_output(
+            data["text"], strip=True, add_html_code=False, escape_backslash=True
+        )
         conv.update_last_message(output)
         yield (state, state.to_gradio_chatbot()) + (enable_btn,) * 5
     except requests.exceptions.RequestException as e:
@@ -800,10 +804,10 @@ def build_single_model_ui(models, add_promotion_links=False):
             height=550,
             show_copy_button=True,
             latex_delimiters=[
-                {"left": '$$', "right": '$$', "display": True},
-                {"left": '$', "right": '$', "display": False},
-                {"left": '\\(', "right": '\\)', "display": False},
-                {"left": '\\[', "right": '\\]', "display": True}
+                {"left": "$$", "right": "$$", "display": True},
+                {"left": "$", "right": "$", "display": False},
+                {"left": "\\(", "right": "\\)", "display": False},
+                {"left": "\\[", "right": "\\]", "display": True},
             ],
         )
     with gr.Row():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Certain advanced models, such as GPT/Yi, have the capability to generate LaTeX formulas enclosed within `\[...\]`, but this format is not support yet. This PR add more LaTeX delimiters for better display format in Chatbot Arena. 

However, there is a bug while specific this `latex_delimiters_set` in stream mode, as mentioned in https://github.com/gradio-app/gradio/issues/8006, we should wait the bug fixed then test and merge this PR 

Update:
Above bug will not trigger after offline deployed webui test. But there is another bug that markdown is treating `\` as escape character first, so `\\[` will be rendered as `[` first, then it will not match LaTeX delimiters defined in `latex_delimiters_set`. The solution might be escape model output by replace `\\[` with `\\\\[` before render...

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
