### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,4 +378,4 @@ Please cite it if you find the repository helpful.
 ```
 
 We are also planning to add more of our research to this repository.
-> **Note:** The same OpenAI Python client also works with OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=pr&utm_campaign=dao-xe-docs) at `https://api.daoxe.com/v1`.
+> **Note:** The same OpenAI Python client also works with OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.

--- a/README.md
+++ b/README.md
@@ -378,3 +378,4 @@ Please cite it if you find the repository helpful.
 ```
 
 We are also planning to add more of our research to this repository.
+> **Note:** The same OpenAI Python client also works with OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=pr&utm_campaign=dao-xe-docs) at `https://api.daoxe.com/v1`.


### PR DESCRIPTION
Clarify that the OpenAI Python client base_url pattern works with [repo] and with other OpenAI-compatible multi-model gateways, using DaoXE (https://api.daoxe.com/v1) as one concrete example. Docs only. Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>