### PR TITLE
Fix bitwise NOT (~) on boolean in tokenizer fallback

### DIFF
--- a/fastchat/model/compression.py
+++ b/fastchat/model/compression.py
@@ -115,7 +115,7 @@ def load_compress_model(model_path, device, torch_dtype, use_fast, revision="mai
         )
     except TypeError:
         tokenizer = AutoTokenizer.from_pretrained(
-            model_path, use_fast=~use_fast, revision=revision, trust_remote_code=True
+            model_path, use_fast=not use_fast, revision=revision, trust_remote_code=True
         )
     with init_empty_weights():
         # `trust_remote_code` should be set as `True` for both AutoConfig and AutoModel


### PR DESCRIPTION
## Bug

In `load_compress_model()`, when `AutoTokenizer.from_pretrained` raises a `TypeError`, the fallback retries with `use_fast=~use_fast`. The `~` operator is Python's bitwise NOT, not logical NOT:

- `~True` → `-2` (truthy)
- `~False` → `-1` (truthy)

So the fallback **never actually flips** `use_fast` — it always passes a truthy value, defeating the purpose of the retry.

## Fix

Replace `~use_fast` with `not use_fast` for correct boolean negation.

Note: the analogous code in `model_adapter.py` (line 116) correctly hardcodes `use_fast=False` in its fallback, confirming the intended behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>