### PR TITLE
Version names for Command R/R+

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -2423,7 +2423,7 @@ class CohereAdapter(BaseModelAdapter):
 
 
 class DBRXAdapter(BaseModelAdapter):
-    """The model adapter for Cohere"""
+    """The model adapter for Databricks"""
 
     def match(self, model_path: str):
         return model_path in ["dbrx-instruct"]

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -195,17 +195,17 @@ register_model_info(
 )
 
 register_model_info(
-    ["command-r-plus"],
-    "Command-R-Plus",
+    ["command-r-plus-04-2024"],
+    "Command R+",
     "https://txt.cohere.com/command-r-plus-microsoft-azure/",
-    "Command-R Plus by Cohere",
+    "Command R+ by Cohere",
 )
 
 register_model_info(
-    ["command-r"],
-    "Command-R",
+    ["command-r-03-2024", "command-r-08-2024"],
+    "Command R",
     "https://txt.cohere.com/command-r/",
-    "Command-R by Cohere",
+    "Command R by Cohere",
 )
 
 register_model_info(

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -202,7 +202,7 @@ register_model_info(
 )
 
 register_model_info(
-    ["command-r", "command-r-04-2024", "command-r-08-2024"],
+    ["command-r", "command-r-03-2024", "command-r-08-2024"],
     "Command R",
     "https://txt.cohere.com/command-r/",
     "Command R by Cohere",

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -202,7 +202,7 @@ register_model_info(
 )
 
 register_model_info(
-    ["command-r", "command-r-03-2024", "command-r-08-2024"],
+    ["command-r", "command-r-04-2024", "command-r-08-2024"],
     "Command R",
     "https://txt.cohere.com/command-r/",
     "Command R by Cohere",

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -195,14 +195,14 @@ register_model_info(
 )
 
 register_model_info(
-    ["command-r-plus-04-2024"],
+    ["command-r-plus", "command-r-plus-04-2024"],
     "Command R+",
     "https://txt.cohere.com/command-r-plus-microsoft-azure/",
     "Command R+ by Cohere",
 )
 
 register_model_info(
-    ["command-r-03-2024", "command-r-08-2024"],
+    ["command-r", "command-r-03-2024", "command-r-08-2024"],
     "Command R",
     "https://txt.cohere.com/command-r/",
     "Command R by Cohere",


### PR DESCRIPTION
### Changes

Adds explicitly versioned names for Command R and R+.

Testing with `python3 -m fastchat.serve.controller` and then `python3 -m fastchat.serve.gradio_web_server` shows 0 models, possibly since docs are assuming you use locally hosted models. I remember running into this last time, but can't remember how it was resolved.

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
