### PR TITLE
Fix batch embedding averaging for batch_size > 1

### DIFF
--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -171,7 +171,7 @@ class ModelWorker(BaseModelWorker):
             mask = attention_mask.unsqueeze(-1).expand(data.size()).float()
             masked_embeddings = data * mask
             sum_embeddings = torch.sum(masked_embeddings, dim=1)
-        token_num = torch.sum(attention_mask).item()
+        token_num = attention_mask.sum(dim=1, keepdim=True)
 
         return sum_embeddings, token_num
 
@@ -224,7 +224,7 @@ class ModelWorker(BaseModelWorker):
                 ):
                     embedding = embedding / token_num
                 normalized_embeddings = F.normalize(embedding, p=2, dim=1)
-                ret["token_num"] = token_num
+                ret["token_num"] = token_num.sum().item()
             else:
                 all_embeddings = []
                 all_token_num = 0
@@ -273,7 +273,7 @@ class ModelWorker(BaseModelWorker):
                 embedding = torch.sum(all_embeddings_tensor, dim=0) / all_token_num
                 normalized_embeddings = F.normalize(embedding, p=2, dim=1)
 
-                ret["token_num"] = all_token_num
+                ret["token_num"] = all_token_num.sum().item()
 
             if base64_encode == "base64":
                 out_embeddings = self.__encode_base64(normalized_embeddings)


### PR DESCRIPTION
## Summary

- Fix incorrect embedding averaging in `model_worker.py` when `batch_size > 1`
- `token_num` was computed as a single scalar (`torch.sum(attention_mask).item()`) summing tokens across the entire batch, causing each sequence's embedding to be divided by the total token count of all sequences instead of its own
- Changed to per-sequence token counts using `attention_mask.sum(dim=1, keepdim=True)` so each sequence is correctly normalized by its own token count

Fixes #3785

## Test plan

- [ ] Verify embedding output for single-sequence input remains unchanged
- [ ] Verify embedding output for multi-sequence batch (batch_size > 1) now correctly averages each sequence independently
- [ ] Confirm `ret["token_num"]` still returns the correct total token count as a scalar

🤖 Generated with [Claude Code](https://claude.com/claude-code)