### PR TITLE
fix: allow separate input/output budgets for T5 in context check

### DIFF
--- a/fastchat/serve/openai_api_server.py
+++ b/fastchat/serve/openai_api_server.py
@@ -166,9 +166,10 @@ async def check_length(request, prompt, max_tokens, worker_addr):
         {"model": request.model, "prompt": prompt},
         "count",
     )
-    length = min(max_tokens, context_len - token_num)
+    is_enc_dec = "t5" in request.model.lower()
+    length = min(max_tokens, context_len if is_enc_dec else context_len - token_num)
 
-    if length <= 0:
+    if (is_enc_dec and token_num > context_len) or length <= 0:
         return None, create_error_response(
             ErrorCode.CONTEXT_OVERFLOW,
             f"This model's maximum context length is {context_len} tokens. However, your messages resulted in {token_num} tokens. Please reduce the length of the messages.",


### PR DESCRIPTION
## Summary
Fixes #1711.

FastChat-T5 supports up to 2K encoder tokens plus 2K decoder tokens, but the OpenAI API server treated context as a single shared budget (`context_len - prompt_tokens`).

## Root cause
`check_length` always used the causal-LM formula, so a 1790-token prompt with `max_tokens=512` was rejected as 2302 > 2048 even though T5 can encode 1790 tokens and still generate 512 more.

## Fix
For T5 models, validate prompt length against `context_len` and cap completion tokens independently, matching encoder-decoder behavior in `inference.py`.

## Test plan
- [ ] Call the API with `fastchat-t5-3b-v1.0`, ~1790 prompt tokens, and `max_tokens=512`; request should succeed
- [ ] Confirm causal models still reject prompts that leave no room for completion


Made with [Cursor](https://cursor.com)