### PR TITLE
fix: tolerate rope_scaling without factor key

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -781,7 +781,8 @@ class LongChatAdapter(BaseModelAdapter):
 
         # Apply monkey patch, TODO(Dacheng): Add flash attention support
         config = AutoConfig.from_pretrained(model_path, revision=revision)
-        replace_llama_with_condense(config.rope_scaling["factor"])
+        rope_scaling = getattr(config, "rope_scaling", None) or {}
+        replace_llama_with_condense(rope_scaling.get("factor", 1))
 
         tokenizer = AutoTokenizer.from_pretrained(
             model_path, use_fast=self.use_fast_tokenizer, revision=revision

--- a/fastchat/utils.py
+++ b/fastchat/utils.py
@@ -365,7 +365,8 @@ def get_context_length(config):
     """Get the context length of a model from a huggingface model config."""
     rope_scaling = getattr(config, "rope_scaling", None)
     if rope_scaling:
-        rope_scaling_factor = config.rope_scaling["factor"]
+        # Some configs (e.g. Phi-3 / Triplex) set rope_scaling without "factor".
+        rope_scaling_factor = rope_scaling.get("factor", 1)
     else:
         rope_scaling_factor = 1
 


### PR DESCRIPTION
## Summary
- `get_context_length` used `rope_scaling["factor"]`, which KeyErrors on Triplex/Phi-3 configs that omit it
- Use `.get("factor", 1)` (same for LongChat adapter)

Fixes #3470

## Test plan
- [ ] Load a model whose `rope_scaling` has no `factor` key

Made with [Cursor](https://cursor.com)