### PR TITLE
fix: replace 4 bare except clauses with except Exception

### DIFF
--- a/fastchat/serve/api_provider.py
+++ b/fastchat/serve/api_provider.py
@@ -1262,7 +1262,7 @@ def reka_api_stream_iter(
     for chunk in response:
         try:
             yield {"text": chunk.responses[0].chunk.content, "error_code": 0}
-        except:
+        except Exception:
             yield {
                 "text": f"**API REQUEST ERROR** ",
                 "error_code": 1,

--- a/fastchat/serve/monitor/monitor.py
+++ b/fastchat/serve/monitor/monitor.py
@@ -886,7 +886,7 @@ def get_combined_table(elo_results, model_table_df):
                 "Model"
             ].values[0]
             return model_name
-        except:
+        except Exception:
             return None
 
     combined_table = []

--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -450,7 +450,7 @@ def image_moderation_request(image_bytes, endpoint, api_key):
         try:
             if response["Status"]["Code"] == 3000:
                 break
-        except:
+        except Exception:
             time.sleep(0.5)
     return response
 

--- a/playground/test_embedding/test_semantic_search.py
+++ b/playground/test_embedding/test_semantic_search.py
@@ -11,7 +11,7 @@ from scipy.spatial.distance import cosine
 def cosine_similarity(vec1, vec2):
     try:
         return 1 - cosine(vec1, vec2)
-    except:
+    except Exception:
         print(vec1.shape, vec2.shape)
 
 


### PR DESCRIPTION
## What
Replace 4 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.