### PR TITLE
Fix off-by-one in is_partial_stop causing false positives

### DIFF
--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -330,7 +330,7 @@ def parse_gradio_auth_creds(filename: str):
 
 def is_partial_stop(output: str, stop_str: str):
     """Check whether the output contains a partial stop str."""
-    for i in range(0, min(len(output), len(stop_str))):
+    for i in range(1, min(len(output), len(stop_str)) + 1):
         if stop_str.startswith(output[-i:]):
             return True
     return False


### PR DESCRIPTION
## Summary

`is_partial_stop` checks whether the tail of the streaming output is a partial match for a stop string. The loop range `range(0, min(len(output), len(stop_str)))` has two bugs:

1. **`i=0` on first iteration**: `output[-0:]` in Python evaluates to `output[0:]` — the *entire* string, not an empty suffix. So `stop_str.startswith(output)` is tested, returning `True` whenever the full output happens to be a prefix of the stop string. This incorrectly suppresses streaming chunks.

2. **Exclusive upper bound**: The largest valid suffix (of length `min(len(output), len(stop_str))`) is never checked.

**Fix**: Change `range(0, ...)` to `range(1, ... + 1)` so the loop checks suffixes of length 1 through `min(len(output), len(stop_str))`.

You can verify in a Python REPL:
```python
>>> s = "hello"
>>> s[-0:]
'hello'  # entire string, not empty
>>> s[-1:]
'o'      # correct: last 1 char
```

## Test plan

- [x] Verified `output[-0:]` returns full string in Python REPL
- [ ] Existing tests in `tests/test_utils.py` should continue to pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)