### PR TITLE
fix: clean tokenization spaces in huggingface_api

### DIFF
--- a/fastchat/serve/huggingface_api.py
+++ b/fastchat/serve/huggingface_api.py
@@ -48,7 +48,10 @@ def main(args):
     else:
         output_ids = output_ids[0][len(inputs["input_ids"][0]) :]
     outputs = tokenizer.decode(
-        output_ids, skip_special_tokens=True, spaces_between_special_tokens=False
+        output_ids,
+        skip_special_tokens=True,
+        spaces_between_special_tokens=False,
+        clean_up_tokenization_spaces=True,
     )
 
     # Print results


### PR DESCRIPTION
## Summary
- `huggingface_api` decode omitted `clean_up_tokenization_spaces=True`, leaving ▁ artifacts on Vicuna/SentencePiece (#3795).
- Align with `inference.py`.

## Test plan
- [ ] `python -m fastchat.serve.huggingface_api --model lmsys/vicuna-7b-v1.5` output has no ▁

Made with [Cursor](https://cursor.com)