### PR TITLE
Return after no-worker yield in Controller.worker_api_generate_stream

### DIFF
--- a/fastchat/serve/controller.py
+++ b/fastchat/serve/controller.py
@@ -267,6 +267,7 @@ class Controller:
         worker_addr = self.get_worker_address(params["model"])
         if not worker_addr:
             yield self.handle_no_worker(params)
+            return
 
         try:
             response = requests.post(


### PR DESCRIPTION
## Bug

`Controller.worker_api_generate_stream` in `fastchat/serve/controller.py` yields a `CONTROLLER_NO_WORKER` error when `get_worker_address` returns an empty string, but then falls through into the HTTP request block:

```python
def worker_api_generate_stream(self, params):
    worker_addr = self.get_worker_address(params["model"])
    if not worker_addr:
        yield self.handle_no_worker(params)

    try:
        response = requests.post(
            worker_addr + "/worker_generate_stream",
            ...
        )
```

With `worker_addr == ""`, the subsequent `requests.post("" + "/worker_generate_stream", ...)` has no scheme/host and raises `requests.exceptions.RequestException`. The `except` branch then yields a second chunk — `CONTROLLER_WORKER_TIMEOUT` attributed to the empty worker address — and the log records a fake timeout for a worker that never existed.

The client ends up consuming two unrelated error frames for a single request (no-worker and worker-timeout), which breaks the single-error contract the stream consumers are written against.

## Root cause

Missing `return` after the `yield self.handle_no_worker(params)` short-circuit. The author clearly meant to bail out after reporting the no-worker condition — every other control-flow branch in this class is structured so that only one error frame is produced per request.

## Fix

Add a `return` right after the no-worker yield. The generator now stops cleanly when there is no available worker, exactly one error chunk is sent, and the misleading timeout log/yield goes away.

```python
if not worker_addr:
    yield self.handle_no_worker(params)
    return
```

## Why the fix is correct

- Pure additive one-liner; all other paths are untouched.
- Matches the existing pattern elsewhere in the class where an error response terminates the stream (e.g., `handle_worker_timeout` is only yielded from the `except` branch, with no further output).
- Eliminates the spurious `requests.post("/worker_generate_stream", ...)` call against an empty URL, which in turn eliminates the follow-up `WORKER_TIMEOUT` frame and the noisy log line pointing at `""`.