### PR TITLE
Remove loading of Copilot Arena tab when env variable is not set

### DIFF
--- a/fastchat/serve/monitor/copilot_arena.py
+++ b/fastchat/serve/monitor/copilot_arena.py
@@ -7,12 +7,6 @@ from fastchat.serve.monitor.monitor import recompute_final_ranking
 
 copilot_arena_leaderboard_url = os.getenv("COPILOT_ARENA_LEADERBOARD_URL")
 
-if not copilot_arena_leaderboard_url:
-    raise ValueError(
-        "COPILOT_ARENA_LEADERBOARD_URL environment variable is not set. "
-        "Please configure it to a valid URL."
-    )
-
 
 def process_copilot_arena_leaderboard(leaderboard):
     leaderboard = leaderboard.copy().loc[leaderboard["visibility"] == "public"]
@@ -41,9 +35,6 @@ def process_copilot_arena_leaderboard(leaderboard):
 
 
 def build_copilot_arena_tab():
-    if copilot_arena_leaderboard_url is None:
-        print("Copilot Arena Leaderboard URL is not set. Skipping this leaderboard.")
-        return
     response = requests.get(copilot_arena_leaderboard_url)
     if response.status_code == 200:
         leaderboard = pd.DataFrame(response.json()["elo_data"])

--- a/fastchat/serve/monitor/monitor.py
+++ b/fastchat/serve/monitor/monitor.py
@@ -1035,11 +1035,17 @@ def build_leaderboard_tab(
                     elo_results_text, model_table_df, model_to_score
                 )
             try:
-                with gr.Tab("Copilot Arena Leaderboard", id=5):
-                    from fastchat.serve.monitor.copilot_arena import (
-                        build_copilot_arena_tab,
-                    )
+                from fastchat.serve.monitor.copilot_arena import (
+                    build_copilot_arena_tab,
+                    copilot_arena_leaderboard_url,
+                )
 
+                if not copilot_arena_leaderboard_url:
+                    raise ValueError(
+                        "COPILOT_ARENA_LEADERBOARD_URL environment variable is not set. "
+                        "Please configure it to a valid URL."
+                    )
+                with gr.Tab("Copilot Arena Leaderboard", id=5):
                     build_copilot_arena_tab()
             except Exception as e:
                 print(f"Unable to build Copilot Arena's Leaderboard. Error: {e}")

--- a/fastchat/serve/monitor/monitor.py
+++ b/fastchat/serve/monitor/monitor.py
@@ -1034,21 +1034,21 @@ def build_leaderboard_tab(
                 build_full_leaderboard_tab(
                     elo_results_text, model_table_df, model_to_score
                 )
-            try:
-                from fastchat.serve.monitor.copilot_arena import (
-                    build_copilot_arena_tab,
-                    copilot_arena_leaderboard_url,
-                )
 
-                if not copilot_arena_leaderboard_url:
-                    raise ValueError(
-                        "COPILOT_ARENA_LEADERBOARD_URL environment variable is not set. "
-                        "Please configure it to a valid URL."
-                    )
+            from fastchat.serve.monitor.copilot_arena import (
+                build_copilot_arena_tab,
+                copilot_arena_leaderboard_url,
+            )
+
+            if copilot_arena_leaderboard_url:
                 with gr.Tab("Copilot Arena Leaderboard", id=5):
                     build_copilot_arena_tab()
-            except Exception as e:
-                print(f"Unable to build Copilot Arena's Leaderboard. Error: {e}")
+            else:
+                print(
+                    "Unable to build Copilot Arena's Leaderboard. "
+                    "COPILOT_ARENA_LEADERBOARD_URL environment variable is not set. "
+                    "Please configure it to a valid URL."
+                )
 
         if not show_plot:
             gr.Markdown(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Adding a small change to https://github.com/lm-sys/FastChat/pull/3618, which doesn't load the Copilot Arena leaderboard tab when the environment variable is not set.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
