### PR TITLE
moderation_filter bug fix in fastchat/serve/gradio_block_arena_named.py

### DIFF
--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -179,7 +179,7 @@ def add_text(
 
     model_list = [states[i].model_name for i in range(num_sides)]
     all_conv_text_left = states[0].conv.get_prompt()
-    all_conv_text_right = states[0].conv.get_prompt()
+    all_conv_text_right = states[1].conv.get_prompt()
     all_conv_text = (
         all_conv_text_left[-1000:] + all_conv_text_right[-1000:] + "\nuser: " + text
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`all_conv_text` in `add_text` used for moderation_filter only includes text from the left chatbot.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ x ] I've run `format.sh` to lint the changes in this PR.
- [ x ] I've included any doc changes needed.
- [ x ] I've made sure the relevant tests are passing (if applicable).
