### PR TITLE
Enable vision arena across all tabs

### DIFF
--- a/fastchat/serve/gradio_block_arena_vision.py
+++ b/fastchat/serve/gradio_block_arena_vision.py
@@ -214,7 +214,7 @@ def moderate_input(state, text, all_conv_text, model_list, images, ip):
 def add_text(
     state,
     model_selector,
-    chat_input,
+    chat_input: Union[str, dict],
     context: Context,
     request: gr.Request,
 ):

--- a/fastchat/serve/gradio_block_arena_vision.py
+++ b/fastchat/serve/gradio_block_arena_vision.py
@@ -146,14 +146,18 @@ def clear_history(request: gr.Request):
     ip = get_ip(request)
     logger.info(f"clear_history. ip: {ip}")
     state = None
-    return (state, [], None) + (disable_btn,) * 5
+    return (state, [], enable_multimodal, invisible_text, invisible_btn) + (
+        disable_btn,
+    ) * 5
 
 
 def clear_history_example(request: gr.Request):
     ip = get_ip(request)
     logger.info(f"clear_history_example. ip: {ip}")
     state = None
-    return (state, [], enable_multimodal) + (disable_btn,) * 5
+    return (state, [], enable_multimodal, invisible_text, invisible_btn) + (
+        disable_btn,
+    ) * 5
 
 
 # TODO(Chris): At some point, we would like this to be a live-reporting feature.
