### PR TITLE
fix: use multi-GPU RWKV strategy from visible CUDA devices

### DIFF
--- a/fastchat/model/rwkv_model.py
+++ b/fastchat/model/rwkv_model.py
@@ -17,9 +17,13 @@ class RwkvModel:
             "Experimental support. Please use ChatRWKV if you want to chat with RWKV"
         )
         self.config = SimpleNamespace(is_encoder_decoder=False)
-        self.model = RWKV(model=model_path, strategy="cuda fp16")
-        # two GPUs
-        # self.model = RWKV(model=model_path, strategy="cuda:0 fp16 *20 -> cuda:1 fp16")
+        n = torch.cuda.device_count()
+        strategy = (
+            " -> ".join(f"cuda:{i} fp16" for i in range(n))
+            if n > 1
+            else "cuda fp16"
+        )
+        self.model = RWKV(model=model_path, strategy=strategy)
 
         self.tokenizer = None
         self.model_path = model_path

--- a/fastchat/model/rwkv_model.py
+++ b/fastchat/model/rwkv_model.py
@@ -19,9 +19,7 @@ class RwkvModel:
         self.config = SimpleNamespace(is_encoder_decoder=False)
         n = torch.cuda.device_count()
         strategy = (
-            " -> ".join(f"cuda:{i} fp16" for i in range(n))
-            if n > 1
-            else "cuda fp16"
+            " -> ".join(f"cuda:{i} fp16" for i in range(n)) if n > 1 else "cuda fp16"
         )
         self.model = RWKV(model=model_path, strategy=strategy)
 


### PR DESCRIPTION
Fixes #1248

## Bug
Launching an RWKV model worker with `--num-gpus` / `--gpus` still loads with `strategy="cuda fp16"`, so RWKV ignores the requested GPU list and runs on a single device.

## Root cause
`RwkvModel.__init__` hardcodes `strategy="cuda fp16"` instead of building a per-device strategy string for multiple visible GPUs.

## Why this fix is correct
When more than one CUDA device is visible (including after `CUDA_VISIBLE_DEVICES` is set by the worker), build `cuda:0 fp16 -> cuda:1 fp16 -> ...` as RWKV expects. Single-GPU behavior stays `cuda fp16`.

Made with [Cursor](https://cursor.com)