### PR TITLE
fix: wrap remaining blocking calls with asyncio.to_thread to prevent DoS

### DIFF
--- a/fastchat/serve/base_model_worker.py
+++ b/fastchat/serve/base_model_worker.py
@@ -215,7 +215,7 @@ async def api_generate(request: Request):
 async def api_get_embeddings(request: Request):
     params = await request.json()
     await acquire_worker_semaphore()
-    embedding = worker.get_embeddings(params)
+    embedding = await asyncio.to_thread(worker.get_embeddings, params)
     release_worker_semaphore()
     return JSONResponse(content=embedding)
 

--- a/fastchat/serve/huggingface_api_worker.py
+++ b/fastchat/serve/huggingface_api_worker.py
@@ -233,7 +233,7 @@ async def api_generate(request: Request):
     params = await request.json()
     worker = worker_map[params["model"]]
     await acquire_worker_semaphore(worker)
-    output = worker.generate_gate(params)
+    output = await asyncio.to_thread(worker.generate_gate, params)
     release_worker_semaphore(worker)
     return JSONResponse(output)
 

--- a/fastchat/serve/multi_model_worker.py
+++ b/fastchat/serve/multi_model_worker.py
@@ -109,7 +109,7 @@ async def api_generate(request: Request):
     params = await request.json()
     await acquire_worker_semaphore()
     worker = worker_map[params["model"]]
-    output = worker.generate_gate(params)
+    output = await asyncio.to_thread(worker.generate_gate, params)
     release_worker_semaphore()
     return JSONResponse(output)
 


### PR DESCRIPTION
## Summary
- Fixes #3833
- Wraps 3 remaining synchronous blocking calls with `asyncio.to_thread()` to prevent event loop blocking
- Matches the pattern already applied in `base_model_worker.py:api_generate()` (commit ff66426)

### Changes
1. `base_model_worker.py:api_get_embeddings()` — wrap `worker.get_embeddings(params)` 
2. `multi_model_worker.py:api_generate()` — wrap `worker.generate_gate(params)`
3. `huggingface_api_worker.py:api_generate()` — wrap `worker.generate_gate(params)`

## Test plan
- [ ] Verify each wrapped call still functions correctly
- [ ] Confirm event loop is no longer blocked during inference
- [ ] Run existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)