@@ -242,7 +246,9 @@ def add_text(
 
     if len(text) <= 0:
         state.skip_next = True
-        return (state, state.to_gradio_chatbot(), None) + (no_change_btn,) * 5
+        return (state, state.to_gradio_chatbot(), None, "", no_change_btn) + (
+            no_change_btn,
+        ) * 5
 
     all_conv_text = state.conv.get_prompt()
     all_conv_text = all_conv_text[-2000:] + "\nuser: " + text
@@ -256,22 +262,36 @@ def add_text(
     if image_flagged:
         logger.info(f"image flagged. ip: {ip}. text: {text}")
         state.skip_next = True
-        return (state, state.to_gradio_chatbot(), {"text": IMAGE_MODERATION_MSG}) + (
+        return (
+            state,
+            state.to_gradio_chatbot(),
+            {"text": IMAGE_MODERATION_MSG},
+            "",
             no_change_btn,
-        ) * 5
+        ) + (no_change_btn,) * 5
 
     if (len(state.conv.messages) - state.conv.offset) // 2 >= CONVERSATION_TURN_LIMIT:
         logger.info(f"conversation turn limit. ip: {ip}. text: {text}")
         state.skip_next = True
-        return (state, state.to_gradio_chatbot(), {"text": CONVERSATION_LIMIT_MSG}) + (
+        return (
+            state,
+            state.to_gradio_chatbot(),
+            {"text": CONVERSATION_LIMIT_MSG},
+            "",
             no_change_btn,
-        ) * 5
+        ) + (no_change_btn,) * 5
 
     text = text[:INPUT_CHAR_LEN_LIMIT]  # Hard cut-off
     text = _prepare_text_with_image(state, text, images, csam_flag=csam_flag)
     state.conv.append_message(state.conv.roles[0], text)
     state.conv.append_message(state.conv.roles[1], None)
-    return (state, state.to_gradio_chatbot(), None) + (disable_btn,) * 5
+    return (
+        state,
+        state.to_gradio_chatbot(),
+        disable_multimodal,
+        visible_text,
+        enable_btn,
+    ) + (disable_btn,) * 5
 
 
 def build_single_vision_language_model_ui(
@@ -318,15 +338,6 @@ Note: You can only chat with <span style='color: #DE3163; font-weight: bold'>one
             gr.Markdown(model_description_md, elem_id="model_description_markdown")
 
     with gr.Row():
-        textbox = gr.MultimodalTextbox(
-            file_types=["image"],
-            show_label=False,
-            placeholder="Enter your prompt or add image here",
-            container=True,
-            render=False,
-            elem_id="input_box",
-        )
-
         with gr.Column(scale=2, visible=False) as image_column:
             imagebox = gr.Image(
                 type="pil",
@@ -339,9 +350,24 @@ Note: You can only chat with <span style='color: #DE3163; font-weight: bold'>one
             )
 
     with gr.Row():
-        textbox.render()
-        # with gr.Column(scale=1, min_width=50):
-        #     send_btn = gr.Button(value="Send", variant="primary")
+        textbox = gr.Textbox(
+            show_label=False,
+            placeholder="👉 Enter your prompt and press ENTER",
+            elem_id="input_box",
+            visible=False,
+        )
+
+        send_btn = gr.Button(
+            value="Send", variant="primary", scale=0, visible=False, interactive=False
+        )
+
+        multimodal_textbox = gr.MultimodalTextbox(
+            file_types=["image"],
+            show_label=False,
+            placeholder="Enter your prompt or add image here",
+            container=True,
+            elem_id="input_box",
+        )
 
     with gr.Row(elem_id="buttons"):
         if random_questions:
@@ -354,22 +380,6 @@ Note: You can only chat with <span style='color: #DE3163; font-weight: bold'>one
         flag_btn = gr.Button(value="⚠️  Flag", interactive=False)
         regenerate_btn = gr.Button(value="🔄  Regenerate", interactive=False)
         clear_btn = gr.Button(value="🗑️  Clear", interactive=False)
-
-    cur_dir = os.path.dirname(os.path.abspath(__file__))
-
-    examples = gr.Examples(
-        examples=[
-            {
-                "text": "How can I prepare a delicious meal using these ingredients?",
-                "files": [f"{cur_dir}/example_images/fridge.jpg"],
-            },
-            {
-                "text": "What might the woman on the right be thinking about?",
-                "files": [f"{cur_dir}/example_images/distracted.jpg"],
-            },
-        ],
-        inputs=[textbox],
-    )
 
     with gr.Accordion("Parameters", open=False) as parameter_row:
         temperature = gr.Slider(
@@ -422,23 +432,50 @@ Note: You can only chat with <span style='color: #DE3163; font-weight: bold'>one
         [state, temperature, top_p, max_output_tokens],
         [state, chatbot] + btn_list,
     )
-    clear_btn.click(clear_history, None, [state, chatbot, textbox] + btn_list)
-
-    model_selector.change(
-        clear_history, None, [state, chatbot, textbox] + btn_list
-    ).then(set_visible_image, [textbox], [image_column])
-    examples.dataset.click(
-        clear_history_example, None, [state, chatbot, textbox] + btn_list
+    clear_btn.click(
+        clear_history,
+        None,
+        [state, chatbot, multimodal_textbox, textbox, send_btn] + btn_list,
     )
 
-    textbox.input(add_image, [textbox], [imagebox]).then(
-        set_visible_image, [textbox], [image_column]
-    ).then(clear_history_example, None, [state, chatbot, textbox] + btn_list)
+    model_selector.change(
+        clear_history,
+        None,
+        [state, chatbot, multimodal_textbox, textbox, send_btn] + btn_list,
+    ).then(set_visible_image, [multimodal_textbox], [image_column])
+
+    multimodal_textbox.input(add_image, [multimodal_textbox], [imagebox]).then(
+        set_visible_image, [multimodal_textbox], [image_column]
+    ).then(
+        clear_history_example,
+        None,
+        [state, chatbot, multimodal_textbox, textbox, send_btn] + btn_list,
+    )
+
+    multimodal_textbox.submit(
+        add_text,
+        [state, model_selector, multimodal_textbox, context_state],
+        [state, chatbot, multimodal_textbox, textbox, send_btn] + btn_list,
+    ).then(set_invisible_image, [], [image_column]).then(
+        bot_response,
+        [state, temperature, top_p, max_output_tokens],
+        [state, chatbot] + btn_list,
+    )
 
     textbox.submit(
         add_text,
         [state, model_selector, textbox, context_state],
-        [state, chatbot, textbox] + btn_list,
+        [state, chatbot, multimodal_textbox, textbox, send_btn] + btn_list,
+    ).then(set_invisible_image, [], [image_column]).then(
+        bot_response,
+        [state, temperature, top_p, max_output_tokens],
+        [state, chatbot] + btn_list,
+    )
+
+    send_btn.click(
+        add_text,
+        [state, model_selector, textbox, context_state],
+        [state, chatbot, multimodal_textbox, textbox, send_btn] + btn_list,
     ).then(set_invisible_image, [], [image_column]).then(
         bot_response,
         [state, temperature, top_p, max_output_tokens],
@@ -449,9 +486,11 @@ Note: You can only chat with <span style='color: #DE3163; font-weight: bold'>one
         random_btn.click(
             get_vqa_sample,  # First, get the VQA sample
             [],  # Pass the path to the VQA samples
-            [textbox, imagebox],  # Outputs are textbox and imagebox
-        ).then(set_visible_image, [textbox], [image_column]).then(
-            clear_history_example, None, [state, chatbot, textbox] + btn_list
+            [multimodal_textbox, imagebox],  # Outputs are textbox and imagebox
+        ).then(set_visible_image, [multimodal_textbox], [image_column]).then(
+            clear_history_example,
+            None,
+            [state, chatbot, multimodal_textbox, textbox, send_btn] + btn_list,
         )
 
     return [state, model_selector]

--- a/fastchat/serve/gradio_block_arena_vision.py
+++ b/fastchat/serve/gradio_block_arena_vision.py
@@ -213,8 +213,8 @@ def moderate_input(state, text, all_conv_text, model_list, images, ip):
 
 def add_text(
     state,
-    model_selector: str,
-    chat_input: Union[str, dict],
+    model_selector,
+    chat_input,
     context: Context,
     request: gr.Request,
 ):

--- a/fastchat/serve/gradio_block_arena_vision.py
+++ b/fastchat/serve/gradio_block_arena_vision.py
@@ -212,7 +212,11 @@ def moderate_input(state, text, all_conv_text, model_list, images, ip):
 
 
 def add_text(
-    state, model_selector: str, chat_input: Union[str, dict], context: Context, request: gr.Request
+    state,
+    model_selector: str,
+    chat_input: Union[str, dict],
+    context: Context,
+    request: gr.Request,
 ):
     if isinstance(chat_input, dict):
         text, images = chat_input["text"], chat_input["files"]

--- a/fastchat/serve/gradio_block_arena_vision.py
+++ b/fastchat/serve/gradio_block_arena_vision.py
@@ -10,7 +10,7 @@ python3 -m fastchat.serve.gradio_web_server_multi --share --vision-arena
 import json
 import os
 import time
-from typing import List
+from typing import List, Union
 
 import gradio as gr
 from gradio.data_classes import FileData
@@ -212,9 +212,12 @@ def moderate_input(state, text, all_conv_text, model_list, images, ip):
 
 
 def add_text(
-    state, model_selector: str, chat_input, context: Context, request: gr.Request
+    state, model_selector: str, chat_input: Union[str, dict], context: Context, request: gr.Request
 ):
-    text, images = chat_input["text"], chat_input["files"]
+    if isinstance(chat_input, dict):
+        text, images = chat_input["text"], chat_input["files"]
+    else:
+        text, images = chat_input, []
 
     if (
         len(images) > 0

--- a/fastchat/serve/gradio_block_arena_vision.py
+++ b/fastchat/serve/gradio_block_arena_vision.py
@@ -211,10 +211,16 @@ def moderate_input(state, text, all_conv_text, model_list, images, ip):
     return text, image_flagged, csam_flagged
 
 
-def add_text(state, model_selector: str, chat_input, context: Context, request: gr.Request):
+def add_text(
+    state, model_selector: str, chat_input, context: Context, request: gr.Request
+):
     text, images = chat_input["text"], chat_input["files"]
 
-    if len(images) > 0 and model_selector in context.text_models and model_selector not in context.vision_models:
+    if (
+        len(images) > 0
+        and model_selector in context.text_models
+        and model_selector not in context.vision_models
+    ):
         gr.Warning(f"{model_selector} is a text-only model. Image is ignored.")
         images = []
 
@@ -289,14 +295,17 @@ Note: You can only chat with <span style='color: #DE3163; font-weight: bold'>one
         with gr.Row(elem_id="model_selector_row"):
             model_selector = gr.Dropdown(
                 choices=text_and_vision_models,
-                value=text_and_vision_models[0] if len(text_and_vision_models) > 0 else "",
+                value=text_and_vision_models[0]
+                if len(text_and_vision_models) > 0
+                else "",
                 interactive=True,
                 show_label=False,
                 container=False,
             )
 
         with gr.Accordion(
-            f"🔍 Expand to see the descriptions of {len(text_and_vision_models)} models", open=False
+            f"🔍 Expand to see the descriptions of {len(text_and_vision_models)} models",
+            open=False,
         ):
             model_description_md = get_model_description_md(text_and_vision_models)
             gr.Markdown(model_description_md, elem_id="model_description_markdown")

--- a/fastchat/serve/gradio_block_arena_vision_anony.py
+++ b/fastchat/serve/gradio_block_arena_vision_anony.py
@@ -115,7 +115,7 @@ def get_vqa_sample():
     return (res, path)
 
 
-def load_demo_side_by_side_vision_anony(url_params):
+def load_demo_side_by_side_vision_anony():
     states = [None] * num_sides
     selector_updates = [
         gr.Markdown(visible=True),

--- a/fastchat/serve/gradio_block_arena_vision_anony.py
+++ b/fastchat/serve/gradio_block_arena_vision_anony.py
@@ -245,7 +245,13 @@ def clear_history(request: gr.Request):
 
 
 def add_text(
-    state0, state1, model_selector0, model_selector1, chat_input, context: Context, request: gr.Request
+    state0,
+    state1,
+    model_selector0,
+    model_selector1,
+    chat_input,
+    context: Context,
+    request: gr.Request,
 ):
     if isinstance(chat_input, dict):
         text, images = chat_input["text"], chat_input["files"]

--- a/fastchat/serve/gradio_block_arena_vision_anony.py
+++ b/fastchat/serve/gradio_block_arena_vision_anony.py
@@ -45,7 +45,6 @@ from fastchat.serve.gradio_block_arena_anony import (
     regenerate,
     clear_history,
     share_click,
-    add_text,
     bot_response_multi,
     set_global_vars_anony,
     load_demo_side_by_side_anony,
@@ -117,11 +116,11 @@ def get_vqa_sample():
 
 
 def load_demo_side_by_side_vision_anony(url_params):
-    states = (None,) * num_sides
-    selector_updates = (
+    states = [None] * num_sides
+    selector_updates = [
         gr.Markdown(visible=True),
         gr.Markdown(visible=True),
-    )
+    ]
 
     return states + selector_updates
 
@@ -250,7 +249,7 @@ def add_text(
     state1,
     model_selector0,
     model_selector1,
-    chat_input: Union[str, dict],
+    chat_input,
     context: Context,
     request: gr.Request,
 ):

--- a/fastchat/serve/gradio_block_arena_vision_anony.py
+++ b/fastchat/serve/gradio_block_arena_vision_anony.py
@@ -8,6 +8,7 @@ import time
 
 import gradio as gr
 import numpy as np
+from typing import Union
 
 from fastchat.constants import (
     TEXT_MODERATION_MSG,
@@ -249,7 +250,7 @@ def add_text(
     state1,
     model_selector0,
     model_selector1,
-    chat_input,
+    chat_input: Union[str, dict],
     context: Context,
     request: gr.Request,
 ):

--- a/fastchat/serve/gradio_block_arena_vision_anony.py
+++ b/fastchat/serve/gradio_block_arena_vision_anony.py
@@ -399,6 +399,7 @@ def build_side_by_side_vision_ui_anony(context: Context, random_questions=None):
     chatbots = [None] * num_sides
     context_state = gr.State(context)
     gr.Markdown(notice_markdown, elem_id="notice_markdown")
+    text_and_vision_models = list(set(context.text_models + context.vision_models))
 
     with gr.Row():
         with gr.Column(scale=2, visible=False) as image_column:
@@ -411,11 +412,11 @@ def build_side_by_side_vision_ui_anony(context: Context, random_questions=None):
         with gr.Column(scale=5):
             with gr.Group(elem_id="share-region-anony"):
                 with gr.Accordion(
-                    f"🔍 Expand to see the descriptions of {len(context.text_models) + len(context.vision_models)} models",
+                    f"🔍 Expand to see the descriptions of {len(text_and_vision_models)} models",
                     open=False,
                 ):
                     model_description_md = get_model_description_md(
-                        context.text_models + context.vision_models
+                        text_and_vision_models
                     )
                     gr.Markdown(
                         model_description_md, elem_id="model_description_markdown"

--- a/fastchat/serve/gradio_block_arena_vision_anony.py
+++ b/fastchat/serve/gradio_block_arena_vision_anony.py
@@ -249,7 +249,7 @@ def add_text(
     state1,
     model_selector0,
     model_selector1,
-    chat_input,
+    chat_input: Union[str, dict],
     context: Context,
     request: gr.Request,
 ):

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -478,7 +478,11 @@ def build_side_by_side_vision_ui_named(context: Context, random_questions=None):
     ).then(
         flash_buttons, [], btn_list
     )
-    clear_btn.click(clear_history, None, states + chatbots + [multimodal_textbox, textbox, send_btn] + btn_list)
+    clear_btn.click(
+        clear_history,
+        None,
+        states + chatbots + [multimodal_textbox, textbox, send_btn] + btn_list,
+    )
 
     share_js = """
 function (a, b, c, d) {

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -478,7 +478,7 @@ def build_side_by_side_vision_ui_named(context: Context, random_questions=None):
     ).then(
         flash_buttons, [], btn_list
     )
-    clear_btn.click(clear_history, None, states + chatbots + [textbox] + btn_list)
+    clear_btn.click(clear_history, None, states + chatbots + [multimodal_textbox, textbox, send_btn] + btn_list)
 
     share_js = """
 function (a, b, c, d) {

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -6,7 +6,7 @@ Users chat with two chosen models.
 import json
 import os
 import time
-from typing import List
+from typing import List, Union
 
 import gradio as gr
 import numpy as np
@@ -186,11 +186,14 @@ def add_text(
     state1,
     model_selector0,
     model_selector1,
-    chat_input,
+    chat_input: Union[str, dict],
     context: Context,
     request: gr.Request,
 ):
-    text, images = chat_input["text"], chat_input["files"]
+    if isinstance(chat_input, dict):
+        text, images = chat_input["text"], chat_input["files"]
+    else:
+        text, images = chat_input, []
 
     if len(images) > 0:
         if (

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -64,7 +64,7 @@ num_sides = 2
 enable_moderation = False
 
 
-def load_demo_side_by_side_vision_named(context: Context, url_params):
+def load_demo_side_by_side_vision_named(context: Context):
     states = [None] * num_sides
 
     # default to the text models

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -186,7 +186,7 @@ def add_text(
     state1,
     model_selector0,
     model_selector1,
-    chat_input,
+    chat_input: Union[str, dict],
     context: Context,
     request: gr.Request,
 ):

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -63,9 +63,10 @@ logger = build_logger("gradio_web_server_multi", "gradio_web_server_multi.log")
 num_sides = 2
 enable_moderation = False
 
+
 def load_demo_side_by_side_vision_named(context: Context, url_params):
     states = (None,) * num_sides
-    
+
     # default to the text models
     models = context.text_models
 
@@ -83,6 +84,7 @@ def load_demo_side_by_side_vision_named(context: Context, url_params):
     )
 
     return states + selector_updates
+
 
 def clear_history_example(request: gr.Request):
     logger.info(f"clear_history_example (named). ip: {get_ip(request)}")
@@ -180,18 +182,30 @@ def clear_history(request: gr.Request):
 
 
 def add_text(
-    state0, state1, model_selector0, model_selector1, chat_input, context: Context, request: gr.Request
+    state0,
+    state1,
+    model_selector0,
+    model_selector1,
+    chat_input,
+    context: Context,
+    request: gr.Request,
 ):
     text, images = chat_input["text"], chat_input["files"]
 
     if len(images) > 0:
-        if model_selector0 in context.text_models and model_selector0 not in context.vision_models:
+        if (
+            model_selector0 in context.text_models
+            and model_selector0 not in context.vision_models
+        ):
             gr.Warning(f"{model_selector0} is a text-only model. Image is ignored.")
-        if model_selector1 in context.text_models and model_selector1 not in context.vision_models:
+        if (
+            model_selector1 in context.text_models
+            and model_selector1 not in context.vision_models
+        ):
             gr.Warning(f"{model_selector1} is a text-only model. Image is ignored.")
 
         images = []
-        
+
     ip = get_ip(request)
     logger.info(f"add_text (named). ip: {ip}. len: {len(text)}")
     states = [state0, state1]
@@ -278,6 +292,7 @@ def add_text(
         * 6
     )
 
+
 def build_side_by_side_vision_ui_named(context: Context, random_questions=None):
     notice_markdown = """
 # ⚔️  LMSYS Chatbot Arena (Multimodal): Benchmarking LLMs and VLMs in the Wild
@@ -317,7 +332,9 @@ def build_side_by_side_vision_ui_named(context: Context, random_questions=None):
                     f"🔍 Expand to see the descriptions of {len(text_and_vision_models)} models",
                     open=False,
                 ):
-                    model_description_md = get_model_description_md(text_and_vision_models)
+                    model_description_md = get_model_description_md(
+                        text_and_vision_models
+                    )
                     gr.Markdown(
                         model_description_md, elem_id="model_description_markdown"
                     )
@@ -327,7 +344,9 @@ def build_side_by_side_vision_ui_named(context: Context, random_questions=None):
                         with gr.Column():
                             model_selectors[i] = gr.Dropdown(
                                 choices=text_and_vision_models,
-                                value=text_and_vision_models[i] if len(text_and_vision_models) > i else "",
+                                value=text_and_vision_models[i]
+                                if len(text_and_vision_models) > i
+                                else "",
                                 interactive=True,
                                 show_label=False,
                                 container=False,

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -82,9 +82,10 @@ def load_demo_side_by_side_vision_named(context: Context):
     else:
         model_right = model_left
 
+    all_models = list(set(context.text_models + context.vision_models))
     selector_updates = [
-        gr.Dropdown(choices=models, value=model_left, visible=True),
-        gr.Dropdown(choices=models, value=model_right, visible=True),
+        gr.Dropdown(choices=all_models, value=model_left, visible=True),
+        gr.Dropdown(choices=all_models, value=model_right, visible=True),
     ]
 
     return states + selector_updates

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -65,7 +65,7 @@ enable_moderation = False
 
 
 def load_demo_side_by_side_vision_named(context: Context, url_params):
-    states = (None,) * num_sides
+    states = [None] * num_sides
 
     # default to the text models
     models = context.text_models
@@ -78,10 +78,10 @@ def load_demo_side_by_side_vision_named(context: Context, url_params):
     else:
         model_right = model_left
 
-    selector_updates = (
+    selector_updates = [
         gr.Dropdown(choices=models, value=model_left, visible=True),
         gr.Dropdown(choices=models, value=model_right, visible=True),
-    )
+    ]
 
     return states + selector_updates
 
@@ -186,7 +186,7 @@ def add_text(
     state1,
     model_selector0,
     model_selector1,
-    chat_input: Union[str, dict],
+    chat_input,
     context: Context,
     request: gr.Request,
 ):

--- a/fastchat/serve/gradio_global_state.py
+++ b/fastchat/serve/gradio_global_state.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass, field
+from typing import List
+
+@dataclass
+class Context:
+    text_models: List[str] = field(default_factory=list)
+    all_text_models: List[str] = field(default_factory=list)
+    vision_models: List[str] = field(default_factory=list)
+    all_vision_models: List[str] = field(default_factory=list)

--- a/fastchat/serve/gradio_global_state.py
+++ b/fastchat/serve/gradio_global_state.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import List
 
+
 @dataclass
 class Context:
     text_models: List[str] = field(default_factory=list)

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -233,7 +233,8 @@ def load_demo_single(context: Context, query_params):
         if model in models:
             selected_model = model
 
-    dropdown_update = gr.Dropdown(choices=models, value=selected_model, visible=True)
+    all_models = list(set(context.text_models + context.vision_models))
+    dropdown_update = gr.Dropdown(choices=all_models, value=selected_model, visible=True)
     state = None
     return [state, dropdown_update]
 

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -223,13 +223,13 @@ def get_model_list(controller_url, register_api_endpoint_file, vision_arena):
     return visible_models, models
 
 
-def load_demo_single(context: Context, url_params):
+def load_demo_single(context: Context, query_params):
     # default to text models
     models = context.text_models
 
     selected_model = models[0] if len(models) > 0 else ""
-    if "model" in url_params:
-        model = url_params["model"]
+    if "model" in query_params:
+        model = query_params["model"]
         if model in models:
             selected_model = model
 

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -152,11 +152,16 @@ class State:
         return base
 
 
-def set_global_vars(controller_url_, enable_moderation_, use_remote_storage_,):
+def set_global_vars(
+    controller_url_,
+    enable_moderation_,
+    use_remote_storage_,
+):
     global controller_url, enable_moderation, use_remote_storage
     controller_url = controller_url_
     enable_moderation = enable_moderation_
     use_remote_storage = use_remote_storage_
+
 
 def get_conv_log_filename(is_vision=False, has_csam_image=False):
     t = datetime.datetime.now()

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -234,7 +234,9 @@ def load_demo_single(context: Context, query_params):
             selected_model = model
 
     all_models = list(set(context.text_models + context.vision_models))
-    dropdown_update = gr.Dropdown(choices=all_models, value=selected_model, visible=True)
+    dropdown_update = gr.Dropdown(
+        choices=all_models, value=selected_model, visible=True
+    )
     state = None
     return [state, dropdown_update]
 

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -235,7 +235,7 @@ def load_demo_single(context: Context, url_params):
 
     dropdown_update = gr.Dropdown(choices=models, value=selected_model, visible=True)
     state = None
-    return state, dropdown_update
+    return [state, dropdown_update]
 
 
 def load_demo(url_params, request: gr.Request):

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -11,6 +11,7 @@ import os
 import random
 import time
 import uuid
+from typing import List
 
 import gradio as gr
 import requests
@@ -32,6 +33,7 @@ from fastchat.model.model_adapter import (
 )
 from fastchat.model.model_registry import get_model_info, model_info
 from fastchat.serve.api_provider import get_api_provider_stream_iter
+from fastchat.serve.gradio_global_state import Context
 from fastchat.serve.remote_logger import get_remote_logger
 from fastchat.utils import (
     build_logger,
@@ -150,12 +152,11 @@ class State:
         return base
 
 
-def set_global_vars(controller_url_, enable_moderation_, use_remote_storage_):
+def set_global_vars(controller_url_, enable_moderation_, use_remote_storage_,):
     global controller_url, enable_moderation, use_remote_storage
     controller_url = controller_url_
     enable_moderation = enable_moderation_
     use_remote_storage = use_remote_storage_
-
 
 def get_conv_log_filename(is_vision=False, has_csam_image=False):
     t = datetime.datetime.now()
@@ -217,7 +218,10 @@ def get_model_list(controller_url, register_api_endpoint_file, vision_arena):
     return visible_models, models
 
 
-def load_demo_single(models, url_params):
+def load_demo_single(context: Context, url_params):
+    # default to text models
+    models = context.text_models
+
     selected_model = models[0] if len(models) > 0 else ""
     if "model" in url_params:
         model = url_params["model"]

--- a/fastchat/serve/gradio_web_server_multi.py
+++ b/fastchat/serve/gradio_web_server_multi.py
@@ -62,15 +62,15 @@ def load_demo(context: Context, url_params, request: gr.Request):
     if "arena" in request.query_params:
         inner_selected = 0
     elif "vision" in request.query_params:
-        inner_selected = 1
+        inner_selected = 0
     elif "compare" in request.query_params:
         inner_selected = 1
     elif "direct" in request.query_params or "model" in request.query_params:
-        inner_selected = 3
+        inner_selected = 2
     elif "leaderboard" in request.query_params:
-        inner_selected = 4
+        inner_selected = 3
     elif "about" in request.query_params:
-        inner_selected = 5
+        inner_selected = 4
 
     if args.model_list_mode == "reload":
         context.text_models, context.all_text_models = get_model_list(
@@ -90,7 +90,7 @@ def load_demo(context: Context, url_params, request: gr.Request):
         side_by_side_anony_updates = load_demo_side_by_side_vision_anony()
 
         side_by_side_named_updates = load_demo_side_by_side_vision_named(
-            context,
+            context, 
         )
 
         direct_chat_updates = load_demo_single(context, request.query_params)

--- a/fastchat/serve/gradio_web_server_multi.py
+++ b/fastchat/serve/gradio_web_server_multi.py
@@ -86,36 +86,26 @@ def load_demo(context: Context, url_params, request: gr.Request):
         )
 
     # Text models
-    single_updates = load_demo_single(context.text_models, [], url_params)
-    side_by_side_anony_updates = load_demo_side_by_side_anony(
-        context.all_text_models, url_params
-    )
-    side_by_side_named_updates = load_demo_side_by_side_named(
-        context.text_models, url_params
-    )
-
-    # Multimodal model support
-    side_by_side_vision_anony_updates = load_demo_side_by_side_vision_anony(url_params)
-
-    side_by_side_vision_named_updates = load_demo_side_by_side_vision_named(
-        context, url_params
-    )
-
-    vision_direct_chat_updates = load_demo_single(context, url_params)
-
-    tabs_list = []
     if args.vision_arena:
-        tabs_list = (
-            side_by_side_vision_anony_updates
-            + side_by_side_vision_named_updates
-            + vision_direct_chat_updates
-        )
-    else:
-        tabs_list = (
-            side_by_side_anony_updates + side_by_side_named_updates + single_updates
+        side_by_side_anony_updates = load_demo_side_by_side_vision_anony(url_params)
+
+        side_by_side_named_updates = load_demo_side_by_side_vision_named(
+            context, url_params
         )
 
-    return (gr.Tabs(selected=inner_selected),) + tabs_list
+        direct_chat_updates = load_demo_single(context, url_params)
+    else:
+        direct_chat_updates = load_demo_single(context.text_models, [], url_params)
+        side_by_side_anony_updates = load_demo_side_by_side_anony(
+            context.all_text_models, url_params
+        )
+        side_by_side_named_updates = load_demo_side_by_side_named(
+            context.text_models, url_params
+        )
+
+    tabs_list = [gr.Tabs(selected=inner_selected)] + side_by_side_anony_updates + side_by_side_named_updates + direct_chat_updates
+
+    return tabs_list
 
 
 def build_demo(context: Context, elo_results_file: str, leaderboard_table_file):
@@ -156,13 +146,13 @@ window.__gradio_mode__ = "app";
                         context,
                         random_questions=args.random_questions,
                     )
-                with gr.Tab("⚔️ Arena (side-by-side)", id=2) as side_by_side_tab:
+                with gr.Tab("⚔️ Arena (side-by-side)", id=1) as side_by_side_tab:
                     side_by_side_tab.select(None, None, None, js=alert_js)
                     side_by_side_named_list = build_side_by_side_vision_ui_named(
                         context, random_questions=args.random_questions
                     )
 
-                with gr.Tab("💬 Direct Chat", id=3) as direct_tab:
+                with gr.Tab("💬 Direct Chat", id=2) as direct_tab:
                     direct_tab.select(None, None, None, js=alert_js)
                     single_model_list = build_single_vision_language_model_ui(
                         context,
@@ -177,32 +167,27 @@ window.__gradio_mode__ = "app";
                         context.all_text_models
                     )
 
-                with gr.Tab("⚔️ Arena (side-by-side)", id=2) as side_by_side_tab:
+                with gr.Tab("⚔️ Arena (side-by-side)", id=1) as side_by_side_tab:
                     side_by_side_tab.select(None, None, None, js=alert_js)
                     side_by_side_named_list = build_side_by_side_ui_named(
                         context.text_models
                     )
 
-                with gr.Tab("💬 Direct Chat", id=3) as direct_tab:
+                with gr.Tab("💬 Direct Chat", id=2) as direct_tab:
                     direct_tab.select(None, None, None, js=alert_js)
                     single_model_list = build_single_model_ui(
                         context.text_models, add_promotion_links=True
                     )
 
-            demo_tabs = (
-                [inner_tabs]
-                + side_by_side_anony_list
-                + side_by_side_named_list
-                + single_model_list
-            )
+            demo_tabs = [inner_tabs] + side_by_side_anony_list + side_by_side_named_list + single_model_list
 
             if elo_results_file:
-                with gr.Tab("🏆 Leaderboard", id=4):
+                with gr.Tab("🏆 Leaderboard", id=3):
                     build_leaderboard_tab(
                         elo_results_file, leaderboard_table_file, show_plot=True
                     )
 
-            with gr.Tab("ℹ️ About Us", id=5):
+            with gr.Tab("ℹ️ About Us", id=4):
                 about = build_about()
 
         url_params = gr.JSON(visible=False)
@@ -307,6 +292,7 @@ if __name__ == "__main__":
     logger.info(f"args: {args}")
 
     # Set global variables
+    set_global_vars(args.controller_url, args.moderate, args.use_remote_storage)
     set_global_vars_named(args.moderate)
     set_global_vars_anony(args.moderate)
     text_models, all_text_models = get_model_list(
@@ -320,7 +306,6 @@ if __name__ == "__main__":
         args.register_api_endpoint_file,
         vision_arena=True,
     )
-    set_global_vars(args.controller_url, args.moderate, args.use_remote_storage)
 
     context = Context(text_models, all_text_models, vision_models, all_vision_models)
 

--- a/fastchat/serve/gradio_web_server_multi.py
+++ b/fastchat/serve/gradio_web_server_multi.py
@@ -59,17 +59,17 @@ def load_demo(context: Context, url_params, request: gr.Request):
     logger.info(f"load_demo. ip: {ip}. params: {url_params}")
 
     inner_selected = 0
-    if "arena" in url_params:
+    if "arena" in request.query_params:
         inner_selected = 0
-    elif "vision" in url_params:
+    elif "vision" in request.query_params:
         inner_selected = 1
-    elif "compare" in url_params:
+    elif "compare" in request.query_params:
         inner_selected = 1
-    elif "direct" in url_params or "model" in url_params:
+    elif "direct" in request.query_params or "model" in request.query_params:
         inner_selected = 3
-    elif "leaderboard" in url_params:
+    elif "leaderboard" in request.query_params:
         inner_selected = 4
-    elif "about" in url_params:
+    elif "about" in request.query_params:
         inner_selected = 5
 
     if args.model_list_mode == "reload":
@@ -87,30 +87,33 @@ def load_demo(context: Context, url_params, request: gr.Request):
 
     # Text models
     if args.vision_arena:
-        side_by_side_anony_updates = load_demo_side_by_side_vision_anony(url_params)
+        side_by_side_anony_updates = load_demo_side_by_side_vision_anony()
 
         side_by_side_named_updates = load_demo_side_by_side_vision_named(
-            context, url_params
+            context,
         )
 
-        direct_chat_updates = load_demo_single(context, url_params)
+        direct_chat_updates = load_demo_single(context, request.query_params)
     else:
-        direct_chat_updates = load_demo_single(context.text_models, [], url_params)
+        direct_chat_updates = load_demo_single(context, request.query_params)
         side_by_side_anony_updates = load_demo_side_by_side_anony(
-            context.all_text_models, url_params
+            context.all_text_models, request.query_params
         )
         side_by_side_named_updates = load_demo_side_by_side_named(
-            context.text_models, url_params
+            context.text_models, request.query_params
         )
 
-    tabs_list = [gr.Tabs(selected=inner_selected)] + side_by_side_anony_updates + side_by_side_named_updates + direct_chat_updates
+    tabs_list = (
+        [gr.Tabs(selected=inner_selected)]
+        + side_by_side_anony_updates
+        + side_by_side_named_updates
+        + direct_chat_updates
+    )
 
     return tabs_list
 
 
 def build_demo(context: Context, elo_results_file: str, leaderboard_table_file):
-    context_state = gr.State(context)
-
     if args.show_terms_of_use:
         load_js = get_window_url_params_with_tos_js
     else:
@@ -179,7 +182,12 @@ window.__gradio_mode__ = "app";
                         context.text_models, add_promotion_links=True
                     )
 
-            demo_tabs = [inner_tabs] + side_by_side_anony_list + side_by_side_named_list + single_model_list
+            demo_tabs = (
+                [inner_tabs]
+                + side_by_side_anony_list
+                + side_by_side_named_list
+                + single_model_list
+            )
 
             if elo_results_file:
                 with gr.Tab("🏆 Leaderboard", id=3):
@@ -190,6 +198,7 @@ window.__gradio_mode__ = "app";
             with gr.Tab("ℹ️ About Us", id=4):
                 about = build_about()
 
+        context_state = gr.State(context)
         url_params = gr.JSON(visible=False)
 
         if args.model_list_mode not in ["once", "reload"]:

--- a/fastchat/serve/gradio_web_server_multi.py
+++ b/fastchat/serve/gradio_web_server_multi.py
@@ -90,7 +90,7 @@ def load_demo(context: Context, url_params, request: gr.Request):
         side_by_side_anony_updates = load_demo_side_by_side_vision_anony()
 
         side_by_side_named_updates = load_demo_side_by_side_vision_named(
-            context, 
+            context,
         )
 
         direct_chat_updates = load_demo_single(context, request.query_params)

--- a/fastchat/serve/gradio_web_server_multi.py
+++ b/fastchat/serve/gradio_web_server_multi.py
@@ -53,6 +53,7 @@ from fastchat.utils import (
 
 logger = build_logger("gradio_web_server_multi", "gradio_web_server_multi.log")
 
+
 def load_demo(context: Context, url_params, request: gr.Request):
     ip = get_ip(request)
     logger.info(f"load_demo. ip: {ip}. params: {url_params}")
@@ -86,27 +87,35 @@ def load_demo(context: Context, url_params, request: gr.Request):
 
     # Text models
     single_updates = load_demo_single(context.text_models, [], url_params)
-    side_by_side_anony_updates = load_demo_side_by_side_anony(context.all_text_models, url_params)
-    side_by_side_named_updates = load_demo_side_by_side_named(context.text_models, url_params)
-
+    side_by_side_anony_updates = load_demo_side_by_side_anony(
+        context.all_text_models, url_params
+    )
+    side_by_side_named_updates = load_demo_side_by_side_named(
+        context.text_models, url_params
+    )
 
     # Multimodal model support
     side_by_side_vision_anony_updates = load_demo_side_by_side_vision_anony(url_params)
 
-    side_by_side_vision_named_updates = load_demo_side_by_side_vision_named(context, url_params)
+    side_by_side_vision_named_updates = load_demo_side_by_side_vision_named(
+        context, url_params
+    )
 
     vision_direct_chat_updates = load_demo_single(context, url_params)
 
     tabs_list = []
     if args.vision_arena:
-        tabs_list = side_by_side_vision_anony_updates + side_by_side_vision_named_updates + vision_direct_chat_updates
+        tabs_list = (
+            side_by_side_vision_anony_updates
+            + side_by_side_vision_named_updates
+            + vision_direct_chat_updates
+        )
     else:
-        tabs_list = side_by_side_anony_updates + side_by_side_named_updates + single_updates
+        tabs_list = (
+            side_by_side_anony_updates + side_by_side_named_updates + single_updates
+        )
 
-    return (
-        (gr.Tabs(selected=inner_selected),)
-        + tabs_list
-    )
+    return (gr.Tabs(selected=inner_selected),) + tabs_list
 
 
 def build_demo(context: Context, elo_results_file: str, leaderboard_table_file):
@@ -149,22 +158,30 @@ window.__gradio_mode__ = "app";
                     )
                 with gr.Tab("⚔️ Arena (side-by-side)", id=2) as side_by_side_tab:
                     side_by_side_tab.select(None, None, None, js=alert_js)
-                    side_by_side_named_list = build_side_by_side_vision_ui_named(context, random_questions=args.random_questions)
+                    side_by_side_named_list = build_side_by_side_vision_ui_named(
+                        context, random_questions=args.random_questions
+                    )
 
                 with gr.Tab("💬 Direct Chat", id=3) as direct_tab:
                     direct_tab.select(None, None, None, js=alert_js)
                     single_model_list = build_single_vision_language_model_ui(
-                        context, add_promotion_links=True, random_questions=args.random_questions
+                        context,
+                        add_promotion_links=True,
+                        random_questions=args.random_questions,
                     )
-                
+
             else:
                 with gr.Tab("⚔️ Arena (battle)", id=0) as arena_tab:
                     arena_tab.select(None, None, None, js=load_js)
-                    side_by_side_anony_list = build_side_by_side_ui_anony(context.all_text_models)
+                    side_by_side_anony_list = build_side_by_side_ui_anony(
+                        context.all_text_models
+                    )
 
                 with gr.Tab("⚔️ Arena (side-by-side)", id=2) as side_by_side_tab:
                     side_by_side_tab.select(None, None, None, js=alert_js)
-                    side_by_side_named_list = build_side_by_side_ui_named(context.text_models)
+                    side_by_side_named_list = build_side_by_side_ui_named(
+                        context.text_models
+                    )
 
                 with gr.Tab("💬 Direct Chat", id=3) as direct_tab:
                     direct_tab.select(None, None, None, js=alert_js)

--- a/fastchat/serve/monitor/monitor.py
+++ b/fastchat/serve/monitor/monitor.py
@@ -350,7 +350,7 @@ def get_arena_table(arena_df, model_table_df, arena_subset_df=None):
             # model display name
             row.append(model_name)
             # elo rating
-            rating = round(arena_df.iloc[i]['rating'])
+            rating = round(arena_df.iloc[i]["rating"])
             row.append(rating)
             upper_diff = round(
                 arena_df.iloc[i]["rating_q975"] - arena_df.iloc[i]["rating"]

--- a/fastchat/serve/monitor/monitor.py
+++ b/fastchat/serve/monitor/monitor.py
@@ -293,7 +293,7 @@ def highlight_top_models(df):
     return df.apply(highlight_max_rank, axis=1)
 
 
-def get_arena_table(arena_df, model_table_df, arena_subset_df=None, round_digit=2):
+def get_arena_table(arena_df, model_table_df, arena_subset_df=None):
     arena_df = arena_df.sort_values(
         by=["final_ranking", "rating"], ascending=[True, False]
     )
@@ -490,7 +490,6 @@ def build_arena_tab(
         )
         return
 
-    round_digit = None if vision else None
     arena_dfs = {}
     category_elo_results = {}
     last_updated_time = elo_results["full"]["last_updated_datetime"].split(" ")[0]
@@ -513,7 +512,6 @@ def build_arena_tab(
             arena_df,
             model_table_df,
             arena_subset_df=arena_subset_df if category != "Overall" else None,
-            round_digit=round_digit,
         )
         if category != "Overall":
             arena_values = update_leaderboard_df(arena_values)

--- a/fastchat/serve/monitor/monitor.py
+++ b/fastchat/serve/monitor/monitor.py
@@ -293,7 +293,7 @@ def highlight_top_models(df):
     return df.apply(highlight_max_rank, axis=1)
 
 
-def get_arena_table(arena_df, model_table_df, arena_subset_df=None):
+def get_arena_table(arena_df, model_table_df, arena_subset_df=None, round_digit=2):
     arena_df = arena_df.sort_values(
         by=["final_ranking", "rating"], ascending=[True, False]
     )


### PR DESCRIPTION
Two major changes:
1. Enable vision arena across the tabs which is just having the side-by-side named tabs align with the side-by-side anonymous tab. Not much radical change.
2. Added a `Context` class which should help us with dependency injection. Right now, we use many global variables which is not the best for keeping track of variables like `text_models`, `vision_models` which many classes depend on. Without some `Context` class held at the top level, we would need to make many `global` calls within each separate file which is not good.