### PR TITLE
Fix bias='lora_only' state-dict collection in train_lora

### DIFF
--- a/fastchat/train/train_lora.py
+++ b/fastchat/train/train_lora.py
@@ -92,9 +92,9 @@ def get_peft_state_maybe_zero_3(named_params, bias):
                 lora_bias_names.add(bias_name)
             elif "bias" in k:
                 maybe_lora_bias[k] = t
-        for k, t in maybe_lora_bias:
-            if bias_name in lora_bias_names:
-                to_return[bias_name] = t
+        for k, t in maybe_lora_bias.items():
+            if k in lora_bias_names:
+                to_return[k] = t
     else:
         raise NotImplementedError
     to_return = {k: maybe_zero_3(v) for k, v in to_return.items()}


### PR DESCRIPTION
## Bug

In `fastchat/train/train_lora.py`, `get_peft_state_maybe_zero_3` crashes
or silently stores bias params under the wrong key whenever `bias ==
\"lora_only\"` is used and the model has any bias parameter.

## Root cause

```python
elif bias == \"lora_only\":
    to_return = {}
    maybe_lora_bias = {}
    lora_bias_names = set()
    for k, t in named_params:
        if \"lora_\" in k:
            to_return[k] = t
            bias_name = k.split(\"lora_\")[0] + \"bias\"
            lora_bias_names.add(bias_name)
        elif \"bias\" in k:
            maybe_lora_bias[k] = t
    for k, t in maybe_lora_bias:                 # (1)
        if bias_name in lora_bias_names:         # (2)
            to_return[bias_name] = t             # (3)
```

1. `for k, t in maybe_lora_bias:` iterates dict **keys**, not items.
   Unpacking a string key into `k, t` raises
   `ValueError: too many values to unpack` the first time the dict is
   non-empty.
2. `bias_name` leaks from the previous loop – it's always the last
   lora-derived bias name – so the membership check is independent of
   the current bias key `k`.
3. `to_return[bias_name] = t` writes the tensor `t` under that leaked
   name, not `k`, so the saved bias param has the wrong key (or
   overwrites whatever was saved there).

## Why the fix is correct

peft's reference implementation (the comment says this helper was
\"borrowed from peft.utils.get_peft_model_state_dict\") matches bias
keys directly against the current loop variable, not a leaked one.
Using `maybe_lora_bias.items()` and `k` makes the three lines self
consistent and produces the same behaviour as peft's `lora_only` branch.

## Change

`fastchat/train/train_lora.py`:

```diff
-        for k, t in maybe_lora_bias:
-            if bias_name in lora_bias_names:
-                to_return[bias_name] = t
+        for k, t in maybe_lora_bias.items():
+            if k in lora_bias_names:
+                to_return[k] = t
```