### PR TITLE
Update sglang_worker.py to fix #3372 error launching SGLand worker

### DIFF
--- a/fastchat/serve/sglang_worker.py
+++ b/fastchat/serve/sglang_worker.py
@@ -293,7 +293,6 @@ if __name__ == "__main__":
         trust_remote_code=args.trust_remote_code,
         mem_fraction_static=args.mem_fraction_static,
         tp_size=args.tp_size,
-        log_level="info",
     )
     sgl.set_default_backend(runtime)
 


### PR DESCRIPTION
This commit fixes the issue #3372

## Why are these changes needed?

While launching SGLang worker it resulted in an error 
```
TypeError: sglang.srt.server_args.ServerArgs() got multiple values for keyword argument 'log_level'
```

## Related issue number (if applicable)

#3372 

## Checks

- [X] I've run `format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed.
- [X] I've made sure the relevant tests are passing (if applicable).
