### PR TITLE
Fix moderation filter checking wrong model in arena side-by-side views

### DIFF
--- a/fastchat/serve/gradio_block_arena_anony.py
+++ b/fastchat/serve/gradio_block_arena_anony.py
@@ -307,7 +307,7 @@ def add_text(
     model_list = [states[i].model_name for i in range(num_sides)]
     # turn on moderation in battle mode
     all_conv_text_left = states[0].conv.get_prompt()
-    all_conv_text_right = states[0].conv.get_prompt()
+    all_conv_text_right = states[1].conv.get_prompt()
     all_conv_text = (
         all_conv_text_left[-1000:] + all_conv_text_right[-1000:] + "\nuser: " + text
     )

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -242,7 +242,7 @@ def add_text(
 
     model_list = [states[i].model_name for i in range(num_sides)]
     all_conv_text_left = states[0].conv.get_prompt()
-    all_conv_text_right = states[0].conv.get_prompt()
+    all_conv_text_right = states[1].conv.get_prompt()
     all_conv_text = (
         all_conv_text_left[-1000:] + all_conv_text_right[-1000:] + "\nuser: " + text
     )


### PR DESCRIPTION
## Summary
- Fixes a copy-paste bug where `all_conv_text_right` read from `states[0]` (left model) instead of `states[1]` (right model) in two arena files
- This meant the right-side model's conversation was never checked by the moderation filter, allowing content policy violations to bypass detection
- The same bug was already fixed in `gradio_block_arena_named.py` (commit 34eca62) but missed in `gradio_block_arena_anony.py` and `gradio_block_arena_vision_named.py`

Fixes #3794

## Changes
- `fastchat/serve/gradio_block_arena_anony.py` line 310: `states[0]` → `states[1]`
- `fastchat/serve/gradio_block_arena_vision_named.py` line 245: `states[0]` → `states[1]`

## Test plan
- [ ] Verify moderation filter triggers on right-side model content in anonymous arena
- [ ] Verify moderation filter triggers on right-side model content in vision named arena
- [ ] Confirm no regression in left-side model moderation

🤖 Generated with [Claude Code](https://claude.com/claude-code)