### PR TITLE
Fix Monitor.update_model_call_limit always rejecting every call

### DIFF
--- a/fastchat/serve/call_monitor.py
+++ b/fastchat/serve/call_monitor.py
@@ -71,8 +71,6 @@ class Monitor:
         return self.model_call_limit_global[model]
 
     def update_model_call_limit(self, model: str, limit: int) -> bool:
-        if model not in self.model_call_limit_global:
-            return False
         self.model_call_limit_global[model] = limit
         return True
 


### PR DESCRIPTION
### Bug
`Monitor.update_model_call_limit` exits early and returns `False` whenever the model is not already present in `self.model_call_limit_global`, but the dict is only ever initialized to `{}` in `Monitor.__init__` and no other code populates it. The first update for any model always fails, the dict stays empty, and every subsequent update also fails - so the `/update_model_call_limit/{model}/{limit}` endpoint is unreachable in practice.

https://github.com/lm-sys/FastChat/blob/587d5cf/fastchat/serve/call_monitor.py#L73-L77

```python
def update_model_call_limit(self, model: str, limit: int) -> bool:
    if model not in self.model_call_limit_global:
        return False
    self.model_call_limit_global[model] = limit
    return True
```

### Root cause
The early-return guards against the only code path that would populate the dict, so the dict never gets populated in the first place.

### Fix
Drop the early-return and upsert the limit unconditionally. The neighbouring accessors already treat a missing key as "no limit configured":

- `get_model_call_limit` returns `-1` when the key is absent.
- `is_model_limit_reached` returns `False` when the key is absent.

so allowing the first call to create the entry is consistent with the rest of the class.