### PR TITLE
fix(arena): pass full conversation history to moderate_input in vision anony arena

### DIFF
--- a/fastchat/serve/gradio_block_arena_vision_anony.py
+++ b/fastchat/serve/gradio_block_arena_vision_anony.py
@@ -311,8 +311,15 @@ def add_text(
 
     images = convert_images_to_conversation_format(images)
 
+    all_conv_text_left = states[0].conv.get_prompt()
+    all_conv_text_right = states[1].conv.get_prompt()
+    all_conv_text = (
+        all_conv_text_left[-1000:] + all_conv_text_right[-1000:] + "
+user: " + text
+    )
+
     text, image_flagged, csam_flag = moderate_input(
-        state0, text, text, model_list, images, ip
+        state0, text, all_conv_text, model_list, images, ip
     )
 
     conv = states[0].conv


### PR DESCRIPTION
**Bug:** In `gradio_block_arena_vision_anony.py`, `moderate_input` is called with `text` as both the user message and the `all_conv_text` argument:

```python
text, image_flagged, csam_flag = moderate_input(
    state0, text, text, model_list, images, ip
)
```

The function signature is `moderate_input(state, text, all_conv_text, model_list, images, ip)`, where `all_conv_text` is the full conversation history that the moderation filter checks. Passing only the current user message means prior model responses are never moderated, allowing policy-violating content to slip through multi-turn conversations.

**Root cause:** The other arena files (`gradio_block_arena_vision_named.py`) already compute `all_conv_text` from both models' prompts and pass it correctly. This file was left with the original two-`text` call.

**Fix:** Compute `all_conv_text` from both models' conversation histories (matching the pattern in `gradio_block_arena_vision_named.py`) and pass it as the third argument:

```python
all_conv_text_left = states[0].conv.get_prompt()
all_conv_text_right = states[1].conv.get_prompt()
all_conv_text = (
    all_conv_text_left[-1000:] + all_conv_text_right[-1000:] + "\nuser: " + text
)
text, image_flagged, csam_flag = moderate_input(
    state0, text, all_conv_text, model_list, images, ip
)
```