### PR TITLE
fix: guard vote_last_response against None state

### DIFF
--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -286,6 +286,8 @@ def load_demo(url_params, request: gr.Request):
 
 
 def vote_last_response(state, vote_type, model_selector, request: gr.Request):
+    if state is None:
+        return
     filename = get_conv_log_filename()
     if "llava" in model_selector:
         filename = filename.replace("2024", "vision-tmp-2024")


### PR DESCRIPTION
**Bug:** `vote_last_response` calls `state.dict()` without checking if `state` is `None`.

**Root cause:** After `clear_history` resets `state` to `None` and returns disabled buttons, there is a small window before Gradio's UI update reaches the client. A rapid vote-button click during this window sends a request with `state=None`, causing `AttributeError: 'NoneType' object has no attribute 'dict'` and crashing the server.

**Why the fix is correct:** The intended behavior when state is absent is to do nothing — the vote is meaningless without a conversation to associate it with. Returning early from `vote_last_response` when `state is None` mirrors the existing null-state guard in `add_text` and prevents the crash without affecting normal operation.

Closes #3787