### PR TITLE
Fix YUAN2 conversation template stripping message characters

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -292,7 +292,9 @@ class Conversation:
                     ret += message + "<n>"
                 else:
                     ret += ""
-            ret = ret.rstrip("<n>") + seps[0]
+            if ret.endswith("<n>"):
+                ret = ret[: -len("<n>")]
+            ret = ret + seps[0]
             return ret
         elif self.sep_style == SeparatorStyle.GEMMA:
             ret = "<bos>"

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,38 @@
+"""
+Usage:
+python3 -m unittest tests.test_conversation
+"""
+
+import unittest
+
+from fastchat.conversation import get_conv_template
+
+
+class TestYuan2Template(unittest.TestCase):
+    def test_message_ending_in_n_is_preserved(self):
+        """The YUAN2 template must only strip the trailing ``<n>`` separator,
+        not characters (``<``, ``n``, ``>``) that belong to the message."""
+        conv = get_conv_template("yuan2")
+        conv.append_message(conv.roles[0], "What is the value of n")
+        conv.append_message(conv.roles[1], None)
+        prompt = conv.get_prompt()
+        self.assertIn("What is the value of n", prompt)
+        self.assertEqual(prompt, "What is the value of n<sep>")
+
+    def test_message_ending_in_angle_bracket_is_preserved(self):
+        conv = get_conv_template("yuan2")
+        conv.append_message(conv.roles[0], "compare a < b")
+        conv.append_message(conv.roles[1], None)
+        prompt = conv.get_prompt()
+        self.assertIn("compare a < b", prompt)
+
+    def test_separator_between_messages_is_kept(self):
+        conv = get_conv_template("yuan2")
+        conv.append_message(conv.roles[0], "hello")
+        conv.append_message(conv.roles[1], "world")
+        prompt = conv.get_prompt()
+        self.assertEqual(prompt, "hello<n>world<sep>")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why are these changes needed?

The `YUAN2` separator style in `fastchat/conversation.py` joins messages with
the literal `<n>` separator and then calls `ret.rstrip("<n>")` to drop the
trailing separator before appending `seps[0]`.

`str.rstrip` treats its argument as a *set of characters*, not a suffix, so it
removes every trailing `<`, `n`, and `>` character. Any message that ends in one
of those characters gets corrupted. For example:

```python
conv = get_conv_template("yuan2")
conv.append_message(conv.roles[0], "What is the value of n")
conv.append_message(conv.roles[1], None)
conv.get_prompt()
# before: 'What is the value of <sep>'   (trailing "n" lost)
# after:  'What is the value of n<sep>'
```

The fix removes only the trailing `<n>` separator with an explicit suffix check,
leaving message content intact.

## Related issue number (if applicable)

N/A

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).

Verification (Linux, offline):

```
$ python3 -m pytest tests/test_conversation.py -v
tests/test_conversation.py::TestYuan2Template::test_message_ending_in_angle_bracket_is_preserved PASSED
tests/test_conversation.py::TestYuan2Template::test_message_ending_in_n_is_preserved PASSED
tests/test_conversation.py::TestYuan2Template::test_separator_between_messages_is_kept PASSED
3 passed
```
