### PR TITLE
Update model_adapter.py

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1744,7 +1744,9 @@ class QwenChatAdapter(BaseModelAdapter):
         )
         # NOTE: if you use the old version of model file, please remove the comments below
         # config.use_flash_attn = False
-        self.float_set(config, "fp16")
+        # Due to the removal of the "fp16" attribute from Qwen2's config, the following conditional statement needs to be added if a Qwen2 model is to be used:
+        if( "qwen2" not in str(config.__class__) ): 
+            self.float_set(config, "fp16")
         generation_config = GenerationConfig.from_pretrained(
             model_path, trust_remote_code=True
         )


### PR DESCRIPTION
        # Due to the removal of the "fp16" attribute from Qwen2's config, the following conditional statement needs to be added if a Qwen2 model is to be used:
        if( "qwen2" not in str(config.__class__) ): 
            self.float_set(config, "fp16")

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
