### PR TITLE
Fix off-by-one in completion_tokens count in generate_stream

### DIFF
--- a/fastchat/serve/inference.py
+++ b/fastchat/serve/inference.py
@@ -279,8 +279,8 @@ def generate_stream(
                     "logprobs": ret_logprobs,
                     "usage": {
                         "prompt_tokens": input_echo_len,
-                        "completion_tokens": i,
-                        "total_tokens": input_echo_len + i,
+                        "completion_tokens": i + 1,
+                        "total_tokens": input_echo_len + i + 1,
                     },
                     "finish_reason": None,
                 }
@@ -300,8 +300,8 @@ def generate_stream(
         "logprobs": ret_logprobs,
         "usage": {
             "prompt_tokens": input_echo_len,
-            "completion_tokens": i,
-            "total_tokens": input_echo_len + i,
+            "completion_tokens": i + 1,
+            "total_tokens": input_echo_len + i + 1,
         },
         "finish_reason": finish_reason,
     }


### PR DESCRIPTION
## Summary

In `generate_stream()`, the loop `for i in range(max_new_tokens)` generates a token and appends it to `output_ids` before yielding. However, the usage dict reports `completion_tokens: i` instead of `i + 1`. Since `i` is 0-indexed and the token is already appended by the time the yield executes, this undercounts by exactly 1 on every streaming chunk and on the final response.

**Example:** After the first token is generated (`i=0`), the response reports `completion_tokens: 0` instead of `1`. After N tokens, it reports `N-1` instead of `N`.

**Fix:** Use `i + 1` for `completion_tokens` and `total_tokens` in both the streaming yield (line 282-283) and the final yield (line 303-304).

**Reference:** The vLLM worker (`vllm_worker.py`) correctly uses `len(output.token_ids)` for the same field, confirming the intended semantics.

## Test plan

- [ ] Verify with a simple generation request that `completion_tokens` matches the actual number of tokens in the response
- [ ] Confirm `total_tokens = prompt_tokens + completion_tokens` holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)