### PR TITLE
fix: per-sequence token counts in batch embedding averaging

### DIFF
--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -171,7 +171,7 @@ class ModelWorker(BaseModelWorker):
             mask = attention_mask.unsqueeze(-1).expand(data.size()).float()
             masked_embeddings = data * mask
             sum_embeddings = torch.sum(masked_embeddings, dim=1)
-        token_num = torch.sum(attention_mask).item()
+        token_num = attention_mask.sum(dim=1, keepdim=True)
 
         return sum_embeddings, token_num
 
@@ -224,10 +224,10 @@ class ModelWorker(BaseModelWorker):
                 ):
                     embedding = embedding / token_num
                 normalized_embeddings = F.normalize(embedding, p=2, dim=1)
-                ret["token_num"] = token_num
+                ret["token_num"] = token_num.sum().item()
             else:
                 all_embeddings = []
-                all_token_num = 0
+                all_token_num = 0  # per-sequence tensor, accumulated across chunks
                 for i in range(0, input_ids.size(1), self.context_len):
                     chunk_input_ids = input_ids[:, i : i + self.context_len]
                     chunk_attention_mask = attention_mask[:, i : i + self.context_len]
@@ -273,7 +273,7 @@ class ModelWorker(BaseModelWorker):
                 embedding = torch.sum(all_embeddings_tensor, dim=0) / all_token_num
                 normalized_embeddings = F.normalize(embedding, p=2, dim=1)
 
-                ret["token_num"] = all_token_num
+                ret["token_num"] = all_token_num.sum().item() if isinstance(all_token_num, torch.Tensor) else all_token_num
 
             if base64_encode == "base64":
                 out_embeddings = self.__encode_base64(normalized_embeddings)

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -273,7 +273,11 @@ class ModelWorker(BaseModelWorker):
                 embedding = torch.sum(all_embeddings_tensor, dim=0) / all_token_num
                 normalized_embeddings = F.normalize(embedding, p=2, dim=1)
 
-                ret["token_num"] = all_token_num.sum().item() if isinstance(all_token_num, torch.Tensor) else all_token_num
+                ret["token_num"] = (
+                    all_token_num.sum().item()
+                    if isinstance(all_token_num, torch.Tensor)
+                    else all_token_num
+                )
 
             if base64_encode == "base64":
                 out_embeddings = self.__encode_base64(normalized_embeddings)


### PR DESCRIPTION
## Summary

- **Bug**: `__process_embed_chunk` computed `token_num = torch.sum(attention_mask).item()`, which sums tokens across the entire batch into a single scalar. When `batch_size > 1`, every sequence's mean-pooled embedding was divided by this aggregate count instead of its own token count, silently producing incorrect embeddings.
- **Fix**: Replace with `attention_mask.sum(dim=1, keepdim=True)` to get per-sequence token counts (shape `(batch, 1)`), so each embedding is normalized correctly via broadcasting.
- The `ret["token_num"]` metadata field (total tokens for billing/logging) is preserved as a scalar via `.sum().item()`.

## Details

The bug affects both code paths in `get_embeddings`:
1. **Truncate path** (line 225): `embedding / token_num` now broadcasts correctly per sequence.
2. **Chunked path** (lines 267-273): `chunk_embeddings * token_num` and the final `/ all_token_num` both broadcast correctly with the `(batch, 1)` shape.

When `batch_size == 1`, the old and new behavior produce identical results, which is why this went undetected.

## Test plan

- [ ] Verify with `batch_size=1`: results unchanged
- [ ] Verify with `batch_size>1` and variable-length sequences: each embedding should now differ from the old (incorrect) output
- [ ] Confirm `ret["token_num"]` remains a scalar integer

🤖 Generated with [Claude Code](https://claude.com/claude-code)