### PR TITLE
Fix ModelPermission.is_blocking type annotation (str -> bool)

### DIFF
--- a/fastchat/protocol/openai_api_protocol.py
+++ b/fastchat/protocol/openai_api_protocol.py
@@ -24,7 +24,7 @@ class ModelPermission(BaseModel):
     allow_fine_tuning: bool = False
     organization: str = "*"
     group: Optional[str] = None
-    is_blocking: str = False
+    is_blocking: bool = False
 
 
 class ModelCard(BaseModel):


### PR DESCRIPTION
## Bug

In \`fastchat/protocol/openai_api_protocol.py\`, \`ModelPermission\` mirrors the OpenAI model-permission object where every \`allow_*\`/\`is_*\` flag is a boolean. The \`is_blocking\` field is the only one whose annotation says \`str\` while its default is a Python \`bool\`:

\`\`\`python
allow_create_engine: bool = False
allow_sampling: bool = True
...
allow_fine_tuning: bool = False
organization: str = \"*\"
group: Optional[str] = None
is_blocking: str = False
\`\`\`

## Root cause

Typo in the annotation: \`is_blocking\` is a boolean flag (matches every other \`allow_*\` field on the same model and the upstream OpenAI \`model_permission\` schema), but the annotation was written as \`str\`. The \`= False\` default makes the mismatch obvious at a glance.

Concretely, building \`ModelPermission(is_blocking=True)\` (or parsing a JSON payload with \`\"is_blocking\": true\`) fails Pydantic v2 validation because \`bool\` is not coerced to \`str\`:

\`\`\`
pydantic.ValidationError: ... is_blocking
  Input should be a valid string [type=string_type, input_value=True, input_type=bool]
\`\`\`

## Why the fix is correct

Switching the annotation to \`bool\` aligns the declared type with (a) the existing \`False\` default, (b) every sibling flag on this Pydantic model, and (c) the OpenAI model-permission contract that this class serializes to/from. It's a one-character change and keeps the serialized JSON (\`false\` / \`true\`) exactly the same as the intended behavior.