### PR TITLE
fix: use identity check for None comparison (PEP 8 E711)

### DIFF
--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -90,7 +90,7 @@ class ModelWorker(BaseModelWorker):
             debug=debug,
         )
         self.device = device
-        if self.tokenizer.pad_token == None:
+        if self.tokenizer.pad_token is None:
             self.tokenizer.pad_token = self.tokenizer.eos_token
         self.context_len = get_context_length(self.model.config)
         self.generate_stream_func = get_generate_stream_function(self.model, model_path)


### PR DESCRIPTION
## Summary

Replace `== None` with `is None` identity check in `model_worker.py` per PEP 8 (E711).

Python's `is` operator is the recommended way to compare with singletons like `None`. Using `==` can produce unexpected results if a class defines a custom `__eq__` method.

**Change:**
```python
# Before
if self.tokenizer.pad_token == None:

# After
if self.tokenizer.pad_token is None:
```

## Testing
No behavior change — identity check with `is` is functionally equivalent to `==` for `None` comparisons in standard usage.