### PR TITLE
fix: check partial stop on cumulative sglang output

### DIFF
--- a/fastchat/serve/sglang_worker.py
+++ b/fastchat/serve/sglang_worker.py
@@ -140,13 +140,13 @@ class SGLWorker(BaseModelWorker):
         async for out, meta_info in state.text_async_iter(
             var_name="response", return_meta_data=True
         ):
-            partial_stop = any(is_partial_stop(out, i) for i in stop)
+            entire_output += out
+            partial_stop = any(is_partial_stop(entire_output, i) for i in stop)
 
             # prevent yielding partial stop sequence
             if partial_stop:
                 continue
 
-            entire_output += out
             prompt_tokens = meta_info["prompt_tokens"]
             completion_tokens = meta_info["completion_tokens"]
 


### PR DESCRIPTION
## Summary

SGLang streaming dropped newlines when a stop string started with `\n` (e.g. `\n<|endoftext|>`).

## Root cause

`sglang_worker.py` called `is_partial_stop(out, stop)` on each delta chunk. A lone `\n` chunk matched as a prefix of `\n<|endoftext|>`, so the worker `continue`d without ever appending it to `entire_output` — the newline was discarded permanently.

## Fix

Append each chunk first, then run the partial-stop check on the cumulative `entire_output` (same pattern as `vllm_worker`). If the suffix is only a tentative stop prefix, skip yielding for that step but keep the text buffered until the next token confirms it is not the stop sequence.

Fixes #3467


Made with [Cursor](https://cursor.com)