### PR TITLE
fix: drop single-$ latex delimiters so currency like 25$ renders

### DIFF
--- a/fastchat/serve/gradio_block_arena_anony.py
+++ b/fastchat/serve/gradio_block_arena_anony.py
@@ -481,7 +481,6 @@ def build_side_by_side_ui_anony(models):
                         height=650,
                         show_copy_button=True,
                         latex_delimiters=[
-                            {"left": "$", "right": "$", "display": False},
                             {"left": "$$", "right": "$$", "display": True},
                             {"left": r"\(", "right": r"\)", "display": False},
                             {"left": r"\[", "right": r"\]", "display": True},

--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -359,7 +359,6 @@ def build_side_by_side_ui_named(models):
                         height=650,
                         show_copy_button=True,
                         latex_delimiters=[
-                            {"left": "$", "right": "$", "display": False},
                             {"left": "$$", "right": "$$", "display": True},
                             {"left": r"\(", "right": r"\)", "display": False},
                             {"left": r"\[", "right": r"\]", "display": True},

--- a/fastchat/serve/gradio_block_arena_vision.py
+++ b/fastchat/serve/gradio_block_arena_vision.py
@@ -357,7 +357,6 @@ Note: You can only chat with <span style='color: #DE3163; font-weight: bold'>one
                 height=650,
                 show_copy_button=True,
                 latex_delimiters=[
-                    {"left": "$", "right": "$", "display": False},
                     {"left": "$$", "right": "$$", "display": True},
                     {"left": r"\(", "right": r"\)", "display": False},
                     {"left": r"\[", "right": r"\]", "display": True},

--- a/fastchat/serve/gradio_block_arena_vision_anony.py
+++ b/fastchat/serve/gradio_block_arena_vision_anony.py
@@ -433,7 +433,6 @@ def build_side_by_side_vision_ui_anony(context: Context, random_questions=None):
                                 height=650,
                                 show_copy_button=True,
                                 latex_delimiters=[
-                                    {"left": "$", "right": "$", "display": False},
                                     {"left": "$$", "right": "$$", "display": True},
                                     {"left": r"\(", "right": r"\)", "display": False},
                                     {"left": r"\[", "right": r"\]", "display": True},

--- a/fastchat/serve/gradio_block_arena_vision_named.py
+++ b/fastchat/serve/gradio_block_arena_vision_named.py
@@ -373,7 +373,6 @@ Note: You can only chat with <span style='color: #DE3163; font-weight: bold'>one
                                 height=650,
                                 show_copy_button=True,
                                 latex_delimiters=[
-                                    {"left": "$", "right": "$", "display": False},
                                     {"left": "$$", "right": "$$", "display": True},
                                     {"left": r"\(", "right": r"\)", "display": False},
                                     {"left": r"\[", "right": r"\]", "display": True},

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -928,7 +928,6 @@ def build_single_model_ui(models, add_promotion_links=False):
             height=650,
             show_copy_button=True,
             latex_delimiters=[
-                {"left": "$", "right": "$", "display": False},
                 {"left": "$$", "right": "$$", "display": True},
                 {"left": r"\(", "right": r"\)", "display": False},
                 {"left": r"\[", "right": r"\]", "display": True},


### PR DESCRIPTION
## Summary
- Fixes #3904: Gradio treated `25$` as math start because chatbots used `$...$` latex delimiters.
- Keep `$$`, `\(...\)`, `\[...\]`.

## Test plan
- [x] black 23.3 check on touched files
- [ ] CI


Made with [Cursor](https://cursor.com)