### PR TITLE
Fix: Info logs incorrectly displayed as ERROR in stderr

### DIFF
--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -45,16 +45,6 @@ def build_logger(logger_name, logger_filename):
             logging.basicConfig(level=logging.INFO)
     logging.getLogger().handlers[0].setFormatter(formatter)
 
-    # Redirect stdout and stderr to loggers
-    stdout_logger = logging.getLogger("stdout")
-    stdout_logger.setLevel(logging.INFO)
-    sl = StreamToLogger(stdout_logger, logging.INFO)
-    sys.stdout = sl
-
-    stderr_logger = logging.getLogger("stderr")
-    stderr_logger.setLevel(logging.ERROR)
-    sl = StreamToLogger(stderr_logger, logging.ERROR)
-    sys.stderr = sl
 
     # Get logger
     logger = logging.getLogger(logger_name)


### PR DESCRIPTION
Bug: Uvicorn and other libraries write INFO-level startup messages to `sys.stderr`. Because `sys.stderr` was globally redirected to a logger with `logging.ERROR` level, these normal INFO messages were prefixed with `ERROR | stderr`. Root cause: Global redirection of `sys.stderr` to `StreamToLogger` with `logging.ERROR`. Why fix is correct: Removing this forced redirection allows standard streams to function naturally, letting native loggers output at their correct severity without being artificially escalated to ERROR.