### PR TITLE
Fix UnboundLocalError in generate_gate when generator yields nothing

### DIFF
--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -144,6 +144,7 @@ class ModelWorker(BaseModelWorker):
             yield json.dumps(ret).encode() + b"\0"
 
     def generate_gate(self, params):
+        x = b"{}\0"
         for x in self.generate_stream_gate(params):
             pass
         return json.loads(x[:-1].decode())


### PR DESCRIPTION
## Summary
- Fixes `UnboundLocalError` in `ModelWorker.generate_gate()` when `generate_stream_gate()` yields no items
- Initializes `x = b"{}\0"` before the loop so the variable is always defined, returning an empty dict as a safe default

## Details
In `fastchat/serve/model_worker.py`, the `generate_gate` method iterates over `generate_stream_gate(params)` and uses the last yielded value `x` after the loop. If the generator yields nothing, `x` is never assigned, causing an `UnboundLocalError`.

Fixes #3786

## Test plan
- [ ] Verify that `generate_gate` no longer crashes when `generate_stream_gate` yields no items
- [ ] Verify normal behavior is unchanged when the generator does yield items

🤖 Generated with [Claude Code](https://claude.com/claude-code)