### PR TITLE
Fix add_text/regenerate return tuple size mismatch in single-model server

### DIFF
--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -328,7 +328,7 @@ def regenerate(state, request: gr.Request):
     logger.info(f"regenerate. ip: {ip}")
     if not state.regen_support:
         state.skip_next = True
-        return (state, state.to_gradio_chatbot(), "", None) + (no_change_btn,) * 5
+        return (state, state.to_gradio_chatbot(), "") + (no_change_btn,) * 5
     state.conv.update_last_message(None)
     return (state, state.to_gradio_chatbot(), "") + (disable_btn,) * 5
 
@@ -361,7 +361,7 @@ def add_text(state, model_selector, text, request: gr.Request):
 
     if len(text) <= 0:
         state.skip_next = True
-        return (state, state.to_gradio_chatbot(), "", None) + (no_change_btn,) * 5
+        return (state, state.to_gradio_chatbot(), "") + (no_change_btn,) * 5
 
     all_conv_text = state.conv.get_prompt()
     all_conv_text = all_conv_text[-2000:] + "\nuser: " + text
@@ -375,7 +375,7 @@ def add_text(state, model_selector, text, request: gr.Request):
     if (len(state.conv.messages) - state.conv.offset) // 2 >= CONVERSATION_TURN_LIMIT:
         logger.info(f"conversation turn limit. ip: {ip}. text: {text}")
         state.skip_next = True
-        return (state, state.to_gradio_chatbot(), CONVERSATION_LIMIT_MSG, None) + (
+        return (state, state.to_gradio_chatbot(), CONVERSATION_LIMIT_MSG) + (
             no_change_btn,
         ) * 5
 


### PR DESCRIPTION
## Bug
Fixes #3783.

In `fastchat/serve/gradio_web_server.py`, `add_text` and `regenerate` have early-return paths that yield a 9-tuple while the normal path returns an 8-tuple. All three callers (`textbox.submit`, `send_btn.click`, `regenerate_btn.click`) wire the output to `[state, chatbot, textbox] + btn_list` — 8 outputs. The 9-value returns trigger a Gradio output-count mismatch error, so any empty-input submit, conversation-limit hit, or regenerate-without-regen-support crashes the UI.

## Root cause
Commit be5db52 (Merge operation & multimodal arena, #3425) removed the `image` parameter from `add_text` in the single-model server and dropped the trailing `None` from the normal return path, but left the same `None` in the two early-return paths of `add_text` and the early-return path of `regenerate`. The extra `None` was the image slot that no longer exists.

## Fix
Drop the leftover `None` from the three early returns so every path returns the 8 values the output components expect. No other behavior changes.