### PR TITLE
removed a duplicate line

### DIFF
--- a/fastchat/train/train.py
+++ b/fastchat/train/train.py
@@ -207,7 +207,6 @@ class LazySupervisedDataset(Dataset):
 
     def __init__(self, raw_data, tokenizer: transformers.PreTrainedTokenizer):
         super(LazySupervisedDataset, self).__init__()
-        self.tokenizer = tokenizer
 
         rank0_print("Formatting inputs...Skip in lazy mode")
         self.tokenizer = tokenizer


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In the `fastchat/train/train.py` file, I found a repeated assignment of the tokenizer in the `LazySupervisedDataset` class.
```python
class LazySupervisedDataset(Dataset):
    """Dataset for supervised fine-tuning."""

    def __init__(self, raw_data, tokenizer: transformers.PreTrainedTokenizer):
        super(LazySupervisedDataset, self).__init__()
        self.tokenizer = tokenizer # <<------- this is a duplicate line.

        rank0_print("Formatting inputs...Skip in lazy mode")
        self.tokenizer = tokenizer 
        self.raw_data = raw_data
        self.cached_data_dict = {}
```
Therefore, I removed the duplicate line.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
