### PR TITLE
fix: correct stderr logger level from ERROR to WARNING

### DIFF
--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -52,8 +52,8 @@ def build_logger(logger_name, logger_filename):
     sys.stdout = sl
 
     stderr_logger = logging.getLogger("stderr")
-    stderr_logger.setLevel(logging.ERROR)
-    sl = StreamToLogger(stderr_logger, logging.ERROR)
+    stderr_logger.setLevel(logging.INFO)
+    sl = StreamToLogger(stderr_logger, logging.WARNING)
     sys.stderr = sl
 
     # Get logger


### PR DESCRIPTION
## Summary
- Fixed `stderr_logger` level in `build_logger()` from `ERROR` to `INFO` (matching `stdout_logger`)
- Fixed `StreamToLogger` for stderr from `logging.ERROR` to `logging.WARNING` to properly reflect stderr's typical content
- Previously, stderr output was being logged at ERROR level, which incorrectly elevated warnings and informational stderr messages to errors

## Details
In `fastchat/utils.py`, the `build_logger()` function sets up stream redirection for both stdout and stderr. The stdout logger correctly uses `INFO` level, but stderr was using `ERROR` for both the logger level and the StreamToLogger level.

This means:
1. Any stderr output (including normal warnings from libraries like `transformers`, `torch`, etc.) gets logged as ERROR
2. The `stderr_logger.setLevel(logging.ERROR)` filters out anything below ERROR, so WARNING-level messages from stderr would be silently dropped

The fix:
- `stderr_logger.setLevel(logging.INFO)` — matches stdout_logger, allows all messages through
- `StreamToLogger(stderr_logger, logging.WARNING)` — logs stderr at WARNING level, which is the appropriate severity for stderr content

## Test plan
- [ ] Verify stderr messages from libraries (e.g., transformers deprecation warnings) now appear in logs at WARNING level instead of ERROR
- [ ] Verify stdout logging behavior is unchanged
- [ ] Run `python -c "from fastchat.utils import build_logger; logger = build_logger('test', 'test.log')"` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)