### PR TITLE
feat: add new Jamba models

### DIFF
--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -133,7 +133,12 @@ register_model_info(
 )
 
 register_model_info(
-    ["jamba-1.5-large", "jamba-1.5-mini"],
+    [
+        "jamba-1.5-large-2024-08",
+        "jamba-1.5-mini-2024-08",
+        "jamba-1.5-large-2025-02",
+        "jamba-1.5-mini-2025-02",
+    ],
     "Jamba 1.5",
     "https://www.ai21.com/jamba",
     "Jamba by AI21 Labs",


### PR DESCRIPTION
## Why are these changes needed?

* Add new Jamba models - `jamba-1.5-large-2025-02`, `jamba-1.5-mini-2025-02`.
* Refactor the generic Jamba model names to their explicit names - `jamba-1.5-large-2024-08`, `jamba-1.5-mini-2024-08` (will still point to the same model).
