### PR TITLE
Add Gemini-2.5 as a judge model

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -1531,6 +1531,74 @@ register_conv_template(
     )
 )
 
+register_conv_template(
+    Conversation(
+        name="gemini-2.5-flash-preview-09-2025",
+        roles=("user", "model"),
+        sep_style=SeparatorStyle.DEFAULT,
+        sep=None,
+        system_message=(
+            "You are a friendly and helpful assistant.\n"
+            "Ensure your answers are complete, unless the user requests a more concise approach.\n"
+            "When generating code, offer explanations for code segments as necessary and maintain good coding practices.\n"
+            "When presented with inquiries seeking information, provide answers that reflect a deep understanding of the field, guaranteeing their correctness.\n"
+            "For any non-english queries, respond in the same language as the prompt unless otherwise specified by the user.\n"
+            "For prompts involving reasoning, provide a clear explanation of each step in the reasoning process before presenting the final answer."
+        ),
+    )
+)
+
+register_conv_template(
+    Conversation(
+        name="gemini-2.5-flash-preview-05-20",
+        roles=("user", "model"),
+        sep_style=SeparatorStyle.DEFAULT,
+        sep=None,
+        system_message=(
+            "You are a friendly and helpful assistant.\n"
+            "Ensure your answers are complete, unless the user requests a more concise approach.\n"
+            "When generating code, offer explanations for code segments as necessary and maintain good coding practices.\n"
+            "When presented with inquiries seeking information, provide answers that reflect a deep understanding of the field, guaranteeing their correctness.\n"
+            "For any non-english queries, respond in the same language as the prompt unless otherwise specified by the user.\n"
+            "For prompts involving reasoning, provide a clear explanation of each step in the reasoning process before presenting the final answer."
+        ),
+    )
+)
+
+register_conv_template(
+    Conversation(
+        name="gemini-2.5-flash",
+        roles=("user", "model"),
+        sep_style=SeparatorStyle.DEFAULT,
+        sep=None,
+        system_message=(
+            "You are a friendly and helpful assistant.\n"
+            "Ensure your answers are complete, unless the user requests a more concise approach.\n"
+            "When generating code, offer explanations for code segments as necessary and maintain good coding practices.\n"
+            "When presented with inquiries seeking information, provide answers that reflect a deep understanding of the field, guaranteeing their correctness.\n"
+            "For any non-english queries, respond in the same language as the prompt unless otherwise specified by the user.\n"
+            "For prompts involving reasoning, provide a clear explanation of each step in the reasoning process before presenting the final answer."
+        ),
+    )
+)
+
+register_conv_template(
+    Conversation(
+        name="gemini-2.5-pro",
+        roles=("user", "model"),
+        sep_style=SeparatorStyle.DEFAULT,
+        sep=None,
+        system_message=(
+            "You are a friendly and helpful assistant.\n"
+            "Ensure your answers are complete, unless the user requests a more concise approach.\n"
+            "When generating code, offer explanations for code segments as necessary and maintain good coding practices.\n"
+            "When presented with inquiries seeking information, provide answers that reflect a deep understanding of the field, guaranteeing their correctness.\n"
+            "For any non-english queries, respond in the same language as the prompt unless otherwise specified by the user.\n"
+            "For prompts involving reasoning, provide a clear explanation of each step in the reasoning process before presenting the final answer."
+        ),
+    )
+)
+
 # BiLLa default template
 register_conv_template(
     Conversation(

--- a/fastchat/llm_judge/common.py
+++ b/fastchat/llm_judge/common.py
@@ -172,9 +172,7 @@ def run_judge_single(question, answer, judge, ref_answer, multi_turn=False):
             model, conv, temperature=0, max_tokens=1024
         )
     elif model in GOOGLE_MODEL_LIST:
-        judgment = chat_completion_google(
-            model, conv, temperature=0, max_tokens=2048
-        )
+        judgment = chat_completion_google(model, conv, temperature=0, max_tokens=2048)
     else:
         raise ValueError(f"Invalid judge model name: {model}")
 
@@ -508,15 +506,12 @@ def chat_completion_google(model, conv, temperature, max_tokens, api_dict=None):
     output = API_ERROR_OUTPUT
     for _ in range(API_MAX_RETRY):
         try:
-            client = genai.Client(api_key = api_key)
+            client = genai.Client(api_key=api_key)
             prompt = conv.get_prompt()
             response = client.models.generate_content(
-                model = model,
-                contents = prompt,
-                config = {
-                    "max_output_tokens": max_tokens,
-                    "temperature": temperature,
-                    }
+                model=model,
+                contents=prompt,
+                config={"max_output_tokens": max_tokens, "temperature": temperature,},
             )
             output = response.text
             if output is None:

--- a/fastchat/llm_judge/common.py
+++ b/fastchat/llm_judge/common.py
@@ -511,7 +511,10 @@ def chat_completion_google(model, conv, temperature, max_tokens, api_dict=None):
             response = client.models.generate_content(
                 model=model,
                 contents=prompt,
-                config={"max_output_tokens": max_tokens, "temperature": temperature,},
+                config={
+                    "max_output_tokens": max_tokens,
+                    "temperature": temperature,
+                },
             )
             output = response.text
             if output is None:

--- a/fastchat/llm_judge/gen_api_answer.py
+++ b/fastchat/llm_judge/gen_api_answer.py
@@ -18,10 +18,11 @@ from fastchat.llm_judge.common import (
     temperature_config,
     chat_completion_openai,
     chat_completion_anthropic,
+    chat_completion_google,
     chat_completion_palm,
 )
 from fastchat.llm_judge.gen_model_answer import reorg_answer_file
-from fastchat.model.model_adapter import get_conversation_template, ANTHROPIC_MODEL_LIST
+from fastchat.model.model_adapter import get_conversation_template, ANTHROPIC_MODEL_LIST, GOOGLE_MODEL_LIST
 
 
 def get_answer(
@@ -55,6 +56,8 @@ def get_answer(
                 chat_state, output = chat_completion_palm(
                     chat_state, model, conv, temperature, max_tokens
                 )
+            elif model in GOOGLE_MODEL_LIST:
+                output = chat_completion_google(model, conv, temperature, max_tokens)
             else:
                 output = chat_completion_openai(model, conv, temperature, max_tokens)
 

--- a/fastchat/llm_judge/gen_api_answer.py
+++ b/fastchat/llm_judge/gen_api_answer.py
@@ -22,7 +22,11 @@ from fastchat.llm_judge.common import (
     chat_completion_palm,
 )
 from fastchat.llm_judge.gen_model_answer import reorg_answer_file
-from fastchat.model.model_adapter import get_conversation_template, ANTHROPIC_MODEL_LIST, GOOGLE_MODEL_LIST
+from fastchat.model.model_adapter import (
+    get_conversation_template,
+    ANTHROPIC_MODEL_LIST,
+    GOOGLE_MODEL_LIST,
+)
 
 
 def get_answer(

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -93,6 +93,12 @@ OPENAI_MODEL_LIST = (
     "o1-mini",
 )
 
+GOOGLE_MODEL_LIST = (
+    "gemini-2.5-flash-preview-09-2025",
+    "gemini-2.5-flash",
+    "gemini-2.5-pro",
+)
+
 
 class BaseModelAdapter:
     """The base and the default model adapter."""
@@ -2244,6 +2250,10 @@ class GeminiAdapter(BaseModelAdapter):
     def get_default_conv_template(self, model_path: str) -> Conversation:
         if "gemini-1.5-pro" in model_path:
             return get_conv_template("gemini-1.5-pro")
+        elif "gemini-2.5-flash" in model_path:
+            return get_conv_template("gemini-2.5-flash")
+        elif "gemini-2.5-pro" in model_path:
+            return get_conv_template("gemini-2.5-pro")
         return get_conv_template("gemini")
 
 

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -91,6 +91,10 @@ register_model_info(
 
 register_model_info(
     [
+        "gemini-2.5-flash-preview-09-2025",
+        "gemini-2.5-flash-preview-05-20",
+        "gemini-2.5-flash",
+        "gemini-2.5-pro",
         "gemini-1.5-pro-exp-0827",
         "gemini-1.5-pro-exp-0801",
         "gemini-1.5-flash-exp-0827",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 model_worker = ["accelerate>=0.21", "peft", "sentencepiece", "torch", "transformers>=4.31.0", "protobuf", "openai", "anthropic"]
 webui = ["gradio>=4.10", "plotly", "scipy"]
 train = ["einops", "flash-attn>=2.0", "wandb"]
-llm_judge = ["openai<1", "anthropic>=0.3", "ray"]
+llm_judge = ["openai<1", "anthropic>=0.3", "ray", "google-genai"]
 dev = ["black==23.3.0", "pylint==2.8.2"]
 
 [project.urls]


### PR DESCRIPTION
Add gemini-2.5 as a judge model. Successfully tested using gemini-2.5-flash-preview-05-20 with google-genai==1.17.0.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. --> 
Gemini 2.5 is powerful enough to be a judge model and is cheaper than GPT4o.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ V ] I've included any doc changes needed.
- [ V ] I've made sure the relevant tests are passing (if applicable).
