### PR TITLE
Fix load_demo_single called with list instead of Context in gradio_web_server

### DIFF
--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -282,7 +282,7 @@ def load_demo(url_params, request: gr.Request):
             controller_url, args.register_api_endpoint_file, vision_arena=False
         )
 
-    return load_demo_single(models, url_params)
+    return load_demo_single(Context(text_models=models, models=models), url_params)
 
 
 def vote_last_response(state, vote_type, model_selector, request: gr.Request):


### PR DESCRIPTION
Fixes #3788.

## Bug

`load_demo` in `fastchat/serve/gradio_web_server.py` invokes
`load_demo_single(models, url_params)`, passing the global `models` list as
the first positional argument. `load_demo_single` now expects a `Context`
object and dereferences `context.text_models` / `context.models`, so the
call raises `AttributeError: 'list' object has no attribute 'text_models'`
when Gradio fires the demo-load callback (including the `--model-list-mode reload` path).

## Root cause

Commit `2c68a13` (*Code sync*, PR #3546) changed `load_demo_single`'s
signature from `(models, url_params)` to `(context: Context, query_params)`
and moved the body to read `context.text_models` / `context.models`, but
`load_demo` in the same file was not updated and still passes the plain
list.

## Why the fix is correct

In the standalone (non-multi) server there is no text/vision distinction,
so wrapping the existing `models` list as both `text_models` and `models`
on a fresh `Context` preserves prior behavior exactly: `load_demo_single`
selects the default model from `context.text_models` and populates the
dropdown choices from `context.models`, which both map to the same list
that was previously used directly. `Context` is already imported in this
file (line 37), and the other caller in `gradio_web_server_multi.py`
continues to pass a fully-populated `Context` unchanged.