### PR TITLE
fix(webui): confirm before clearing chat history

### DIFF
--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -28,6 +28,7 @@ from fastchat.serve.gradio_web_server import (
     acknowledgment_md,
     get_ip,
     get_model_description_md,
+    CLEAR_HISTORY_CONFIRM_JS,
 )
 from fastchat.serve.remote_logger import get_remote_logger
 from fastchat.utils import (
@@ -457,7 +458,12 @@ def build_side_by_side_ui_named(models):
     ).then(
         flash_buttons, [], btn_list
     )
-    clear_btn.click(clear_history, None, states + chatbots + [textbox] + btn_list)
+    clear_btn.click(
+        clear_history,
+        None,
+        states + chatbots + [textbox] + btn_list,
+        js=CLEAR_HISTORY_CONFIRM_JS,
+    )
 
     share_js = """
 function (a, b, c, d) {

--- a/fastchat/serve/gradio_block_arena_vision.py
+++ b/fastchat/serve/gradio_block_arena_vision.py
@@ -38,6 +38,7 @@ from fastchat.serve.gradio_web_server import (
     State,
     get_conv_log_filename,
     get_remote_logger,
+    CLEAR_HISTORY_CONFIRM_JS,
 )
 from fastchat.serve.vision.image import ImageFormat, Image
 from fastchat.utils import (
@@ -451,6 +452,7 @@ Note: You can only chat with <span style='color: #DE3163; font-weight: bold'>one
         clear_history,
         None,
         [state, chatbot, multimodal_textbox, textbox, send_btn] + btn_list,
+        js=CLEAR_HISTORY_CONFIRM_JS,
     )
 
     model_selector.change(

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -54,6 +54,7 @@ from fastchat.serve.gradio_web_server import (
     get_ip,
     get_model_description_md,
     enable_text,
+    CLEAR_HISTORY_CONFIRM_JS,
 )
 from fastchat.serve.remote_logger import get_remote_logger
 from fastchat.utils import (
@@ -492,6 +493,7 @@ Note: You can only chat with <span style='color: #DE3163; font-weight: bold'>one
         clear_history,
         None,
         states + chatbots + [multimodal_textbox, textbox, send_btn] + btn_list,
+        js=CLEAR_HISTORY_CONFIRM_JS,
     )
 
     share_js = """

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -47,6 +47,14 @@ from fastchat.utils import (
 
 logger = build_logger("gradio_web_server", "gradio_web_server.log")
 
+CLEAR_HISTORY_CONFIRM_JS = """
+() => {
+    if (!confirm("Are you sure you want to clear your chat history?")) {
+        throw new Error("Clear history cancelled");
+    }
+}
+"""
+
 headers = {"User-Agent": "FastChat Client"}
 
 no_change_btn = gr.Button()
@@ -1000,7 +1008,12 @@ def build_single_model_ui(models, add_promotion_links=False):
         [state, temperature, top_p, max_output_tokens],
         [state, chatbot] + btn_list,
     )
-    clear_btn.click(clear_history, None, [state, chatbot, textbox] + btn_list)
+    clear_btn.click(
+        clear_history,
+        None,
+        [state, chatbot, textbox] + btn_list,
+        js=CLEAR_HISTORY_CONFIRM_JS,
+    )
 
     model_selector.change(clear_history, None, [state, chatbot, textbox] + btn_list)
 


### PR DESCRIPTION
## Summary
- Adds a confirmation step before the Clear History action in Gradio web UIs
- Prevents accidental loss of conversation history from misclicks while scrolling

Fixes #3881

## Test plan
- [ ] Open the Gradio web UI and click Clear History
- [ ] Verify a confirmation prompt appears and history is only cleared after confirming
- [ ] Verify canceling leaves existing chat history intact

Made with [Cursor](https://cursor.com)