### PR TITLE
Fix moderation only checking left model's conversation in arena battles

### DIFF
--- a/fastchat/serve/gradio_block_arena_anony.py
+++ b/fastchat/serve/gradio_block_arena_anony.py
@@ -307,7 +307,7 @@ def add_text(
     model_list = [states[i].model_name for i in range(num_sides)]
     # turn on moderation in battle mode
     all_conv_text_left = states[0].conv.get_prompt()
-    all_conv_text_right = states[0].conv.get_prompt()
+    all_conv_text_right = states[1].conv.get_prompt()
     all_conv_text = (
         all_conv_text_left[-1000:] + all_conv_text_right[-1000:] + "\nuser: " + text
     )

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -242,7 +242,7 @@ def add_text(
 
     model_list = [states[i].model_name for i in range(num_sides)]
     all_conv_text_left = states[0].conv.get_prompt()
-    all_conv_text_right = states[0].conv.get_prompt()
+    all_conv_text_right = states[1].conv.get_prompt()
     all_conv_text = (
         all_conv_text_left[-1000:] + all_conv_text_right[-1000:] + "\nuser: " + text
     )


### PR DESCRIPTION
## Bug

In `gradio_block_arena_anony.py` and `gradio_block_arena_vision_named.py`, `all_conv_text_right` reads from `states[0]` (left model) instead of `states[1]` (right model):

```python
all_conv_text_left = states[0].conv.get_prompt()
all_conv_text_right = states[0].conv.get_prompt()  # bug: should be states[1]
```

This means the right model's conversation is never passed to the moderation filter, allowing policy-violating content through unchecked.

## Root cause

Copy-paste error. The correct version exists in `gradio_block_arena_named.py` (line 182), which uses `states[1]`.

## Fix

Change `states[0]` → `states[1]` for `all_conv_text_right` in both files.

🤖 Generated with [Claude Code](https://claude.ai/code)