### PR TITLE
Fix VLLMWorker.generate_stream referencing module-level engine instead of self

### DIFF
--- a/fastchat/serve/vllm_worker.py
+++ b/fastchat/serve/vllm_worker.py
@@ -54,6 +54,7 @@ class VLLMWorker(BaseModelWorker):
         logger.info(
             f"Loading the model {self.model_names} on worker {worker_id}, worker type: vLLM worker..."
         )
+        self.llm_engine = llm_engine
         self.tokenizer = llm_engine.engine.tokenizer
         # This is to support vllm >= 0.2.7 where TokenizerGroup was introduced
         # and llm_engine.engine.tokenizer was no longer a raw tokenizer
@@ -116,7 +117,7 @@ class VLLMWorker(BaseModelWorker):
             frequency_penalty=frequency_penalty,
             best_of=best_of,
         )
-        results_generator = engine.generate(context, sampling_params, request_id)
+        results_generator = self.llm_engine.generate(context, sampling_params, request_id)
 
         async for request_output in results_generator:
             prompt = request_output.prompt
@@ -135,7 +136,7 @@ class VLLMWorker(BaseModelWorker):
 
             aborted = False
             if request and await request.is_disconnected():
-                await engine.abort(request_id)
+                await self.llm_engine.abort(request_id)
                 request_output.finished = True
                 aborted = True
                 for output in request_output.outputs:


### PR DESCRIPTION
## Bug

\`VLLMWorker.__init__\` accepts \`llm_engine: AsyncLLMEngine\` and reads attributes off it (\`self.tokenizer\`, \`self.context_len\`), but never stores it on \`self\`. \`generate_stream\` then calls:

\`\`\`python
results_generator = engine.generate(context, sampling_params, request_id)
...
await engine.abort(request_id)
\`\`\`

## Root cause

There is no \`engine\` attribute on \`self\` and no enclosing scope inside the method that defines it. The reference resolves to a module-level \`engine\` variable that only exists when \`fastchat/serve/vllm_worker.py\` is run as \`__main__\` (line 290: \`engine = AsyncLLMEngine.from_engine_args(engine_args)\`). When \`VLLMWorker\` is imported and instantiated from another module, \`generate_stream\` raises \`NameError: name 'engine' is not defined\` the first time it tries to dispatch a request or abort one.

## Fix

Bind the engine to the instance in \`__init__\` (\`self.llm_engine = llm_engine\`) and route the two call sites through \`self.llm_engine\`. Behavior under the \`__main__\` entry point is unchanged: it still passes the same \`engine\` instance into \`VLLMWorker\`, which is now reachable via the worker rather than via module globals.

Module-level helpers in this file (\`create_background_tasks\`, \`api_generate\`) intentionally reference the global \`engine\` because they're only registered when running as \`__main__\`; this PR keeps those untouched.