### PR TITLE
Fix gradio web server demo error

### DIFF
--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -251,7 +251,7 @@ def load_demo_single(context: Context, query_params):
 
 def load_demo(url_params, request: gr.Request):
     global models
-
+    all_models = models
     ip = get_ip(request)
     logger.info(f"load_demo. ip: {ip}. params: {url_params}")
 
@@ -259,8 +259,16 @@ def load_demo(url_params, request: gr.Request):
         models, all_models = get_model_list(
             controller_url, args.register_api_endpoint_file, vision_arena=False
         )
-
-    return load_demo_single(models, url_params)
+    # We're serving a single-model demo without vision_arena support, so we can just use the text models
+    context = Context(
+        models,
+        all_models,
+        [],  # vision_models
+        [],  # all_vision_models
+        models,
+        all_models,
+    )
+    return load_demo_single(context, url_params)
 
 
 def vote_last_response(state, vote_type, model_selector, request: gr.Request):


### PR DESCRIPTION
## Why are these changes needed?
A quick fix for the single-model Gradio web server. The original code was passing a list to the `Context` object, which caused an AttributeError. This PR corrects that issue by ensuring the proper `Context` object is passed.

## Related issue number (if applicable):  
#3595 

## Checks:  
- [x] I've run `format.sh` to lint the changes in this PR.  
- [x] I've included any necessary doc changes. (No doc changes required.)  
- [x] I've ensured that the relevant tests are passing (if applicable).

## Test:  
Follow the instructions [here](https://github.com/lm-sys/FastChat?tab=readme-ov-file#serving-with-web-gui), and the error no longer occurs after running the controller, model worker, and Gradio worker, then opening the browser.

