### PR TITLE
Initialize lines = [] in load_log_files to avoid UnboundLocalError on FileNotFoundError retry failures

### DIFF
--- a/fastchat/serve/monitor/basic_stats.py
+++ b/fastchat/serve/monitor/basic_stats.py
@@ -36,6 +36,7 @@ def get_log_files(max_num_files=None):
 
 def load_log_files(filename):
     data = []
+    lines = []
     for retry in range(5):
         try:
             lines = open(filename).readlines()


### PR DESCRIPTION
Bug:
In `fastchat/serve/monitor/basic_stats.py`, when all 5 retries to read a log file fail due to a `FileNotFoundError`, an `UnboundLocalError: local variable 'lines' referenced before assignment` is raised at `for l in lines:`.

Root Cause:
`lines` is only assigned a value when `open(filename).readlines()` executes successfully inside the `try` block. If a `FileNotFoundError` occurs for all 5 attempts, the loop terminates without `lines` being initialized, but the code still proceeds to access `lines`.

Why Fix is Correct:
By initializing `lines = []` before starting the retry loop, we ensure that `lines` is always defined. If all retries fail, it remains an empty list, and the function gracefully skips the parsing loop and returns an empty list rather than crashing.