### PR TITLE
Fix ModelPermission.is_blocking type annotation (str -> bool)

### DIFF
--- a/fastchat/protocol/openai_api_protocol.py
+++ b/fastchat/protocol/openai_api_protocol.py
@@ -24,7 +24,7 @@ class ModelPermission(BaseModel):
     allow_fine_tuning: bool = False
     organization: str = "*"
     group: Optional[str] = None
-    is_blocking: str = False
+    is_blocking: bool = False
 
 
 class ModelCard(BaseModel):


### PR DESCRIPTION
## Bug

`ModelPermission.is_blocking` in `fastchat/protocol/openai_api_protocol.py` is annotated as `str` but defaults to `False` (a `bool`):

```python
is_blocking: str = False
```

## Root cause

This is a typo dating back to the initial commit of the file. All other permission flags on `ModelPermission` (`allow_create_engine`, `allow_sampling`, `allow_logprobs`, `allow_search_indices`, `allow_view`, `allow_fine_tuning`) are typed as `bool`, and OpenAI's `ModelPermission` schema (which this class mirrors for the `/v1/models` response at `fastchat/serve/openai_api_server.py:407`) defines `is_blocking` as a boolean. The intended type is clearly `bool` — it got typo'd to `str`.

## Fix

Change the annotation from `str` to `bool` so it matches the default value and the upstream OpenAI contract:

```python
is_blocking: bool = False
```

One-line change, no behavioral risk for existing consumers that already treat the field as a boolean; clients parsing `/v1/models` strictly as the OpenAI schema now get the correct JSON type.