### PR TITLE
Fix mutable default argument and unreachable exception handler

### DIFF
--- a/fastchat/llm_judge/common.py
+++ b/fastchat/llm_judge/common.py
@@ -454,12 +454,12 @@ def chat_completion_openai_azure(model, conv, temperature, max_tokens, api_dict=
             )
             output = response["choices"][0]["message"]["content"]
             break
-        except openai.error.OpenAIError as e:
-            print(type(e), e)
-            time.sleep(API_RETRY_SLEEP)
         except openai.error.InvalidRequestError as e:
             print(type(e), e)
             break
+        except openai.error.OpenAIError as e:
+            print(type(e), e)
+            time.sleep(API_RETRY_SLEEP)
         except KeyError:
             print(response)
             break

--- a/fastchat/serve/gradio_block_arena_anony.py
+++ b/fastchat/serve/gradio_block_arena_anony.py
@@ -190,7 +190,9 @@ SAMPLING_BOOST_MODELS = []
 OUTAGE_MODELS = []
 
 
-def get_sample_weight(model, outage_models, sampling_weights, sampling_boost_models=None):
+def get_sample_weight(
+    model, outage_models, sampling_weights, sampling_boost_models=None
+):
     if sampling_boost_models is None:
         sampling_boost_models = []
     if model in outage_models:

--- a/fastchat/serve/gradio_block_arena_anony.py
+++ b/fastchat/serve/gradio_block_arena_anony.py
@@ -190,7 +190,9 @@ SAMPLING_BOOST_MODELS = []
 OUTAGE_MODELS = []
 
 
-def get_sample_weight(model, outage_models, sampling_weights, sampling_boost_models=[]):
+def get_sample_weight(model, outage_models, sampling_weights, sampling_boost_models=None):
+    if sampling_boost_models is None:
+        sampling_boost_models = []
     if model in outage_models:
         return 0
     weight = sampling_weights.get(model, 0)


### PR DESCRIPTION
## Summary

- **`fastchat/serve/gradio_block_arena_anony.py`**: Replace mutable default argument `sampling_boost_models=[]` with `None` in `get_sample_weight()`. Mutable defaults are shared across all calls and can lead to subtle, hard-to-diagnose bugs when the list is mutated.

- **`fastchat/llm_judge/common.py`**: Reorder exception handlers in `chat_completion_openai_azure()` so that `openai.error.InvalidRequestError` is caught *before* its parent class `openai.error.OpenAIError`. The previous ordering made the `InvalidRequestError` handler unreachable dead code, meaning invalid request errors were retried instead of breaking immediately.

## Test plan

- [x] Verified `get_sample_weight()` still works correctly with and without `sampling_boost_models` argument
- [x] Verified exception handler ordering now catches `InvalidRequestError` before the generic `OpenAIError`
- [x] No functional changes beyond the bug fixes