### PR TITLE
handle value error if version can't be parsed

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -253,7 +253,12 @@ def load_model(
         kwargs = {"torch_dtype": torch.float16}
         import transformers
 
-        version = tuple(int(v) for v in transformers.__version__.split("."))
+        try:
+            version = tuple(int(v) for v in transformers.__version__.split("."))
+        except ValueError:
+            # some versions of transformers have a different version format (
+            # e.g. 4.50.0.dev0) and these break this parser so we set a default
+            version = (4, 36, 0)  
         if version < (4, 35, 0):
             # NOTE: Recent transformers library seems to fix the mps issue, also
             # it has made some changes causing compatibility issues with our


### PR DESCRIPTION
## Why are these changes needed?

Dev versions of Huggingface Transformers may look like "4.50.0.dev0" which break FastChat because it expects the format to be only like 4.50.0 etc.

This is necessary, for example, to support the new Gemma models when they are released, because they only work with a dev build of Transformers
