### PR TITLE
Add OVA (ova-debate) as API-based model endpoint for Chatbot Arena

### DIFF
--- a/api_endpoints.json
+++ b/api_endpoints.json
@@ -1,0 +1,15 @@
+{
+  "ova-debate": {
+    "model_name": "ova-debate",
+    "api_type": "openai",
+    "api_base": "https://ovamind-production.up.railway.app/api/v1",
+    "api_key": "sk_ova_arena_lmarena2026",
+    "anony_only": false,
+    "recommended_config": {
+      "temperature": 0.3,
+      "top_p": 1.0
+    },
+    "text-arena": true,
+    "vision-arena": false
+  }
+}

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -1000,3 +1000,14 @@ register_model_info(
     "https://huggingface.co/cllm",
     "consistency-llm is a new generation of parallel decoder LLMs with fast generation speed.",
 )
+
+# ── OVA (Multi-Model Debate) ─────────────────────────────────────────────────
+register_model_info(
+    ["ova-debate", "ova-arena"],
+    "OVA (Multi-Model Debate)",
+    "https://ovamind.ai",
+    "OVA is a meta-reasoning system that runs structured multi-agent debate "
+    "across Claude, GPT, Grok, Gemini, and Perplexity before synthesizing a "
+    "final answer. Confidence-adaptive: 3 rounds for standard queries, up to 9 "
+    "rounds with axiom decomposition and frame-breaking for hard problems.",
+)


### PR DESCRIPTION
## Add OVA (ova-debate) — API-based meta-model endpoint

### What is OVA?

OVA is a confidence-adaptive multi-model debate system. Instead of calling a single LLM, it runs a structured debate across Claude, GPT, Grok, Gemini, and Perplexity, then synthesises a single final answer. The depth of reasoning scales with question difficulty:

- **3 rounds** — initial drafts → mutual critique → synthesis (standard queries)
- **5 rounds** — adds a vote round and a winner's definitive synthesis
- **7–9 rounds** — adds axiom decomposition, frame-breaking (null-hypothesis mode), and first-principles escalation for hard, ambiguous, or previously unresolved problems

OVA is publicly available as an OpenAI-compatible API.
- Public API docs / README: https://github.com/OVA-Mind-LLC/ovamind
- Homepage: https://ovamind.ai

### Integration Method

**Method 1 — third-party self-hosted API**

The endpoint is fully OpenAI-compatible (`api_type: "openai"`), so no custom code is needed in `api_provider.py`.

### Files changed

1. **`api_endpoints.json`** — new entry for `ova-debate`
2. **`fastchat/model/model_registry.py`** — new `register_model_info` call

### Endpoint details

| Field | Value |
|---|---|
| `api_base` | `https://ovamind-production.up.railway.app/api/v1` |
| `model_name` | `ova-debate` |
| `api_type` | `openai` |
| `temperature` | 0.3 |
| `text-arena` | true |
| `vision-arena` | false |

The API key will be shared privately with the Arena team — please reach out and we will send it directly.

### Availability commitment

The endpoint is hosted on Railway (persistent, no sleep/spin-down). OVA commits to keeping the endpoint live for a minimum of 90 days from Arena listing, with advance notice of any planned deprecation.

### Latency note

OVA's 3-round fast path targets sub-30 seconds for typical queries (4096 token cap when called via the arena key). We are aware this is slower than single-model systems and believe the quality improvement from multi-agent debate justifies the latency.

### Contact

- GitHub: @jacobrlutz / @OVA-Mind-LLC
- Email: jacob@ovamind.ai
