### PR TITLE
Accelerate Bradley Terry MLE model fitting

### DIFF
--- a/fastchat/serve/monitor/elo_analysis.py
+++ b/fastchat/serve/monitor/elo_analysis.py
@@ -11,8 +11,6 @@ from functools import partial
 import multiprocessing as mp
 
 import numpy as np
-from scipy.special import expit as sigmoid
-from scipy.optimize import minimize
 import pandas as pd
 import plotly.express as px
 from tqdm import tqdm
@@ -101,6 +99,8 @@ def preprocess_battles_to_arrays(df):
 
 def bt_loss_and_grad(ratings, matchups, outcomes, weights, alpha=1.0):
     """negative log likelihood and gradient for BT model with numpy array inputs"""
+    from scipy.special import expit as sigmoid
+
     matchup_ratings = ratings[matchups]
     logits = alpha * (matchup_ratings[:, 0] - matchup_ratings[:, 1])
     probs = sigmoid(logits)
@@ -121,6 +121,8 @@ def bt_loss_and_grad(ratings, matchups, outcomes, weights, alpha=1.0):
 
 def fit_bt(matchups, outcomes, weights, n_models, alpha, tol=1e-6):
     """perform the BT likelihood optimization"""
+    from scipy.optimize import minimize
+
     initial_ratings = np.zeros(n_models, dtype=np.float64)
     result = minimize(
         fun=bt_loss_and_grad,

--- a/fastchat/serve/monitor/elo_analysis.py
+++ b/fastchat/serve/monitor/elo_analysis.py
@@ -23,7 +23,7 @@ from fastchat.serve.monitor.rating_systems import (
     compute_style_control,
     compute_bootstrap_elo,
     compute_bootstrap_bt,
-    compute_bootstrap_style_control
+    compute_bootstrap_style_control,
 )
 
 pd.options.display.float_format = "{:.2f}".format
@@ -373,7 +373,9 @@ def report_elo_analysis_results(
 
     if rating_system == "bt":
         if style_control:
-            bootstrap_df, boostrap_coef = compute_bootstrap_style_control(battles, num_round=num_bootstrap)
+            bootstrap_df, boostrap_coef = compute_bootstrap_style_control(
+                battles, num_round=num_bootstrap
+            )
             elo_rating_final, coef_final = compute_style_control(battles)
         else:
             bootstrap_df = compute_bootstrap_bt(battles, num_round=num_bootstrap)

--- a/fastchat/serve/monitor/elo_analysis.py
+++ b/fastchat/serve/monitor/elo_analysis.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 import ast
 from collections import defaultdict
@@ -7,8 +8,11 @@ import math
 import pickle
 from pytz import timezone
 from functools import partial
+import multiprocessing as mp
 
 import numpy as np
+from scipy.special import expit as sigmoid
+from scipy.optimize import minimize
 import pandas as pd
 import plotly.express as px
 from tqdm import tqdm
@@ -65,70 +69,102 @@ def get_bootstrap_result(battles, func_compute_elo, num_round=1000):
     df = pd.DataFrame(rows)
     return df[df.median().sort_values(ascending=False).index]
 
+def preprocess_battles_to_arrays(df):
+    """convert the battles df into numpy arrays optimized for BT likelihood calculation"""
+
+    models = pd.unique(df[['model_a', 'model_b']].values.ravel()).tolist()
+    model_to_idx = {model:idx for idx,model in enumerate(models)}
+    # the 3 columns of schedule represent: model_a id, model_b id, outcome_id
+    schedule = np.empty((len(df), 3), dtype=np.int32)
+    # set the two model cols by mapping the model names to their int ids
+    schedule[:,[0,1]] = df[['model_a', 'model_b']].map(lambda x: model_to_idx[x]).values
+    # map outcomes to integers (must be same dtype as model ids so it can be in the same array)
+    # model_a win -> 2, tie -> 1, model_b win -> 0
+    schedule[:,2] = np.select(
+        condlist=[df['winner'] == 'model_a', df['winner'] == 'model_b'],
+        choicelist=[2, 0],
+        default=1
+    )
+    # count the number of occurances of each observed result
+    matchups_outcomes, weights = np.unique(schedule, return_counts=True, axis=0)
+    matchups = matchups_outcomes[:,[0,1]]
+    # map 2 -> 1.0, 1 -> 0.5, 0 -> 0.0 which will be used as labels during optimization
+    outcomes = matchups_outcomes[:,2].astype(np.float64) / 2.0
+    weights = weights.astype(np.float64)
+    # each possible result is weighted according to number of times it occured in the dataset
+    weights = weights / weights.sum()
+    return matchups, outcomes, weights, models
+
+def bt_loss_and_grad(ratings, matchups, outcomes, weights, alpha=1.0):
+    """negative log likelihood and gradient for BT model with numpy array inputs"""
+    matchup_ratings = ratings[matchups]
+    logits = alpha * (matchup_ratings[:,0] - matchup_ratings[:,1])
+    probs = sigmoid(logits)
+    # this form naturally counts a draw as half a win and half a loss
+    loss = -((np.log(probs) * outcomes + np.log(1.0 - probs) * (1.0 - outcomes)) * weights).sum()
+    matchups_grads = -alpha * (outcomes - probs) * weights
+    model_grad = np.zeros_like(ratings)
+    # aggregate gradients at the model level using the indices in matchups
+    np.add.at(model_grad, matchups[:, [0, 1]], matchups_grads[:, None] * np.array([1.0, -1.0], dtype=np.float64))
+    return loss, model_grad
+
+def fit_bt(matchups, outcomes, weights, n_models, alpha, tol=1e-6):
+    """perform the BT likelihood optimization"""
+    initial_ratings = np.zeros(n_models, dtype=np.float64)
+    result = minimize(
+        fun=bt_loss_and_grad,
+        x0=initial_ratings,
+        args=(matchups, outcomes, weights, alpha),
+        jac=True,
+        method='L-BFGS-B',
+        options={'disp' : False, 'maxiter': 100, 'gtol': tol},
+    )
+    return result["x"]
+
+
+def scale_and_offset(ratings, models, scale=400, init_rating=1000, baseline_model="mixtral-8x7b-instruct-v0.1", baseline_rating=1114):
+    """convert ratings from the natural scale to the Elo rating scale with an anchored baseline"""
+    scaled_ratings = (ratings * scale) + init_rating
+    if baseline_model in models:
+        baseline_idx = models.index(baseline_model)
+        scaled_ratings += (baseline_rating - scaled_ratings[..., [baseline_idx]])
+    return scaled_ratings
 
 def compute_elo_mle_with_tie(
-    df, SCALE=400, BASE=10, INIT_RATING=1000, sample_weight=None
+    df,
+    SCALE=400,
+    BASE=10,
+    INIT_RATING=1000,
+    baseline_model="mixtral-8x7b-instruct-v0.1",
+    baseline_rating=1114.0,
 ):
-    from sklearn.linear_model import LogisticRegression
-
-    ptbl_a_win = pd.pivot_table(
-        df[df["winner"] == "model_a"],
-        index="model_a",
-        columns="model_b",
-        aggfunc="size",
-        fill_value=0,
+    matchups, outcomes, weights, models = preprocess_battles_to_arrays(df)
+    ratings = fit_bt(matchups, outcomes, weights, len(models), np.log(BASE))
+    scaled_ratings = scale_and_offset(ratings, models, SCALE, INIT_RATING, baseline_model, baseline_rating)
+    return pd.Series(scaled_ratings, index=models).sort_values(ascending=False)
+    
+def get_bootstrap_result_elo_mle_with_tie(df, num_round, BASE=10.0, SCALE=400.0, INIT_RATING=1000.0):
+    matchups, outcomes, weights, models = preprocess_battles_to_arrays(battles)
+    # bootstrap sample the unique outcomes and their counts directly using the multinomial distribution
+    idxs = np.random.multinomial(
+        n=len(battles),
+        pvals=weights,
+        size=(num_round)
     )
-    ptbl_tie = pd.pivot_table(
-        df[df["winner"].isin(["tie", "tie (bothbad)"])],
-        index="model_a",
-        columns="model_b",
-        aggfunc="size",
-        fill_value=0,
-    )
-    ptbl_tie = ptbl_tie + ptbl_tie.T
-    ptbl_b_win = pd.pivot_table(
-        df[df["winner"] == "model_b"],
-        index="model_a",
-        columns="model_b",
-        aggfunc="size",
-        fill_value=0,
-    )
-    ptbl_win = ptbl_a_win * 2 + ptbl_b_win.T * 2 + ptbl_tie
+    # only the distribution over their occurance counts changes between samples (and it can be 0)
+    boot_weights = idxs.astype(np.float64) / len(battles)
 
-    models = pd.Series(np.arange(len(ptbl_win.index)), index=ptbl_win.index)
+    # the only thing different across samples is the distribution of weights
+    bt_fn = partial(fit_bt, matchups, outcomes, n_models=len(models), alpha=np.log(BASE))
 
-    p = len(models)
-    X = np.zeros([p * (p - 1) * 2, p])
-    Y = np.zeros(p * (p - 1) * 2)
+    with mp.Pool(os.cpu_count()) as pool:
+        results = pool.map(bt_fn, boot_weights)
 
-    cur_row = 0
-    sample_weights = []
-    for m_a in ptbl_win.index:
-        for m_b in ptbl_win.columns:
-            if m_a == m_b:
-                continue
-            # if nan skip
-            if math.isnan(ptbl_win.loc[m_a, m_b]) or math.isnan(ptbl_win.loc[m_b, m_a]):
-                continue
-            X[cur_row, models[m_a]] = +math.log(BASE)
-            X[cur_row, models[m_b]] = -math.log(BASE)
-            Y[cur_row] = 1.0
-            sample_weights.append(ptbl_win.loc[m_a, m_b])
-
-            X[cur_row + 1, models[m_a]] = math.log(BASE)
-            X[cur_row + 1, models[m_b]] = -math.log(BASE)
-            Y[cur_row + 1] = 0.0
-            sample_weights.append(ptbl_win.loc[m_b, m_a])
-            cur_row += 2
-    X = X[:cur_row]
-    Y = Y[:cur_row]
-
-    lr = LogisticRegression(fit_intercept=False, penalty=None)
-    lr.fit(X, Y, sample_weight=sample_weights)
-    elo_scores = SCALE * lr.coef_[0] + INIT_RATING
-    if "mixtral-8x7b-instruct-v0.1" in models.index:
-        elo_scores += 1114 - elo_scores[models["mixtral-8x7b-instruct-v0.1"]]
-    return pd.Series(elo_scores, index=models.index).sort_values(ascending=False)
+    ratings = np.array(results)
+    scaled_ratings = scale_and_offset(ratings, models, SCALE, INIT_RATING)
+    df = pd.DataFrame(scaled_ratings, columns=models)
+    return df[df.median().sort_values(ascending=False).index]
+    
 
 
 def get_median_elo_from_bootstrap(bootstrap_df):
@@ -604,8 +640,8 @@ def report_elo_analysis_results(
             )
             elo_rating_final, coef_final = fit_mle_elo(X, Y, models)
         else:
-            bootstrap_df = get_bootstrap_result(
-                battles, compute_elo_mle_with_tie, num_round=num_bootstrap
+            bootstrap_df = get_bootstrap_result_elo_mle_with_tie(
+                battles, num_round=num_bootstrap
             )
             elo_rating_final = compute_elo_mle_with_tie(battles)
     elif rating_system == "elo":

--- a/fastchat/serve/monitor/elo_analysis.py
+++ b/fastchat/serve/monitor/elo_analysis.py
@@ -332,6 +332,7 @@ def report_elo_analysis_results(
     scale=1,
     filter_func=lambda x: True,
     style_control=False,
+    num_cpu=None,
 ):
     battles = pd.DataFrame(battles_json)
 
@@ -378,10 +379,14 @@ def report_elo_analysis_results(
             )
             elo_rating_final, coef_final = compute_style_control(battles)
         else:
-            bootstrap_df = compute_bootstrap_bt(battles, num_round=num_bootstrap)
+            bootstrap_df = compute_bootstrap_bt(
+                battles, num_round=num_bootstrap, num_cpu=num_cpu
+            )
             elo_rating_final = compute_bt(battles)
     elif rating_system == "elo":
-        bootstrap_df = compute_bootstrap_elo(battles, num_round=num_bootstrap)
+        bootstrap_df = compute_bootstrap_elo(
+            battles, num_round=num_bootstrap, num_cpu=num_cpu
+        )
         elo_rating_median = get_median_elo_from_bootstrap(bootstrap_df)
         elo_rating_final = elo_rating_median
 
@@ -485,6 +490,7 @@ if __name__ == "__main__":
     parser.add_argument("--category", nargs="+", default=["full"])
     parser.add_argument("--scale", type=float, default=1)
     parser.add_argument("--style-control", action="store_true")
+    parser.add_argument("--num-cpu", type=int, default=12)
     args = parser.parse_args()
 
     np.random.seed(42)
@@ -523,6 +529,7 @@ if __name__ == "__main__":
             scale=args.scale,
             filter_func=filter_func,
             style_control=args.style_control,
+            num_cpu=args.num_cpu,
         )
 
     for cat in args.category:

--- a/fastchat/serve/monitor/elo_analysis.py
+++ b/fastchat/serve/monitor/elo_analysis.py
@@ -1,4 +1,3 @@
-import os
 import argparse
 import ast
 from collections import defaultdict
@@ -8,7 +7,6 @@ import math
 import pickle
 from pytz import timezone
 from functools import partial
-import multiprocessing as mp
 
 import numpy as np
 import pandas as pd

--- a/fastchat/serve/monitor/rating_systems.py
+++ b/fastchat/serve/monitor/rating_systems.py
@@ -5,7 +5,7 @@ from functools import partial
 import numpy as np
 from scipy.special import expit
 from scipy.optimize import minimize
-import pandas  as pd
+import pandas as pd
 
 
 STYLE_CONTROL_ELEMENTS_V1 = [
@@ -19,11 +19,13 @@ STYLE_CONTROL_ELEMENTS_V1 = [
     "bold_count_b",
 ]
 
+
 def get_matchups_models(df):
     n_rows = len(df)
-    model_indices, models = pd.factorize(pd.concat([df['model_a'], df['model_b']])) 
+    model_indices, models = pd.factorize(pd.concat([df["model_a"], df["model_b"]]))
     matchups = np.column_stack([model_indices[:n_rows], model_indices[n_rows:]])
     return matchups, models.to_list()
+
 
 def preprocess_for_elo(df):
     """
@@ -44,16 +46,16 @@ def preprocess_for_bt(df):
     # the 3 columns of schedule represent: model_a id, model_b id, outcome_id
     schedule = np.full((n_rows, 3), fill_value=1, dtype=np.int32)
     # set the two model cols by mapping the model names to their int ids
-    schedule[:,[0,1]], models = get_matchups_models(df)
+    schedule[:, [0, 1]], models = get_matchups_models(df)
     # map outcomes to integers (must be same dtype as model ids so it can be in the same array)
     # model_a win -> 2, tie -> 1 (prefilled by default), model_b win -> 0
-    schedule[df['winner'] == 'model_a',2] = 2
-    schedule[df['winner'] == 'model_b',2] = 0
+    schedule[df["winner"] == "model_a", 2] = 2
+    schedule[df["winner"] == "model_b", 2] = 0
     # count the number of occurances of each observed result
     matchups_outcomes, weights = np.unique(schedule, return_counts=True, axis=0)
-    matchups = matchups_outcomes[:,[0,1]]
+    matchups = matchups_outcomes[:, [0, 1]]
     # map 2 -> 1.0, 1 -> 0.5, 0 -> 0.0 which will be used as labels during optimization
-    outcomes = matchups_outcomes[:,2].astype(np.float64) / 2.0
+    outcomes = matchups_outcomes[:, 2].astype(np.float64) / 2.0
     weights = weights.astype(np.float64)
     # each possible result is weighted according to number of times it occured in the dataset
     return matchups, outcomes, models, weights
@@ -65,7 +67,9 @@ def preprocess_for_style(
     style_elements=STYLE_CONTROL_ELEMENTS_V1,
     add_one=True,
 ):
-    matchups, outcomes, models = preprocess_for_elo(df) # this can use the same preprocessing as Elo
+    matchups, outcomes, models = preprocess_for_elo(
+        df
+    )  # this can use the same preprocessing as Elo
 
     n = matchups.shape[0]
     k = int(len(style_elements) / 2)
@@ -77,9 +81,11 @@ def preprocess_for_style(
         else:
             return sum(val.values())
 
-    style_vector = np.zeros(shape=(2*k,n), dtype=np.int32)
+    style_vector = np.zeros(shape=(2 * k, n), dtype=np.int32)
     for idx, element in enumerate(style_elements):
-        style_vector[idx,:] = df.conv_metadata.map(partial(extract_style_feature, feature=element)).values
+        style_vector[idx, :] = df.conv_metadata.map(
+            partial(extract_style_feature, feature=element)
+        ).values
     style_vector = np.ascontiguousarray(style_vector)
 
     style_diff = (style_vector[:k] - style_vector[k:]).astype(float)
@@ -109,7 +115,7 @@ def fit_vectorized_elo(
     base=10.0,
     init_rating=1000.0,
     scale=400.0,
-    ):
+):
     """fit multiple sets of Elo ratings on different samples of the data at the same time"""
     alpha = math.log(base) / scale
     num_samples = sample_indices.shape[1]
@@ -117,8 +123,8 @@ def fit_vectorized_elo(
     # iterate over the rows of sample_indices, each column is an index into a match in the input arrays
     sample_range = np.arange(num_samples)
     for matchup_indices in sample_indices:
-        model_a_indices = matchups[matchup_indices,0]
-        model_b_indices = matchups[matchup_indices,1]
+        model_a_indices = matchups[matchup_indices, 0]
+        model_b_indices = matchups[matchup_indices, 1]
         model_a_ratings = ratings[sample_range, model_a_indices]
         model_b_ratings = ratings[sample_range, model_b_indices]
         sample_outcomes = outcomes[matchup_indices]
@@ -134,31 +140,43 @@ def compute_elo(df, k=4.0, base=10.0, init_rating=1000.0, scale=400.0):
     alpha = math.log(base) / scale
     ratings = np.full(shape=(len(models),), fill_value=init_rating)
     for (model_a_idx, model_b_idx), outcome in zip(matchups, outcomes):
-        prob = 1.0 / (1.0 + math.exp(alpha * (ratings[model_b_idx] - ratings[model_a_idx])))
+        prob = 1.0 / (
+            1.0 + math.exp(alpha * (ratings[model_b_idx] - ratings[model_a_idx]))
+        )
         update = k * (outcome - prob)
         ratings[model_a_idx] += update
         ratings[model_b_idx] -= update
-    return {model:ratings[idx] for idx,model in enumerate(models)}
+    return {model: ratings[idx] for idx, model in enumerate(models)}
 
 
-def compute_bootstrap_elo(df, num_round=100, k=4.0, base=10.0, init_rating=1000.0, scale=400.0):
+def compute_bootstrap_elo(
+    df, num_round=100, k=4.0, base=10.0, init_rating=1000.0, scale=400.0
+):
     matchups, outcomes, models = preprocess_for_elo(df)
     sample_indices = np.random.randint(low=0, high=len(df), size=(len(df), num_round))
-    ratings = fit_vectorized_elo(matchups, outcomes, sample_indices, len(models), k, base, init_rating, scale)
+    ratings = fit_vectorized_elo(
+        matchups, outcomes, sample_indices, len(models), k, base, init_rating, scale
+    )
     df = pd.DataFrame(data=ratings, columns=models)
     return df[df.median().sort_values(ascending=False).index]
 
 
 def bt_loss_and_grad(ratings, matchups, outcomes, weights, alpha=1.0):
     matchup_ratings = ratings[matchups]
-    logits = alpha * (matchup_ratings[:,0] - matchup_ratings[:,1])
+    logits = alpha * (matchup_ratings[:, 0] - matchup_ratings[:, 1])
     probs = expit(logits)
     # this form naturally counts a draw as half a win and half a loss
-    loss = -((np.log(probs) * outcomes + np.log(1.0 - probs) * (1.0 - outcomes)) * weights).sum()
+    loss = -(
+        (np.log(probs) * outcomes + np.log(1.0 - probs) * (1.0 - outcomes)) * weights
+    ).sum()
     matchups_grads = -alpha * (outcomes - probs) * weights
     model_grad = np.zeros_like(ratings)
     # aggregate gradients at the model level using the indices in matchups
-    np.add.at(model_grad, matchups[:, [0, 1]], matchups_grads[:, None] * np.array([1.0, -1.0], dtype=np.float64))
+    np.add.at(
+        model_grad,
+        matchups[:, [0, 1]],
+        matchups_grads[:, None] * np.array([1.0, -1.0], dtype=np.float64),
+    )
     return loss, model_grad
 
 
@@ -169,8 +187,8 @@ def fit_bt(matchups, outcomes, weights, n_models, alpha, tol=1e-6):
         x0=initial_ratings,
         args=(matchups, outcomes, weights, alpha),
         jac=True,
-        method='L-BFGS-B',
-        options={'disp' : False, 'maxiter': 100, 'gtol': tol},
+        method="L-BFGS-B",
+        options={"disp": False, "maxiter": 100, "gtol": tol},
     )
     return result["x"]
 
@@ -198,20 +216,22 @@ def compute_bt(df, base=10.0, scale=400.0, init_rating=1000, tol=1e-6):
     return pd.Series(scaled_ratings, index=models).sort_values(ascending=False)
 
 
-def compute_bootstrap_bt(battles, num_round, base=10.0, scale=400.0, init_rating=1000.0, tol=1e-6):
+def compute_bootstrap_bt(
+    battles, num_round, base=10.0, scale=400.0, init_rating=1000.0, tol=1e-6
+):
     matchups, outcomes, models, weights = preprocess_for_bt(battles)
     # bootstrap sample the unique outcomes and their counts directly using the multinomial distribution
     rng = np.random.default_rng(seed=0)
     idxs = rng.multinomial(
-        n=len(battles),
-        pvals=weights / weights.sum(),
-        size=(num_round)
+        n=len(battles), pvals=weights / weights.sum(), size=(num_round)
     )
     # only the distribution over their occurance counts changes between samples (and it can be 0)
     boot_weights = idxs.astype(np.float64) / len(battles)
 
     # the only thing different across samples is the distribution of weights
-    bt_fn = partial(fit_bt, matchups, outcomes, n_models=len(models), alpha=np.log(base), tol=tol)
+    bt_fn = partial(
+        fit_bt, matchups, outcomes, n_models=len(models), alpha=np.log(base), tol=tol
+    )
     with mp.Pool(os.cpu_count()) as pool:
         results = pool.map(bt_fn, boot_weights)
 
@@ -220,17 +240,22 @@ def compute_bootstrap_bt(battles, num_round, base=10.0, scale=400.0, init_rating
     df = pd.DataFrame(scaled_ratings, columns=models)
     return df[df.median().sort_values(ascending=False).index]
 
-DIFF_MASK = np.array([1.0, -1.0], dtype=np.float64) # create globally to not incur the instantiation cost in each call
+
+DIFF_MASK = np.array(
+    [1.0, -1.0], dtype=np.float64
+)  # create globally to not incur the instantiation cost in each call
+
+
 def contextual_bt_loss_and_grad(
-        params,
-        n_competitors,
-        matchups,
-        features,
-        outcomes,
-        alpha=1.0,
-        reg=1.0,
-        half_reg=0.5,
-    ):
+    params,
+    n_competitors,
+    matchups,
+    features,
+    outcomes,
+    alpha=1.0,
+    reg=1.0,
+    half_reg=0.5,
+):
     reg_loss = half_reg * np.inner(params, params)
 
     # Split params into ratings and feature parameters
@@ -238,37 +263,39 @@ def contextual_bt_loss_and_grad(
     feature_params = params[n_competitors:]
 
     matchup_ratings = ratings[matchups]
-    bt_logits = alpha * (matchup_ratings[:,0] - matchup_ratings[:,1])
+    bt_logits = alpha * (matchup_ratings[:, 0] - matchup_ratings[:, 1])
     context_logits = np.dot(features, feature_params)
     probs = expit(bt_logits + context_logits)
-    loss = -((np.log(probs) * outcomes + np.log(1.0 - probs) * (1.0 - outcomes))).sum() + reg_loss
+    loss = (
+        -((np.log(probs) * outcomes + np.log(1.0 - probs) * (1.0 - outcomes))).sum()
+        + reg_loss
+    )
 
-    error = (outcomes - probs)
-    grad = reg * params # initialize the grad as the regularization grad
+    error = outcomes - probs
+    grad = reg * params  # initialize the grad as the regularization grad
     matchups_grads = -alpha * error
     np.add.at(
-        grad[:n_competitors],
-        matchups[:, [0, 1]],
-        matchups_grads[:, None] * DIFF_MASK
+        grad[:n_competitors], matchups[:, [0, 1]], matchups_grads[:, None] * DIFF_MASK
     )
     grad[n_competitors:] -= np.dot(features.T, error)
     return loss, grad
 
+
 # note on regularization:
 # default reg is to 0.5 since the LogisticRegression default is 1.0
-# in the original implementation, matchups were duplicated 
+# in the original implementation, matchups were duplicated
 # that made the ratio of log loss to reg loss "twice as high"
 # in this non-duplicated version for parity we also reduce the reg by one half to match
 def fit_contextual_bt(
-        matchups,
-        features,
-        outcomes,
-        models,
-        idxs=None,
-        alpha=math.log(10.0),
-        reg=0.5,
-        tol=1e-6
-    ):
+    matchups,
+    features,
+    outcomes,
+    models,
+    idxs=None,
+    alpha=math.log(10.0),
+    reg=0.5,
+    tol=1e-6,
+):
     n_features = features.shape[1]
     n_models = len(models)
     initial_params = np.zeros(n_models + n_features, dtype=np.float64)
@@ -277,24 +304,20 @@ def fit_contextual_bt(
     # sample idxs optionally allow for fitting on a bootstrap sample of the dataset
     if idxs is not None:
         matchups, features, outcomes = matchups[idxs], features[idxs], outcomes[idxs]
-    
+
     result = minimize(
         fun=contextual_bt_loss_and_grad,
         x0=initial_params,
         args=(n_models, matchups, features, outcomes, alpha, reg, half_reg),
         jac=True,
-        method='L-BFGS-B',
-        options={'disp': False, 'maxiter': 100, 'gtol': tol},
+        method="L-BFGS-B",
+        options={"disp": False, "maxiter": 100, "gtol": tol},
     )
     return result["x"]
 
+
 def compute_style_control(
-    df,
-    alpha=math.log(10.0),
-    reg=0.5,
-    init_rating=1000.0,
-    scale=400.0, 
-    tol=1e-6 
+    df, alpha=math.log(10.0), reg=0.5, init_rating=1000.0, scale=400.0, tol=1e-6
 ):
     matchups, features, outcomes, models = preprocess_for_style(df)
     ratings_params = fit_contextual_bt(
@@ -306,10 +329,12 @@ def compute_style_control(
         reg=reg,
         tol=tol,
     )
-    ratings = ratings_params[:len(models)]
-    params = ratings_params[len(models):]
+    ratings = ratings_params[: len(models)]
+    params = ratings_params[len(models) :]
     scaled_ratings = scale_and_offset(ratings, models, scale, init_rating)
-    scaled_ratings = pd.Series(scaled_ratings, index=models).sort_values(ascending=False)
+    scaled_ratings = pd.Series(scaled_ratings, index=models).sort_values(
+        ascending=False
+    )
     return scaled_ratings, params
 
 
@@ -319,13 +344,20 @@ def compute_bootstrap_style_control(
     alpha=math.log(10.0),
     reg=0.5,
     init_rating=1000.0,
-    scale=400.0, 
-    tol=1e-6 
+    scale=400.0,
+    tol=1e-6,
 ):
     matchups, features, outcomes, models = preprocess_for_style(df)
 
     contextual_bt_fn = partial(
-        fit_contextual_bt, matchups, features, outcomes, models, alpha=alpha, reg=reg, tol=tol
+        fit_contextual_bt,
+        matchups,
+        features,
+        outcomes,
+        models,
+        alpha=alpha,
+        reg=reg,
+        tol=tol,
     )
 
     boot_idxs = np.random.randint(
@@ -337,8 +369,8 @@ def compute_bootstrap_style_control(
         results = pool.map(contextual_bt_fn, boot_idxs)
 
     ratings_params = np.array(results)
-    ratings = ratings_params[:,:len(models)]
-    params = ratings_params[:,len(models):]
+    ratings = ratings_params[:, : len(models)]
+    params = ratings_params[:, len(models) :]
     scaled_ratings = scale_and_offset(ratings, models, scale, init_rating)
     df = pd.DataFrame(scaled_ratings, columns=models)
     return df[df.median().sort_values(ascending=False).index], params

--- a/fastchat/serve/monitor/rating_systems.py
+++ b/fastchat/serve/monitor/rating_systems.py
@@ -1,0 +1,344 @@
+import os
+import math
+import multiprocessing as mp
+from functools import partial
+import numpy as np
+from scipy.special import expit
+from scipy.optimize import minimize
+import pandas  as pd
+
+
+STYLE_CONTROL_ELEMENTS_V1 = [
+    "sum_assistant_a_tokens",
+    "header_count_a",
+    "list_count_a",
+    "bold_count_a",
+    "sum_assistant_b_tokens",
+    "header_count_b",
+    "list_count_b",
+    "bold_count_b",
+]
+
+def get_matchups_models(df):
+    n_rows = len(df)
+    model_indices, models = pd.factorize(pd.concat([df['model_a'], df['model_b']])) 
+    matchups = np.column_stack([model_indices[:n_rows], model_indices[n_rows:]])
+    return matchups, models.to_list()
+
+def preprocess_for_elo(df):
+    """
+    in Elo we want numpy arrays for matchups and outcomes
+      matchups: int32 (N,2)  contains model ids for the competitors in a match
+      outcomes: float64 (N,) contains 1.0, 0.5, or 0.0 representing win, tie, or loss for model_a
+    """
+    matchups, models = get_matchups_models(df)
+    outcomes = np.full(len(df), 0.5)
+    outcomes[df["winner"] == "model_a"] = 1.0
+    outcomes[df["winner"] == "model_b"] = 0.0
+    return matchups, outcomes, models
+
+
+def preprocess_for_bt(df):
+    """in BT we only need the unique (matchup,outcome) sets along with the weights of how often they occur"""
+    n_rows = len(df)
+    # the 3 columns of schedule represent: model_a id, model_b id, outcome_id
+    schedule = np.full((n_rows, 3), fill_value=1, dtype=np.int32)
+    # set the two model cols by mapping the model names to their int ids
+    schedule[:,[0,1]], models = get_matchups_models(df)
+    # map outcomes to integers (must be same dtype as model ids so it can be in the same array)
+    # model_a win -> 2, tie -> 1 (prefilled by default), model_b win -> 0
+    schedule[df['winner'] == 'model_a',2] = 2
+    schedule[df['winner'] == 'model_b',2] = 0
+    # count the number of occurances of each observed result
+    matchups_outcomes, weights = np.unique(schedule, return_counts=True, axis=0)
+    matchups = matchups_outcomes[:,[0,1]]
+    # map 2 -> 1.0, 1 -> 0.5, 0 -> 0.0 which will be used as labels during optimization
+    outcomes = matchups_outcomes[:,2].astype(np.float64) / 2.0
+    weights = weights.astype(np.float64)
+    # each possible result is weighted according to number of times it occured in the dataset
+    return matchups, outcomes, models, weights
+
+
+def preprocess_for_style(
+    df,
+    apply_ratio=[1, 1, 1, 1],
+    style_elements=STYLE_CONTROL_ELEMENTS_V1,
+    add_one=True,
+):
+    matchups, outcomes, models = preprocess_for_elo(df) # this can use the same preprocessing as Elo
+
+    n = matchups.shape[0]
+    k = int(len(style_elements) / 2)
+
+    def extract_style_feature(x, feature):
+        val = x[feature]
+        if isinstance(val, int):
+            return val
+        else:
+            return sum(val.values())
+
+    style_vector = np.zeros(shape=(2*k,n), dtype=np.int32)
+    for idx, element in enumerate(style_elements):
+        style_vector[idx,:] = df.conv_metadata.map(partial(extract_style_feature, feature=element)).values
+    style_vector = np.ascontiguousarray(style_vector)
+
+    style_diff = (style_vector[:k] - style_vector[k:]).astype(float)
+    style_sum = (style_vector[:k] + style_vector[k:]).astype(float)
+
+    if add_one:
+        style_sum = style_sum + np.ones(style_diff.shape)
+
+    apply_ratio = np.flatnonzero(apply_ratio)
+
+    # Apply ratio where necessary (length, etc)
+    style_diff[apply_ratio] /= style_sum[apply_ratio]
+
+    style_mean = np.mean(style_diff, axis=1)
+    style_std = np.std(style_diff, axis=1)
+    features = ((style_diff - style_mean[:, np.newaxis]) / style_std[:, np.newaxis]).T
+
+    return matchups, features, outcomes, models
+
+
+def fit_vectorized_elo(
+    matchups,
+    outcomes,
+    sample_indices,
+    num_models,
+    k=4.0,
+    base=10.0,
+    init_rating=1000.0,
+    scale=400.0,
+    ):
+    """fit multiple sets of Elo ratings on different samples of the data at the same time"""
+    alpha = math.log(base) / scale
+    num_samples = sample_indices.shape[1]
+    ratings = np.zeros(shape=(num_samples, num_models), dtype=np.float64)
+    # iterate over the rows of sample_indices, each column is an index into a match in the input arrays
+    sample_range = np.arange(num_samples)
+    for matchup_indices in sample_indices:
+        model_a_indices = matchups[matchup_indices,0]
+        model_b_indices = matchups[matchup_indices,1]
+        model_a_ratings = ratings[sample_range, model_a_indices]
+        model_b_ratings = ratings[sample_range, model_b_indices]
+        sample_outcomes = outcomes[matchup_indices]
+        probs = expit(alpha * (model_a_ratings - model_b_ratings))
+        updates = k * (sample_outcomes - probs)
+        ratings[sample_range, model_a_indices] += updates
+        ratings[sample_range, model_b_indices] -= updates
+    return ratings + init_rating
+
+
+def compute_elo(df, k=4.0, base=10.0, init_rating=1000.0, scale=400.0):
+    matchups, outcomes, models = preprocess_for_elo(df)
+    alpha = math.log(base) / scale
+    ratings = np.full(shape=(len(models),), fill_value=init_rating)
+    for (model_a_idx, model_b_idx), outcome in zip(matchups, outcomes):
+        prob = 1.0 / (1.0 + math.exp(alpha * (ratings[model_b_idx] - ratings[model_a_idx])))
+        update = k * (outcome - prob)
+        ratings[model_a_idx] += update
+        ratings[model_b_idx] -= update
+    return {model:ratings[idx] for idx,model in enumerate(models)}
+
+
+def compute_bootstrap_elo(df, num_round=100, k=4.0, base=10.0, init_rating=1000.0, scale=400.0):
+    matchups, outcomes, models = preprocess_for_elo(df)
+    sample_indices = np.random.randint(low=0, high=len(df), size=(len(df), num_round))
+    ratings = fit_vectorized_elo(matchups, outcomes, sample_indices, len(models), k, base, init_rating, scale)
+    df = pd.DataFrame(data=ratings, columns=models)
+    return df[df.median().sort_values(ascending=False).index]
+
+
+def bt_loss_and_grad(ratings, matchups, outcomes, weights, alpha=1.0):
+    matchup_ratings = ratings[matchups]
+    logits = alpha * (matchup_ratings[:,0] - matchup_ratings[:,1])
+    probs = expit(logits)
+    # this form naturally counts a draw as half a win and half a loss
+    loss = -((np.log(probs) * outcomes + np.log(1.0 - probs) * (1.0 - outcomes)) * weights).sum()
+    matchups_grads = -alpha * (outcomes - probs) * weights
+    model_grad = np.zeros_like(ratings)
+    # aggregate gradients at the model level using the indices in matchups
+    np.add.at(model_grad, matchups[:, [0, 1]], matchups_grads[:, None] * np.array([1.0, -1.0], dtype=np.float64))
+    return loss, model_grad
+
+
+def fit_bt(matchups, outcomes, weights, n_models, alpha, tol=1e-6):
+    initial_ratings = np.zeros(n_models, dtype=np.float64)
+    result = minimize(
+        fun=bt_loss_and_grad,
+        x0=initial_ratings,
+        args=(matchups, outcomes, weights, alpha),
+        jac=True,
+        method='L-BFGS-B',
+        options={'disp' : False, 'maxiter': 100, 'gtol': tol},
+    )
+    return result["x"]
+
+
+def scale_and_offset(
+    ratings,
+    models,
+    scale=400,
+    init_rating=1000,
+    baseline_model="mixtral-8x7b-instruct-v0.1",
+    baseline_rating=1114,
+):
+    """convert ratings from the natural scale to the Elo rating scale with an anchored baseline"""
+    scaled_ratings = (ratings * scale) + init_rating
+    if baseline_model in models:
+        baseline_idx = models.index(baseline_model)
+        scaled_ratings += baseline_rating - scaled_ratings[..., [baseline_idx]]
+    return scaled_ratings
+
+
+def compute_bt(df, base=10.0, scale=400.0, init_rating=1000, tol=1e-6):
+    matchups, outcomes, models, weights = preprocess_for_bt(df)
+    ratings = fit_bt(matchups, outcomes, weights, len(models), math.log(base), tol)
+    scaled_ratings = scale_and_offset(ratings, models, scale, init_rating=init_rating)
+    return pd.Series(scaled_ratings, index=models).sort_values(ascending=False)
+
+
+def compute_bootstrap_bt(battles, num_round, base=10.0, scale=400.0, init_rating=1000.0, tol=1e-6):
+    matchups, outcomes, models, weights = preprocess_for_bt(battles)
+    # bootstrap sample the unique outcomes and their counts directly using the multinomial distribution
+    rng = np.random.default_rng(seed=0)
+    idxs = rng.multinomial(
+        n=len(battles),
+        pvals=weights / weights.sum(),
+        size=(num_round)
+    )
+    # only the distribution over their occurance counts changes between samples (and it can be 0)
+    boot_weights = idxs.astype(np.float64) / len(battles)
+
+    # the only thing different across samples is the distribution of weights
+    bt_fn = partial(fit_bt, matchups, outcomes, n_models=len(models), alpha=np.log(base), tol=tol)
+    with mp.Pool(os.cpu_count()) as pool:
+        results = pool.map(bt_fn, boot_weights)
+
+    ratings = np.array(results)
+    scaled_ratings = scale_and_offset(ratings, models, scale, init_rating)
+    df = pd.DataFrame(scaled_ratings, columns=models)
+    return df[df.median().sort_values(ascending=False).index]
+
+DIFF_MASK = np.array([1.0, -1.0], dtype=np.float64) # create globally to not incur the instantiation cost in each call
+def contextual_bt_loss_and_grad(
+        params,
+        n_competitors,
+        matchups,
+        features,
+        outcomes,
+        alpha=1.0,
+        reg=1.0,
+        half_reg=0.5,
+    ):
+    reg_loss = half_reg * np.inner(params, params)
+
+    # Split params into ratings and feature parameters
+    ratings = params[:n_competitors]
+    feature_params = params[n_competitors:]
+
+    matchup_ratings = ratings[matchups]
+    bt_logits = alpha * (matchup_ratings[:,0] - matchup_ratings[:,1])
+    context_logits = np.dot(features, feature_params)
+    probs = expit(bt_logits + context_logits)
+    loss = -((np.log(probs) * outcomes + np.log(1.0 - probs) * (1.0 - outcomes))).sum() + reg_loss
+
+    error = (outcomes - probs)
+    grad = reg * params # initialize the grad as the regularization grad
+    matchups_grads = -alpha * error
+    np.add.at(
+        grad[:n_competitors],
+        matchups[:, [0, 1]],
+        matchups_grads[:, None] * DIFF_MASK
+    )
+    grad[n_competitors:] -= np.dot(features.T, error)
+    return loss, grad
+
+# note on regularization:
+# default reg is to 0.5 since the LogisticRegression default is 1.0
+# in the original implementation, matchups were duplicated 
+# that made the ratio of log loss to reg loss "twice as high"
+# in this non-duplicated version for parity we also reduce the reg by one half to match
+def fit_contextual_bt(
+        matchups,
+        features,
+        outcomes,
+        models,
+        idxs=None,
+        alpha=math.log(10.0),
+        reg=0.5,
+        tol=1e-6
+    ):
+    n_features = features.shape[1]
+    n_models = len(models)
+    initial_params = np.zeros(n_models + n_features, dtype=np.float64)
+    half_reg = reg / 2.0
+
+    # sample idxs optionally allow for fitting on a bootstrap sample of the dataset
+    if idxs is not None:
+        matchups, features, outcomes = matchups[idxs], features[idxs], outcomes[idxs]
+    
+    result = minimize(
+        fun=contextual_bt_loss_and_grad,
+        x0=initial_params,
+        args=(n_models, matchups, features, outcomes, alpha, reg, half_reg),
+        jac=True,
+        method='L-BFGS-B',
+        options={'disp': False, 'maxiter': 100, 'gtol': tol},
+    )
+    return result["x"]
+
+def compute_style_control(
+    df,
+    alpha=math.log(10.0),
+    reg=0.5,
+    init_rating=1000.0,
+    scale=400.0, 
+    tol=1e-6 
+):
+    matchups, features, outcomes, models = preprocess_for_style(df)
+    ratings_params = fit_contextual_bt(
+        matchups,
+        features,
+        outcomes,
+        models=models,
+        alpha=alpha,
+        reg=reg,
+        tol=tol,
+    )
+    ratings = ratings_params[:len(models)]
+    params = ratings_params[len(models):]
+    scaled_ratings = scale_and_offset(ratings, models, scale, init_rating)
+    scaled_ratings = pd.Series(scaled_ratings, index=models).sort_values(ascending=False)
+    return scaled_ratings, params
+
+
+def compute_bootstrap_style_control(
+    df,
+    num_round,
+    alpha=math.log(10.0),
+    reg=0.5,
+    init_rating=1000.0,
+    scale=400.0, 
+    tol=1e-6 
+):
+    matchups, features, outcomes, models = preprocess_for_style(df)
+
+    contextual_bt_fn = partial(
+        fit_contextual_bt, matchups, features, outcomes, models, alpha=alpha, reg=reg, tol=tol
+    )
+
+    boot_idxs = np.random.randint(
+        low=0, high=matchups.shape[0], size=(num_round, matchups.shape[0])
+    )
+
+    # this one is still memory and cpu intensive so don't make too many processes
+    with mp.Pool(4) as pool:
+        results = pool.map(contextual_bt_fn, boot_idxs)
+
+    ratings_params = np.array(results)
+    ratings = ratings_params[:,:len(models)]
+    params = ratings_params[:,len(models):]
+    scaled_ratings = scale_and_offset(ratings, models, scale, init_rating)
+    df = pd.DataFrame(scaled_ratings, columns=models)
+    return df[df.median().sort_values(ascending=False).index], params


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The bootstrap Bradley Terry model takes upwards of 15 minutes to run for 100 samples. This is costly on resources and hinders experiments such as studying hyperparameters like scale and base. With these changes the BT MLE bootstrap takes around 10 seconds. Parity tests are conducted in this repo: https://github.com/cthorrez/faster-arena-elo/tree/main



<!-- Please give a short summary of the change and the problem this solves. -->
* Added functions to:
  * preprocess battles into deduplicated unique outcomes (model_a, model_b, winner) weighted by occurrence count
  * compute and optimize the Bradley Terry log-likelihood on the deduplicated data
  * do bootstrap sampling directly in the deduplicated space by sampling counts for each possible outcome via multinomial and fit the bootstrap samples in parallel with multiprocessing
* modified the call in `__main__` to look at the new BT bootstrap function

## Checks

- [X] I've run `format.sh` to lint the changes in this PR.
- [N/A] I've included any doc changes needed. (interface in leaderboard.md is unchanged)
- [N/A?] I've made sure the relevant tests are passing (if applicable).
