### PR TITLE
fix: detect partial stop sequences by output suffix

### DIFF
--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -329,8 +329,8 @@ def parse_gradio_auth_creds(filename: str):
 
 
 def is_partial_stop(output: str, stop_str: str):
-    """Check whether the output contains a partial stop str."""
-    for i in range(0, min(len(output), len(stop_str))):
+    """Check whether the output ends with a partial stop str."""
+    for i in range(1, min(len(output), len(stop_str)) + 1):
         if stop_str.startswith(output[-i:]):
             return True
     return False


### PR DESCRIPTION
## Summary

Fixes streaming stop handling for OpenAI-compatible APIs (reported in #1048).

## Root cause

`is_partial_stop` iterated from `i=0`, where `output[-0:]` is the entire string rather than an empty suffix. That only matched when the full output was a prefix of the stop string, so longer outputs could stream a growing partial stop (e.g. `Obs` from `Observation:`) before the complete stop was detected.

## Why this fix is correct

Check proper suffixes of length `1..min(len(output), len(stop_str))` at the end of the output. This matches the intended “ends with partial stop” semantics used by `inference.py` and worker backends to suppress chunks until the stop sequence is complete or ruled out.

Fixes #1048

## Test plan
- [ ] Stream a completion with `stop=["Observation:"]` and confirm partial prefixes are not emitted to the client


Made with [Cursor](https://cursor.com)