### PR TITLE
Revert "Add max-model-len argument to vllm worker"

### DIFF
--- a/fastchat/serve/vllm_worker.py
+++ b/fastchat/serve/vllm_worker.py
@@ -278,12 +278,6 @@ if __name__ == "__main__":
         "throughput. However, if the value is too high, it may cause out-of-"
         "memory (OOM) errors.",
     )
-    parser.add_argument(
-        "--max-model-len",
-        type=float,
-        default=None,
-        help="Model context length. If unspecified, will be automatically derived from the model config.",
-    )
 
     parser = AsyncEngineArgs.add_cli_args(parser)
     args = parser.parse_args()


### PR DESCRIPTION
Reverts lm-sys/FastChat#3451

This conflicts with the vllm package vllm/engine so reverting the change. You can actually use vllm_worker and pass on the vllm engine parameter directly. I have been using it already prior to this change.

```
2024-08-21 03:38:53 | ERROR | stderr |   File "/home/ubuntu/projects/FastChat/fastchat/serve/vllm_worker.py", line 288, in <module>
2024-08-21 03:38:53 | ERROR | stderr |     parser = AsyncEngineArgs.add_cli_args(parser)
2024-08-21 03:38:53 | ERROR | stderr |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-08-21 03:38:53 | ERROR | stderr |   File "/home/ubuntu/projects/insanai_inference/.venv/lib/python3.11/site-packages/vllm/engine/arg_utils.py", line 888, in add_cli_args
2024-08-21 03:38:53 | ERROR | stderr |     parser = EngineArgs.add_cli_args(parser)
2024-08-21 03:38:53 | ERROR | stderr |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-08-21 03:38:53 | ERROR | stderr |   File "/home/ubuntu/projects/insanai_inference/.venv/lib/python3.11/site-packages/vllm/engine/arg_utils.py", line 240, in add_cli_args
2024-08-21 03:38:53 | ERROR | stderr |     parser.add_argument('--max-model-len',
2024-08-21 03:38:53 | ERROR | stderr |   File "/home/ubuntu/.pyenv/versions/3.11.9/lib/python3.11/argparse.py", line 1473, in add_argument
2024-08-21 03:38:53 | ERROR | stderr |     return self._add_action(action)
2024-08-21 03:38:53 | ERROR | stderr |            ^^^^^^^^^^^^^^^^^^^^^^^^
2024-08-21 03:38:53 | ERROR | stderr |   File "/home/ubuntu/.pyenv/versions/3.11.9/lib/python3.11/argparse.py", line 1855, in _add_action
2024-08-21 03:38:53 | ERROR | stderr |     self._optionals._add_action(action)
2024-08-21 03:38:53 | ERROR | stderr |   File "/home/ubuntu/.pyenv/versions/3.11.9/lib/python3.11/argparse.py", line 1675, in _add_action
2024-08-21 03:38:53 | ERROR | stderr |     action = super(_ArgumentGroup, self)._add_action(action)
2024-08-21 03:38:53 | ERROR | stderr |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-08-21 03:38:53 | ERROR | stderr |   File "/home/ubuntu/.pyenv/versions/3.11.9/lib/python3.11/argparse.py", line 1487, in _add_action
2024-08-21 03:38:53 | ERROR | stderr |     self._check_conflict(action)
2024-08-21 03:38:53 | ERROR | stderr |   File "/home/ubuntu/.pyenv/versions/3.11.9/lib/python3.11/argparse.py", line 1624, in _check_conflict
2024-08-21 03:38:53 | ERROR | stderr |     conflict_handler(action, confl_optionals)
2024-08-21 03:38:53 | ERROR | stderr |   File "/home/ubuntu/.pyenv/versions/3.11.9/lib/python3.11/argparse.py", line 1633, in _handle_conflict_error
2024-08-21 03:38:53 | ERROR | stderr |     raise ArgumentError(action, message % conflict_string)
2024-08-21 03:38:53 | ERROR | stderr | argparse.ArgumentError: argument --max-model-len: conflicting option string: --max-model-len
```