### PR TITLE
fix: map uvicorn stderr prefixes to correct log levels

### DIFF
--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -52,7 +52,7 @@ def build_logger(logger_name, logger_filename):
     sys.stdout = sl
 
     stderr_logger = logging.getLogger("stderr")
-    stderr_logger.setLevel(logging.ERROR)
+    stderr_logger.setLevel(logging.DEBUG)
     sl = StreamToLogger(stderr_logger, logging.ERROR)
     sys.stderr = sl
 
@@ -106,15 +106,31 @@ class StreamToLogger(object):
             # translates them so this is still cross platform.
             if line[-1] == "\n":
                 encoded_message = line.encode("utf-8", "ignore").decode("utf-8")
-                self.logger.log(self.log_level, encoded_message.rstrip())
+                level = infer_stream_log_level(encoded_message, self.log_level)
+                self.logger.log(level, encoded_message.rstrip())
             else:
                 self.linebuf += line
 
     def flush(self):
         if self.linebuf != "":
             encoded_message = self.linebuf.encode("utf-8", "ignore").decode("utf-8")
-            self.logger.log(self.log_level, encoded_message.rstrip())
+            level = infer_stream_log_level(encoded_message, self.log_level)
+            self.logger.log(level, encoded_message.rstrip())
         self.linebuf = ""
+
+
+def infer_stream_log_level(line: str, default: int) -> int:
+    """Map uvicorn-style stderr prefixes to the correct log level."""
+    stripped = line.lstrip()
+    if stripped.startswith("INFO:"):
+        return logging.INFO
+    if stripped.startswith("WARNING:") or stripped.startswith("WARN:"):
+        return logging.WARNING
+    if stripped.startswith("ERROR:") or stripped.startswith("CRITICAL:"):
+        return logging.ERROR
+    if stripped.startswith("DEBUG:"):
+        return logging.DEBUG
+    return default
 
 
 def disable_torch_init():

--- a/tests/test_stream_logger.py
+++ b/tests/test_stream_logger.py
@@ -4,7 +4,12 @@ from fastchat.utils import infer_stream_log_level
 
 
 def test_infer_stream_log_level_maps_uvicorn_prefixes():
-    assert infer_stream_log_level("INFO:     Started server", logging.ERROR) == logging.INFO
-    assert infer_stream_log_level("WARNING: deprecated", logging.ERROR) == logging.WARNING
+    assert (
+        infer_stream_log_level("INFO:     Started server", logging.ERROR)
+        == logging.INFO
+    )
+    assert (
+        infer_stream_log_level("WARNING: deprecated", logging.ERROR) == logging.WARNING
+    )
     assert infer_stream_log_level("ERROR: boom", logging.ERROR) == logging.ERROR
     assert infer_stream_log_level("plain stderr line", logging.ERROR) == logging.ERROR

--- a/tests/test_stream_logger.py
+++ b/tests/test_stream_logger.py
@@ -1,0 +1,10 @@
+import logging
+
+from fastchat.utils import infer_stream_log_level
+
+
+def test_infer_stream_log_level_maps_uvicorn_prefixes():
+    assert infer_stream_log_level("INFO:     Started server", logging.ERROR) == logging.INFO
+    assert infer_stream_log_level("WARNING: deprecated", logging.ERROR) == logging.WARNING
+    assert infer_stream_log_level("ERROR: boom", logging.ERROR) == logging.ERROR
+    assert infer_stream_log_level("plain stderr line", logging.ERROR) == logging.ERROR


### PR DESCRIPTION
Fixes #1292

## Summary
- Uvicorn and similar libraries write INFO-level startup messages to stderr, but FastChat's `StreamToLogger` redirected all stderr output at ERROR level.
- Parse common log level prefixes on redirected stderr lines and emit them at the matching level, while keeping unparsed stderr at ERROR.

## Test plan
- [ ] Start `python -m fastchat.serve.controller` and confirm uvicorn startup lines appear as INFO instead of ERROR


Made with [Cursor](https://cursor.com)