### PR TITLE
Fix arena moderation skipping right model conversation history

### DIFF
--- a/fastchat/serve/gradio_block_arena_anony.py
+++ b/fastchat/serve/gradio_block_arena_anony.py
@@ -307,7 +307,7 @@ def add_text(
     model_list = [states[i].model_name for i in range(num_sides)]
     # turn on moderation in battle mode
     all_conv_text_left = states[0].conv.get_prompt()
-    all_conv_text_right = states[0].conv.get_prompt()
+    all_conv_text_right = states[1].conv.get_prompt()
     all_conv_text = (
         all_conv_text_left[-1000:] + all_conv_text_right[-1000:] + "\nuser: " + text
     )

--- a/fastchat/serve/gradio_block_arena_vision_anony.py
+++ b/fastchat/serve/gradio_block_arena_vision_anony.py
@@ -308,11 +308,16 @@ def add_text(
         )
 
     model_list = [states[i].model_name for i in range(num_sides)]
+    all_conv_text_left = states[0].conv.get_prompt()
+    all_conv_text_right = states[1].conv.get_prompt()
+    all_conv_text = (
+        all_conv_text_left[-1000:] + all_conv_text_right[-1000:] + "\nuser: " + text
+    )
 
     images = convert_images_to_conversation_format(images)
 
     text, image_flagged, csam_flag = moderate_input(
-        state0, text, text, model_list, images, ip
+        state0, text, all_conv_text, model_list, images, ip
     )
 
     conv = states[0].conv

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -242,7 +242,7 @@ def add_text(
 
     model_list = [states[i].model_name for i in range(num_sides)]
     all_conv_text_left = states[0].conv.get_prompt()
-    all_conv_text_right = states[0].conv.get_prompt()
+    all_conv_text_right = states[1].conv.get_prompt()
     all_conv_text = (
         all_conv_text_left[-1000:] + all_conv_text_right[-1000:] + "\nuser: " + text
     )


### PR DESCRIPTION
In side-by-side arena mode, the moderation filter builds `all_conv_text` from both models' histories before each turn. Two files had a copy-paste bug where `all_conv_text_right` read `states[0]` (left model) instead of `states[1]` (right model), so Model B's responses were never checked. The vision anonymous arena was worse — it passed the current user message as `all_conv_text`, so no prior history from either model was moderated.

This matches the fix already in `gradio_block_arena_named.py` (34eca62).

Fixes #3834, #3794

Made with [Cursor](https://cursor.com)