### PR TITLE
[Ascend] Enable support for 310p NPUs

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -44,7 +44,7 @@ from fastchat.modules.awq import AWQConfig, load_awq_quantized
 from fastchat.modules.exllama import ExllamaConfig, load_exllama_model
 from fastchat.modules.xfastertransformer import load_xft_model, XftConfig
 from fastchat.modules.gptq import GptqConfig, load_gptq_quantized
-from fastchat.utils import get_gpu_memory
+from fastchat.utils import get_gpu_memory, get_npu_memory
 
 # Check an environment variable to check if we should be sharing Peft model
 # weights.  When false we treat all Peft models as separate.
@@ -861,7 +861,7 @@ class ChatGLMAdapter(BaseModelAdapter):
         return "chatglm" in model_path.lower()
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
-        # Disable JIT on-the-fly compilation
+        # Disable JIT just-in-time compilation
         torch.npu.set_compile_mode(jit_compile=False)
         revision = from_pretrained_kwargs.get("revision", "main")
         if "chatglm3" in model_path.lower():

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -44,7 +44,7 @@ from fastchat.modules.awq import AWQConfig, load_awq_quantized
 from fastchat.modules.exllama import ExllamaConfig, load_exllama_model
 from fastchat.modules.xfastertransformer import load_xft_model, XftConfig
 from fastchat.modules.gptq import GptqConfig, load_gptq_quantized
-from fastchat.utils import get_gpu_memory, get_npu_memory
+from fastchat.utils import get_gpu_memory, get_npu_memory, get_npu_type
 
 # Check an environment variable to check if we should be sharing Peft model
 # weights.  When false we treat all Peft models as separate.
@@ -719,7 +719,8 @@ class VicunaAdapter(BaseModelAdapter):
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
         # Disable JIT just-in-time compilation
-        torch.npu.set_compile_mode(jit_compile=False)
+        if get_npu_type().startswith("Ascend310P"):
+            torch.npu.set_compile_mode(jit_compile=False)
         revision = from_pretrained_kwargs.get("revision", "main")
         tokenizer = AutoTokenizer.from_pretrained(
             model_path, use_fast=self.use_fast_tokenizer, revision=revision
@@ -862,7 +863,8 @@ class ChatGLMAdapter(BaseModelAdapter):
 
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
         # Disable JIT just-in-time compilation
-        torch.npu.set_compile_mode(jit_compile=False)
+        if get_npu_type().startswith("Ascend310P"):
+            torch.npu.set_compile_mode(jit_compile=False)
         revision = from_pretrained_kwargs.get("revision", "main")
         if "chatglm3" in model_path.lower():
             tokenizer = AutoTokenizer.from_pretrained(

--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -149,6 +149,28 @@ def get_gpu_memory(max_gpus=None):
     return gpu_memory
 
 
+def get_npu_memory(max_npus=None):
+    """Get available memory for each NPU."""
+    import torch_npu
+
+    npu_memory = []
+    num_npus = (
+        torch_npu.npu.device_count()
+        if max_npus is None
+        else min(max_npus, torch_npu.npu.device_count())
+    )
+
+    for npu_id in range(num_npus):
+        with torch_npu.npu.device(npu_id):
+            device = torch_npu.npu.current_device()
+            npu_properties = torch_npu.npu.get_device_properties(device)
+            total_memory = npu_properties.total_memory / (1024**3)
+            allocated_memory = torch_npu.npu.memory_allocated() / (1024**3)
+            available_memory = total_memory - allocated_memory
+            npu_memory.append(available_memory)
+    return npu_memory
+
+
 def oai_moderation(text, custom_thresholds=None):
     """
     Check whether the text violates OpenAI moderation API.

--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -171,6 +171,16 @@ def get_npu_memory(max_npus=None):
     return npu_memory
 
 
+def get_npu_type():
+    import torch_npu
+    chip_type = ""
+    try:
+        chip_type = torch_npu.npu.get_device_name(0)
+    except AssertionError:
+        warnings.warn("No accessible NPU devices!")
+    return chip_type
+
+
 def oai_moderation(text, custom_thresholds=None):
     """
     Check whether the text violates OpenAI moderation API.


### PR DESCRIPTION
### Adapted models

- [x] ChatGLM3-6B
- [x] vicuna-7b-v1.3

:warning:Before loading ChatGLM3-6B, you need to modify the model code file!

- modeling_chatglm.py

~~~python
...
# @torch.jit.script
def apply_rotary_pos_emb(x: torch.Tensor, rope_cache: torch.Tensor) -> torch.Tensor:
    ...
~~~



### Environment Preparation

:information_source:Recommend that build a Docker image for environment setup.

- Docker: 20.10.2+
  - Ascend Docker Runtime Plugin: [Download](https://gitee.com/ascend/ascend-docker-runtime/releases/download/v6.0.0-RC2/Ascend-docker-runtime_6.0.RC2_linux-aarch64.run)

- NPU Driver and Firmware: [Download Page](https://www.hiascend.com/hardware/firmware-drivers/community?product=2&model=17&cann=8.0.RC2.beta1&driver=1.0.25.alpha)
- CANN: 8.0.RC2
- Python: 3.8+
  - torch-npu==2.1.0.post6
  - transformers>=4.41.0

### Inference with Command Line Interface

<img width="1246" alt="使用FastChat适配NPU" src="https://github.com/user-attachments/assets/9454a435-ed7c-4897-8065-eca14c2c1219">

##### Single NPU

~~~shell
python3 -m fastchat.serve.cli --model-path /opt/models/vicuna-7b-v1.3/ --device npu
~~~

##### Multiple NPUs

~~~shell
ASCEND_RT_VISIBLE_DEVICES=0,1 python3 -m fastchat.serve.cli --model-path /opt/models/vicuna-7b-v1.3/ --num-gpus 2 --device npu --max-gpu-memory 12GiB
~~~
