### PR TITLE
fix: guard against IndexError on empty LLM choices/content list

### DIFF
--- a/fastchat/serve/api_provider.py
+++ b/fastchat/serve/api_provider.py
@@ -348,6 +348,8 @@ def openai_api_stream_iter(
                 max_tokens=max_new_tokens,
                 stream=False,
             )
+        if not res.choices:
+            return
         text = res.choices[0].message.content
         pos = 0
         while pos < len(text):

--- a/fastchat/serve/api_provider.py
+++ b/fastchat/serve/api_provider.py
@@ -348,7 +348,7 @@ def openai_api_stream_iter(
                 max_tokens=max_new_tokens,
                 stream=False,
             )
-        if not res.choices:
+        if not res.choices or res.choices[0].message is None:
             return
         text = res.choices[0].message.content
         pos = 0

--- a/fastchat/serve/monitor/classify/label.py
+++ b/fastchat/serve/monitor/classify/label.py
@@ -64,6 +64,8 @@ def chat_completion_openai(model, messages, temperature, max_tokens, api_dict=No
                 max_tokens=max_tokens,
                 # extra_body={"guided_choice": GUIDED_CHOICES} if GUIDED_CHOICES else None,
             )
+            if not completion.choices:
+                break
             output = completion.choices[0].message.content
             # print(output)
             break
@@ -114,6 +116,8 @@ def chat_completion_anthropic(model, messages, temperature, max_tokens, api_dict
                 temperature=temperature,
                 system=sys_msg,
             )
+            if not response.content:
+                break
             output = response.content[0].text
             break
         except anthropic.APIError as e:

--- a/fastchat/serve/monitor/classify/label.py
+++ b/fastchat/serve/monitor/classify/label.py
@@ -64,7 +64,7 @@ def chat_completion_openai(model, messages, temperature, max_tokens, api_dict=No
                 max_tokens=max_tokens,
                 # extra_body={"guided_choice": GUIDED_CHOICES} if GUIDED_CHOICES else None,
             )
-            if not completion.choices:
+            if not completion.choices or completion.choices[0].message is None:
                 break
             output = completion.choices[0].message.content
             # print(output)

--- a/fastchat/serve/monitor/criteria_labeling.py
+++ b/fastchat/serve/monitor/criteria_labeling.py
@@ -89,7 +89,7 @@ def chat_completion_openai(model, messages, temperature, max_tokens, api_dict=No
                 max_tokens=max_tokens,
                 # extra_body={"guided_choice": GUIDED_CHOICES} if GUIDED_CHOICES else None,
             )
-            if not completion.choices:
+            if not completion.choices or completion.choices[0].message is None:
                 break
             output = completion.choices[0].message.content
             break

--- a/fastchat/serve/monitor/criteria_labeling.py
+++ b/fastchat/serve/monitor/criteria_labeling.py
@@ -89,6 +89,8 @@ def chat_completion_openai(model, messages, temperature, max_tokens, api_dict=No
                 max_tokens=max_tokens,
                 # extra_body={"guided_choice": GUIDED_CHOICES} if GUIDED_CHOICES else None,
             )
+            if not completion.choices:
+                break
             output = completion.choices[0].message.content
             break
         except openai.RateLimitError as e:


### PR DESCRIPTION
## Problem

Three files access `choices[0]` or `content[0]` without first checking whether the API returned any results. An empty list can occur when:

- the LLM applies a **content-policy filter** and returns `choices=[]`
- a **token limit** is hit before the first choice arrives  
- a **rate-limit fallback** returns a non-standard response body
- the **Anthropic API** returns `content=[]` on a refusal

This raises a bare `IndexError` that propagates as an unhandled exception.

## Changes

| File | Line | Fix |
|------|------|-----|
| `fastchat/serve/api_provider.py` | 351 | `if not res.choices: return` before accessing `choices[0]` |
| `fastchat/serve/monitor/classify/label.py` | 67 | `if not completion.choices: break` before accessing `choices[0]` |
| `fastchat/serve/monitor/classify/label.py` | 117 | `if not response.content: break` before accessing Anthropic `content[0]` |
| `fastchat/serve/monitor/criteria_labeling.py` | 92 | `if not completion.choices: break` before accessing `choices[0]` |

All three files already use retry loops — `break` on empty response exits the loop and returns the `API_ERROR_OUTPUT` sentinel, which is the same behaviour as any other API error.

No new files, no behaviour change on successful API responses.

---
*Found by [pact](https://github.com/qizwiz/pact) static analysis — `llm_response_unguarded` mode.*