### PR TITLE
fix(openai_api_server): use exclude_none for completion stream finish chunks

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -673,7 +673,7 @@ async def generate_completion_stream_generator(
                 yield f"data: {chunk.model_dump_json(exclude_unset=True)}\n\n"
     # There is not "content" field in the last delta message, so exclude_none to exclude field "content".
     for finish_chunk in finish_stream_events:
-        yield f"data: {finish_chunk.model_dump_json(exclude_unset=True)}\n\n"
+        yield f"data: {finish_chunk.model_dump_json(exclude_none=True)}\n\n"
     yield "data: [DONE]\n\n"
 
 


### PR DESCRIPTION
## Bug

\`generate_completion_stream_generator\` (\`fastchat/serve/openai_api_server.py\`) emits the final SSE chunks for a completion stream with \`model_dump_json(exclude_unset=True)\`, leaving \`None\` fields (e.g. \`logprobs\`) in the payload that the preceding comment explicitly says should be stripped.

## Root cause

The function ends with:

\`\`\`python
# There is not \"content\" field in the last delta message, so exclude_none to exclude field \"content\".
for finish_chunk in finish_stream_events:
    yield f\"data: {finish_chunk.model_dump_json(exclude_unset=True)}\\n\\n\"
\`\`\`

The comment and \`exclude_*\` keyword disagree. The parallel chat-completion path \`chat_completion_stream_generator\` carries the identical comment immediately above and correctly uses \`exclude_none=True\`:

\`\`\`python
# There is not \"content\" field in the last delta message, so exclude_none to exclude field \"content\".
for finish_chunk in finish_stream_events:
    yield f\"data: {finish_chunk.model_dump_json(exclude_none=True)}\\n\\n\"
\`\`\`

This is a copy-paste asymmetry: the completion-stream version kept \`exclude_unset\` while the chat-stream version was corrected to \`exclude_none\`.

## Fix

Switch the completion-stream finish loop to \`exclude_none=True\` so it matches its comment and its chat-stream counterpart. One-line change; per-chunk emission inside the loop body (which legitimately uses \`exclude_unset\`) is untouched.