### PR TITLE
Replace bare except clauses with except Exception

### DIFF
--- a/fastchat/serve/api_provider.py
+++ b/fastchat/serve/api_provider.py
@@ -1262,7 +1262,7 @@ def reka_api_stream_iter(
     for chunk in response:
         try:
             yield {"text": chunk.responses[0].chunk.content, "error_code": 0}
-        except:
+        except Exception:
             yield {
                 "text": f"**API REQUEST ERROR** ",
                 "error_code": 1,

--- a/fastchat/serve/monitor/monitor.py
+++ b/fastchat/serve/monitor/monitor.py
@@ -886,7 +886,7 @@ def get_combined_table(elo_results, model_table_df):
                 "Model"
             ].values[0]
             return model_name
-        except:
+        except Exception:
             return None
 
     combined_table = []

--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -450,7 +450,7 @@ def image_moderation_request(image_bytes, endpoint, api_key):
         try:
             if response["Status"]["Code"] == 3000:
                 break
-        except:
+        except Exception:
             time.sleep(0.5)
     return response
 

--- a/playground/test_embedding/test_semantic_search.py
+++ b/playground/test_embedding/test_semantic_search.py
@@ -11,7 +11,7 @@ from scipy.spatial.distance import cosine
 def cosine_similarity(vec1, vec2):
     try:
         return 1 - cosine(vec1, vec2)
-    except:
+    except Exception:
         print(vec1.shape, vec2.shape)
 
 


### PR DESCRIPTION
## Summary

- Replace all bare `except:` clauses with `except Exception:` across the codebase

## Problem

Bare `except:` catches `BaseException`, which includes `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`. This can:

- Prevent clean process shutdowns (e.g., `Ctrl+C` / `SIGTERM` gets swallowed)
- Mask critical system-level exceptions that should propagate
- Make debugging significantly harder by silently catching unexpected errors

## Changes

Replaced `except:` with `except Exception:` in four files:

| File | Context |
|------|---------|
| `fastchat/serve/api_provider.py` | Streaming response chunk parsing in `reka_api_stream_iter` |
| `fastchat/serve/monitor/monitor.py` | Model name lookup in `get_combined_table` |
| `fastchat/utils.py` | Retry loop in `image_moderation_request` |
| `playground/test_embedding/test_semantic_search.py` | `cosine_similarity` error handling |

## Why `except Exception` instead of more specific types

`except Exception` is the standard Python best practice for broad error handling ([PEP 8](https://peps.python.org/pep-0008/#programming-recommendations)). It catches all "regular" exceptions while correctly allowing `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` to propagate. This is the minimal safe fix with no behavioral change for normal error paths.

## Test plan

- [x] No behavioral change for normal exception handling — `Exception` is the base class for all non-system exceptions
- [x] Verified no remaining bare `except:` clauses in the codebase