### PR TITLE
add seed params support from vllm_worker

### DIFF
--- a/fastchat/protocol/openai_api_protocol.py
+++ b/fastchat/protocol/openai_api_protocol.py
@@ -72,6 +72,7 @@ class ChatCompletionRequest(BaseModel):
     presence_penalty: Optional[float] = 0.0
     frequency_penalty: Optional[float] = 0.0
     user: Optional[str] = None
+    seed: Optional[int] = None
 
 
 class ChatMessage(BaseModel):
@@ -166,6 +167,7 @@ class CompletionRequest(BaseModel):
     user: Optional[str] = None
     use_beam_search: Optional[bool] = False
     best_of: Optional[int] = None
+    seed: Optional[int] = None
 
 
 class CompletionResponseChoice(BaseModel):

--- a/fastchat/serve/vllm_worker.py
+++ b/fastchat/serve/vllm_worker.py
@@ -82,6 +82,7 @@ class VLLMWorker(BaseModelWorker):
         echo = params.get("echo", True)
         use_beam_search = params.get("use_beam_search", False)
         best_of = params.get("best_of", None)
+        seed = params.get("seed", None)
 
         request = params.get("request", None)
 
@@ -115,6 +116,7 @@ class VLLMWorker(BaseModelWorker):
             presence_penalty=presence_penalty,
             frequency_penalty=frequency_penalty,
             best_of=best_of,
+            seed=seed,
         )
         results_generator = engine.generate(context, sampling_params, request_id)
 


### PR DESCRIPTION
Add `seed` parameter support for openai api protocol.

I tested vllm_worker:

```bash
python3 -m fastchat.serve.controller
CUDA_VISIBLE_DEVICES=0 python3 -m fastchat.serve.vllm_worker --model-path facebook/opt-125m --model-names opt-125m --controller http://localhost:21001 --port 31001 --worker-address http://localhost:31001
python3 -m fastchat.serve.openai_api_server --host 0.0.0.0 --controller-address http://127.0.0.1:21001 --port 8000
```

The following code will produce same output

```python
from openai import OpenAI
client = OpenAI(
    base_url="http://localhost:8000/v1",
    api_key="token-abc123",
)
completion = client.chat.completions.create(
        model="opt-125m",
        messages=[
            {"role": "user", "content": "Hello!"}
        ],
        seed=1,
        max_tokens=200,
    )
print(completion.choices[0].message.content)
```

Note that other types of worker may not reproduce same output.

Maybe related to these issues: [issue 3215](https://github.com/lm-sys/FastChat/issues/3215), [issue 3216](https://github.com/lm-sys/FastChat/issues/3216)