### PR TITLE
Merged duplicate `GeminiAdapter` class definitions

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1209,6 +1209,8 @@ class GeminiAdapter(BaseModelAdapter):
         raise NotImplementedError()
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
+        if "gemini-1.5-pro" in model_path:
+            return get_conv_template("gemini-1.5-pro")
         return get_conv_template("gemini")
 
 
@@ -2188,21 +2190,6 @@ class DeepseekChatAdapter(BaseModelAdapter):
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("deepseek-chat")
-
-
-class GeminiAdapter(BaseModelAdapter):
-    """The model adapter for Gemini"""
-
-    def match(self, model_path: str):
-        return "gemini" in model_path.lower() or "bard" in model_path.lower()
-
-    def load_model(self, model_path: str, from_pretrained_kwargs: dict):
-        raise NotImplementedError()
-
-    def get_default_conv_template(self, model_path: str) -> Conversation:
-        if "gemini-1.5-pro" in model_path:
-            return get_conv_template("gemini-1.5-pro")
-        return get_conv_template("gemini")
 
 
 class Yuan2Adapter(BaseModelAdapter):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR addresses the issue of duplicate `GeminiAdapter` class definitions found in the codebase. 
The changes aim to merge the two identical class definitions, keeping the more specific implementation of the `get_default_conv_template` method. 
This will resolve potential confusion and issues with class resolution.

## Changes made

- Removed the duplicate `GeminiAdapter` class definition
- Updated the remaining `GeminiAdapter` class to include the more specific `get_default_conv_template` method
 
## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->
Closes #3462 

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
