### PR TITLE
Add conversation id to metagen request

### DIFF
--- a/fastchat/serve/api_provider.py
+++ b/fastchat/serve/api_provider.py
@@ -244,6 +244,7 @@ def get_api_provider_stream_iter(
             max_new_tokens,
             api_base=model_api_dict["api_base"],
             api_key=model_api_dict["api_key"],
+            conversation_id=state.conv_id,
         )
     else:
         raise NotImplementedError()
@@ -1195,6 +1196,7 @@ def metagen_api_stream_iter(
     max_new_tokens,
     api_key,
     api_base,
+    conversation_id,
 ):
     try:
         text_messages = []
@@ -1227,6 +1229,7 @@ def metagen_api_stream_iter(
                 "model": model_name,
                 "chunks_delimited": True,
                 "messages": messages,
+                "conversation_id": conversation_id,
                 "options": {
                     "max_tokens": max_new_tokens,
                     "generation_algorithm": "top_p",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Slightly change metagen request format and add conversation id to metagen request.

## Checks

- [ x] I've made sure the relevant tests are passing (if applicable).

Tested this change on the legacy commit by 
```
python -m fastchat.serve.gradio_web_server --controller "" --share --register new_api_endpoints.json
```

It seems the cmd is broken in the most recent commit though.
