### PR TITLE
fix: model worker --debug flag parsing

### DIFF
--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -333,7 +333,7 @@ def create_model_worker():
         help="Overwrite the random seed for each generation.",
     )
     parser.add_argument(
-        "--debug", type=bool, default=False, help="Print debugging messages"
+        "--debug", action="store_true", help="Print debugging messages"
     )
     parser.add_argument(
         "--ssl",

--- a/fastchat/serve/model_worker.py
+++ b/fastchat/serve/model_worker.py
@@ -332,9 +332,7 @@ def create_model_worker():
         default=None,
         help="Overwrite the random seed for each generation.",
     )
-    parser.add_argument(
-        "--debug", action="store_true", help="Print debugging messages"
-    )
+    parser.add_argument("--debug", action="store_true", help="Print debugging messages")
     parser.add_argument(
         "--ssl",
         action="store_true",


### PR DESCRIPTION
## Summary
- switch `--debug` from `type=bool` to `action="store_true"`

`type=bool` in argparse treats any non-empty string as True, so `--debug False` still turned debug on.

## Test plan
- [ ] start model worker without `--debug` and confirm debug logs are off
- [ ] start with `--debug` and confirm debug logs appear


Made with [Cursor](https://cursor.com)