### PR TITLE
fix: add missing return after no-worker error in controller stream generator

### DIFF
--- a/fastchat/serve/controller.py
+++ b/fastchat/serve/controller.py
@@ -267,6 +267,7 @@ class Controller:
         worker_addr = self.get_worker_address(params["model"])
         if not worker_addr:
             yield self.handle_no_worker(params)
+            return
 
         try:
             response = requests.post(


### PR DESCRIPTION
## Summary

- In `Controller.worker_api_generate_stream()`, when no worker is available for the requested model, the code yields an error response but does **not** return from the generator. This causes execution to fall through into the `try` block, which attempts a POST request to an empty URL (`"" + "/worker_generate_stream"`), raising a `MissingSchema`/`ConnectionError`. That exception is caught and a second, misleading "worker timeout" error is yielded to the client.
- Adding `return` after the no-worker yield ensures the generator terminates cleanly with only the correct error message.

## How to reproduce

1. Start a controller with no workers registered
2. Send a `/worker_generate_stream` request to the controller
3. Observe that the client receives two error chunks instead of one: first the "no worker" error, then a spurious "worker timeout" error

## Test plan

- [x] Verified the fix by reading the control flow — `yield` in a generator does not exit the function, so `return` is required
- [x] No other callers of `handle_no_worker` are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)