### PR TITLE
Fix crash in vote_last_response when state is None after clear_history

### DIFF
--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -286,6 +286,10 @@ def load_demo(url_params, request: gr.Request):
 
 
 def vote_last_response(state, vote_type, model_selector, request: gr.Request):
+    if state is None:
+        # clear_history resets state to None; a vote click before the UI
+        # updates would otherwise crash on state.dict() below.
+        return
     filename = get_conv_log_filename()
     if "llava" in model_selector:
         filename = filename.replace("2024", "vision-tmp-2024")


### PR DESCRIPTION
## Bug

`vote_last_response` in `fastchat/serve/gradio_web_server.py` unconditionally calls `state.dict()`, but `state` can be `None`. Reported in #3787.

## Root cause

`clear_history` explicitly resets the Gradio state:

\`\`\`python
def clear_history(request: gr.Request):
    ...
    state = None
    return (state, [], \"\") + (disable_btn,) * 5
\`\`\`

The vote buttons are disabled as part of that return, but the UI update is asynchronous in Gradio. If a user clicks upvote / downvote / flag between \`clear_history\` firing and the button-disable reaching the browser, the stale event runs \`vote_last_response(None, ...)\`, hitting \`state.dict()\` and raising \`AttributeError: 'NoneType' object has no attribute 'dict'\`.

## Fix

Early-return from \`vote_last_response\` when \`state is None\`. The callers (\`upvote_last_response\`, \`downvote_last_response\`, \`flag_last_response\`) ignore its return value, so a no-op is safe and they still return the same \`disable_btn\` tuple as before.

Fixes #3787.