### PR TITLE
fix(security): sanitize HTML in chat UI to prevent XSS injection

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -374,9 +374,7 @@ class Conversation:
                         img_str = f'<img src="{html.escape(image.url)}" alt="user upload image" />'
                     elif image.image_format == ImageFormat.BYTES:
                         img_str = f'<img src="data:image/{html.escape(image.filetype)};base64,{image.base64_str}" alt="user upload image" />'
-                    msg = img_str + html.escape(
-                        msg.replace("<image>\n", "").strip()
-                    )
+                    msg = img_str + html.escape(msg.replace("<image>\n", "").strip())
                 else:
                     if msg is not None:
                         msg = html.escape(msg)

--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -8,6 +8,7 @@ If you have any changes in mind, please contribute back so the community can ben
 import base64
 import dataclasses
 from enum import auto, IntEnum
+import html
 from io import BytesIO
 import os
 from typing import List, Any, Dict, Union, Tuple
@@ -370,13 +371,20 @@ class Conversation:
                     msg, images = msg
                     image = images[0]  # Only one image on gradio at one time
                     if image.image_format == ImageFormat.URL:
-                        img_str = f'<img src="{image.url}" alt="user upload image" />'
+                        img_str = f'<img src="{html.escape(image.url)}" alt="user upload image" />'
                     elif image.image_format == ImageFormat.BYTES:
-                        img_str = f'<img src="data:image/{image.filetype};base64,{image.base64_str}" alt="user upload image" />'
-                    msg = img_str + msg.replace("<image>\n", "").strip()
+                        img_str = f'<img src="data:image/{html.escape(image.filetype)};base64,{image.base64_str}" alt="user upload image" />'
+                    msg = img_str + html.escape(
+                        msg.replace("<image>\n", "").strip()
+                    )
+                else:
+                    if msg is not None:
+                        msg = html.escape(msg)
 
                 ret.append([msg, None])
             else:
+                if msg is not None:
+                    msg = html.escape(msg)
                 ret[-1][-1] = msg
         return ret
 

--- a/fastchat/serve/gradio_block_arena_anony.py
+++ b/fastchat/serve/gradio_block_arena_anony.py
@@ -480,6 +480,7 @@ def build_side_by_side_ui_anony(models):
                         elem_id="chatbot",
                         height=650,
                         show_copy_button=True,
+                        sanitize_html=True,
                         latex_delimiters=[
                             {"left": "$", "right": "$", "display": False},
                             {"left": "$$", "right": "$$", "display": True},

--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -358,6 +358,7 @@ def build_side_by_side_ui_named(models):
                         elem_id=f"chatbot",
                         height=650,
                         show_copy_button=True,
+                        sanitize_html=True,
                         latex_delimiters=[
                             {"left": "$", "right": "$", "display": False},
                             {"left": "$$", "right": "$$", "display": True},

--- a/fastchat/serve/gradio_block_arena_vision.py
+++ b/fastchat/serve/gradio_block_arena_vision.py
@@ -356,6 +356,7 @@ Note: You can only chat with <span style='color: #DE3163; font-weight: bold'>one
                 label="Scroll down and start chatting",
                 height=650,
                 show_copy_button=True,
+                sanitize_html=True,
                 latex_delimiters=[
                     {"left": "$", "right": "$", "display": False},
                     {"left": "$$", "right": "$$", "display": True},

--- a/fastchat/serve/gradio_block_arena_vision_anony.py
+++ b/fastchat/serve/gradio_block_arena_vision_anony.py
@@ -432,6 +432,7 @@ def build_side_by_side_vision_ui_anony(context: Context, random_questions=None):
                                 elem_id="chatbot",
                                 height=650,
                                 show_copy_button=True,
+                                sanitize_html=True,
                                 latex_delimiters=[
                                     {"left": "$", "right": "$", "display": False},
                                     {"left": "$$", "right": "$$", "display": True},

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -372,6 +372,7 @@ Note: You can only chat with <span style='color: #DE3163; font-weight: bold'>one
                                 elem_id=f"chatbot",
                                 height=650,
                                 show_copy_button=True,
+                                sanitize_html=True,
                                 latex_delimiters=[
                                     {"left": "$", "right": "$", "display": False},
                                     {"left": "$$", "right": "$$", "display": True},

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -927,6 +927,7 @@ def build_single_model_ui(models, add_promotion_links=False):
             label="Scroll down and start chatting",
             height=650,
             show_copy_button=True,
+            sanitize_html=True,
             latex_delimiters=[
                 {"left": "$", "right": "$", "display": False},
                 {"left": "$$", "right": "$$", "display": True},


### PR DESCRIPTION
## Summary

- Escape HTML entities in user messages and model responses in `Conversation.to_gradio_chatbot()` using `html.escape()`, preventing raw HTML/JS from being rendered in the chat UI
- Escape dynamic attributes (URL, filetype) in programmatically constructed `<img>` tags for uploaded images
- Add `sanitize_html=True` to all 6 `gr.Chatbot()` instances across all Gradio UI modules as defense-in-depth

## Vulnerability

Both user input and model output were passed **unescaped** to Gradio's Chatbot component. This allowed:

1. **Direct injection**: A user could type `<img onerror=alert(1) src=#>` and it would execute JavaScript
2. **Model-driven injection**: A model could be prompted to return HTML that executes scripts in the viewer's browser
3. **Stored XSS in arena**: In battle/arena modes, injected HTML could affect other users viewing shared conversations

Reproduction (from #88):
```
concatenate "<img src='' onerror=javascript:alert(1)" and "/>"
```

## Approach

The fix applies **output escaping** (not input sanitization), which is the correct strategy because:
- Input sanitization doesn't work here since models transform input unpredictably
- The model itself can generate malicious HTML regardless of input filtering
- Escaping at the rendering boundary catches all vectors

Intentionally constructed `<img>` tags for user-uploaded images are preserved since they use trusted data (image objects from Gradio's upload handler), but their dynamic attributes are also escaped as a precaution.

## Files changed

| File | Change |
|------|--------|
| `fastchat/conversation.py` | Add `html.escape()` to text messages in `to_gradio_chatbot()` |
| `fastchat/serve/gradio_web_server.py` | Add `sanitize_html=True` to `gr.Chatbot()` |
| `fastchat/serve/gradio_block_arena_anony.py` | Add `sanitize_html=True` to `gr.Chatbot()` |
| `fastchat/serve/gradio_block_arena_named.py` | Add `sanitize_html=True` to `gr.Chatbot()` |
| `fastchat/serve/gradio_block_arena_vision.py` | Add `sanitize_html=True` to `gr.Chatbot()` |
| `fastchat/serve/gradio_block_arena_vision_anony.py` | Add `sanitize_html=True` to `gr.Chatbot()` |
| `fastchat/serve/gradio_block_arena_vision_named.py` | Add `sanitize_html=True` to `gr.Chatbot()` |

## Test plan

- [ ] Start the Gradio web server and type `<img onerror=alert(1) src=#>` — should display as plain text, not execute
- [ ] Type `<script>alert('xss')</script>` — should display as plain text
- [ ] Upload an image and chat — image should still render correctly
- [ ] Verify LaTeX rendering still works (e.g. `$E=mc^2$`)
- [ ] Test arena mode (both anonymous and named) with HTML input

Fixes #3154
Fixes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)