### PR TITLE
fix: register workers with matching address in launch_all_serve

### DIFF
--- a/fastchat/serve/launch_all_serve.py
+++ b/fastchat/serve/launch_all_serve.py
@@ -47,7 +47,14 @@ controller_args = ["controller-host", "controller-port", "dispatch-method"]
 
 parser.add_argument("--worker-host", type=str, default="localhost")
 parser.add_argument("--worker-port", type=int, default=21002)
-# parser.add_argument("--worker-address", type=str, default="http://localhost:21002")
+parser.add_argument(
+    "--worker-address",
+    type=str,
+    default=None,
+    help="Address registered with the controller. "
+    "Defaults to http://{worker-host}:{worker-port}; "
+    "overridden per worker from --model-path-address.",
+)
 # parser.add_argument(
 #     "--controller-address", type=str, default="http://localhost:21001"
 # )
@@ -129,6 +136,7 @@ parser.add_argument("--no-register", action="store_true")
 worker_args = [
     "worker-host",
     "worker-port",
+    "worker-address",
     "model-path",
     "revision",
     "device",
@@ -242,6 +250,9 @@ def launch_worker(item):
     )
 
     args.model_path, args.worker_host, args.worker_port = item.split("@")
+    # model_worker registers with --worker-address independently of --host/--port.
+    # Keep them aligned so the controller can reach the worker on the custom port.
+    args.worker_address = f"http://{args.worker_host}:{args.worker_port}"
     print("*" * 80)
     worker_str_args = string_args(args, worker_args)
     print(worker_str_args)


### PR DESCRIPTION
## Summary
- `launch_all_serve` forwarded `--host`/`--port` from `model-path@host@port` but never set `--worker-address`.
- `model_worker` registers with the controller using `--worker-address` (default `http://localhost:21002`), so custom ports (including the script default `@20002`) left the controller pointing at the wrong address.
- Derive and pass `http://{host}:{port}` as `--worker-address` for each launched worker.

## Test plan
- [x] Local simulation: `model-path@localhost@20002` now emits `--port 20002` and `--worker-address http://localhost:20002`
- [x] `python3 -m py_compile fastchat/serve/launch_all_serve.py`
- [ ] Launch `python -m fastchat.serve.launch_all_serve --model-path-address "MODEL@localhost@2021"` and confirm controller lists `http://localhost:2021`

Made with [Cursor](https://cursor.com)